### PR TITLE
Fix macOS launch at login for menubar app

### DIFF
--- a/cmd/menubar/launchagent.go
+++ b/cmd/menubar/launchagent.go
@@ -1,21 +1,30 @@
 package main
 
 import (
-	"fmt"
+	"encoding/xml"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+const (
+	launchAgentLabel = "com.copilot-proxy.menubar"
+	// Keep this in sync with APP_BUNDLE_ID in the Makefile.
+	appBundleID = launchAgentLabel
+)
+
+const plistHeader = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.copilot-proxy.menubar</string>
+    <string>` + launchAgentLabel + `</string>
     <key>ProgramArguments</key>
     <array>
-        <string>%s</string>
-    </array>
+`
+
+const plistFooter = `    </array>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -29,7 +38,7 @@ func plistPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, "Library", "LaunchAgents", "com.copilot-proxy.menubar.plist"), nil
+	return filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist"), nil
 }
 
 func isLaunchAgentInstalled() bool {
@@ -39,6 +48,51 @@ func isLaunchAgentInstalled() bool {
 	}
 	_, err = os.Stat(p)
 	return err == nil
+}
+
+func launchAgentProgramArguments(executable string) []string {
+	if resolved, err := filepath.EvalSymlinks(executable); err == nil {
+		executable = resolved
+	}
+
+	if isAppBundleExecutable(executable) {
+		// Launch the bundle via Launch Services so login items do not pin a
+		// transient App Translocation path or bypass app-bundle semantics.
+		return []string{"/usr/bin/open", "-b", appBundleID}
+	}
+
+	return []string{executable}
+}
+
+func isAppBundleExecutable(executable string) bool {
+	dir := filepath.Clean(filepath.Dir(executable))
+	for {
+		if strings.EqualFold(filepath.Ext(dir), ".app") {
+			return true
+		}
+
+		next := filepath.Dir(dir)
+		if next == dir {
+			return false
+		}
+		dir = next
+	}
+}
+
+func launchAgentPlist(programArguments []string) (string, error) {
+	var builder strings.Builder
+	builder.WriteString(plistHeader)
+
+	for _, arg := range programArguments {
+		builder.WriteString("        <string>")
+		if err := xml.EscapeText(&builder, []byte(arg)); err != nil {
+			return "", err
+		}
+		builder.WriteString("</string>\n")
+	}
+
+	builder.WriteString(plistFooter)
+	return builder.String(), nil
 }
 
 func installLaunchAgent() error {
@@ -56,7 +110,12 @@ func installLaunchAgent() error {
 		return err
 	}
 
-	return os.WriteFile(p, []byte(fmt.Sprintf(plistTemplate, exe)), 0o644)
+	plist, err := launchAgentPlist(launchAgentProgramArguments(exe))
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(p, []byte(plist), 0o644)
 }
 
 func removeLaunchAgent() error {
@@ -64,5 +123,8 @@ func removeLaunchAgent() error {
 	if err != nil {
 		return err
 	}
-	return os.Remove(p)
+	if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }

--- a/cmd/menubar/launchagent_test.go
+++ b/cmd/menubar/launchagent_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLaunchAgentProgramArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		executable string
+		want       []string
+	}{
+		{
+			name:       "app bundle executable uses open by bundle id",
+			executable: "/Applications/Copilot Proxy.app/Contents/MacOS/copilot-proxy-menubar",
+			want:       []string{"/usr/bin/open", "-b", appBundleID},
+		},
+		{
+			name:       "standalone executable uses direct path",
+			executable: "/usr/local/bin/copilot-proxy-menubar",
+			want:       []string{"/usr/local/bin/copilot-proxy-menubar"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := launchAgentProgramArguments(tt.executable)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("launchAgentProgramArguments(%q) = %v, want %v", tt.executable, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLaunchAgentPlistEscapesArguments(t *testing.T) {
+	t.Parallel()
+
+	plist, err := launchAgentPlist([]string{"/tmp/Copilot & Proxy", "--model=claude<sonnet>"})
+	if err != nil {
+		t.Fatalf("launchAgentPlist() error = %v", err)
+	}
+
+	wantFragments := []string{
+		"<string>/tmp/Copilot &amp; Proxy</string>",
+		"<string>--model=claude&lt;sonnet&gt;</string>",
+		"<string>" + launchAgentLabel + "</string>",
+	}
+
+	for _, fragment := range wantFragments {
+		if !strings.Contains(plist, fragment) {
+			t.Fatalf("launchAgentPlist() missing fragment %q in %q", fragment, plist)
+		}
+	}
+}

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -47,6 +47,9 @@ func onReady() {
 
 	mLaunch := systray.AddMenuItemCheckbox("Launch at Login", "Launch at Login", false)
 	if isLaunchAgentInstalled() {
+		if err := installLaunchAgent(); err != nil {
+			log.Error("failed to refresh launch agent", logger.Err(err))
+		}
 		mLaunch.Check()
 	}
 


### PR DESCRIPTION
## Summary
- launch the menubar app at login via Launch Services when running from a .app bundle instead of hardcoding the current inner executable path
- refresh existing launch-agent plists on startup so previously enabled login items self-heal after updating
- add unit coverage for launch-agent argument selection and plist escaping

## Testing
- go test ./... -count=1
- go vet ./...
- make build-app