### PR TITLE
Handle menubar startup failure when port is busy

### DIFF
--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -110,11 +110,13 @@ func startProxy() {
 		return
 	}
 
-	srv = server.New(authenticator, log, "0.0.0.0", "1337")
-	if err := srv.Start(); err != nil {
+	nextSrv := server.New(authenticator, log, "0.0.0.0", "1337")
+	if err := nextSrv.Start(); err != nil {
 		log.Error("server start failed", logger.Err(err))
+		showErrorDialog("Proxy Start Failed", fmt.Sprintf("Could not start the proxy on port 1337.\n\n%v", err))
 		return
 	}
+	srv = nextSrv
 
 	mToggle.SetTitle("Stop Proxy")
 	systray.SetIcon(iconOn)

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -51,14 +52,19 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 // Start begins listening in a goroutine. It returns an error if the listener
 // cannot be established.
 func (s *Server) Start() error {
+	ln, err := net.Listen("tcp", s.httpServer.Addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.httpServer.Addr, err)
+	}
+
 	s.running.Store(true)
 	s.log.Info("copilot-proxy listening", logger.F("addr", s.httpServer.Addr))
 
 	go func() {
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			s.log.Fatal("server error", logger.Err(err))
+		defer s.running.Store(false)
+		if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.log.Error("server error", logger.Err(err))
 		}
-		s.running.Store(false)
 	}()
 
 	return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sozercan/copilot-proxy/auth"
+	"github.com/sozercan/copilot-proxy/logger"
+)
+
+func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve port: %v", err)
+	}
+	defer listener.Close()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected TCP address, got %T", listener.Addr())
+	}
+
+	srv := New(auth.NewTestAuthenticator("test-token"), logger.New(logger.ParseLevel("error")), "127.0.0.1", strconv.Itoa(addr.Port))
+	err = srv.Start()
+	if err == nil {
+		t.Fatal("expected Start to fail when port is already in use")
+	}
+	if srv.IsRunning() {
+		t.Fatal("expected server to remain stopped after listen failure")
+	}
+	if !strings.Contains(err.Error(), "address already in use") {
+		t.Fatalf("expected address-in-use error, got %v", err)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,7 +15,11 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to reserve port: %v", err)
 	}
-	defer listener.Close()
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("failed to close listener: %v", err)
+		}
+	}()
 
 	addr, ok := listener.Addr().(*net.TCPAddr)
 	if !ok {


### PR DESCRIPTION
## Summary
- bind the HTTP listener synchronously in `server.Start()` so port conflicts are returned to the caller instead of crashing from a background goroutine
- show a macOS error dialog from the menubar app when port `1337` is already in use and only store the server instance after a successful start
- add a regression test covering the address-in-use startup path

## Testing
- go test ./... -count=1
- go vet ./...