### PR TITLE
Fix Anthropic screenshot/image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible 
 
 ## Features
 
-- **Anthropic Messages API** (`POST /v1/messages`) — full request/response translation between Anthropic and OpenAI formats
+- **Anthropic Messages API** (`POST /v1/messages`) — request/response translation for supported Anthropic text, image, and tool formats
 - **Gemini Generate Content API** (`POST /v1beta/models/{model}:generateContent`, `POST /models/{model}:generateContent`) — Gemini request/response/SSE translation on top of Copilot chat completions
 - **Gemini Count Tokens API** (`POST /v1beta/models/{model}:countTokens`, `POST /models/{model}:countTokens`) — translated token counting via a minimal upstream probe with short-lived caching
 - **OpenAI Chat Completions API** (`POST /v1/chat/completions`) — near zero-copy passthrough (tools-aware, see below)
@@ -200,10 +200,10 @@ curl http://localhost:1337/v1/responses \
 
 ### `POST /v1/messages` (Anthropic)
 
-Full Anthropic Messages API compatibility. Incoming requests are translated to OpenAI Chat Completions format, forwarded to GitHub Copilot, and responses are translated back to Anthropic format.
+Anthropic Messages API compatibility for the supported content and tool subset. Incoming requests are translated to OpenAI Chat Completions format, forwarded to GitHub Copilot, and responses are translated back to Anthropic format.
 
 **Supported features:**
-- Text and tool-use content blocks
+- Text, image-input, and tool-use content blocks
 - System messages (string or content block array)
 - Tool definitions and tool choice (`auto`, `any`, `tool`)
 - Stop sequences

--- a/models/anthropic.go
+++ b/models/anthropic.go
@@ -6,21 +6,21 @@ import "encoding/json"
 
 // AnthropicRequest represents an incoming Anthropic Messages API request.
 type AnthropicRequest struct {
-	Model         string               `json:"model"`
-	Messages      []AnthropicMessage   `json:"messages"`
-	MaxTokens     *int                 `json:"max_tokens,omitempty"`
-	System        json.RawMessage      `json:"system,omitempty"`
-	Stream        bool                 `json:"stream,omitempty"`
-	StopSequences []string             `json:"stop_sequences,omitempty"`
-	Temperature   *float64             `json:"temperature,omitempty"`
-	TopP          *float64             `json:"top_p,omitempty"`
-	TopK          *int                 `json:"top_k,omitempty"`
-	Tools         []AnthropicTool      `json:"tools,omitempty"`
-	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
-	Metadata      json.RawMessage      `json:"metadata,omitempty"`
-	Thinking      *AnthropicThinking   `json:"thinking,omitempty"`
-	ServiceTier   string               `json:"service_tier,omitempty"`
-	InferenceGeo  string               `json:"inference_geo,omitempty"`
+	Model         string                 `json:"model"`
+	Messages      []AnthropicMessage     `json:"messages"`
+	MaxTokens     *int                   `json:"max_tokens,omitempty"`
+	System        json.RawMessage        `json:"system,omitempty"`
+	Stream        bool                   `json:"stream,omitempty"`
+	StopSequences []string               `json:"stop_sequences,omitempty"`
+	Temperature   *float64               `json:"temperature,omitempty"`
+	TopP          *float64               `json:"top_p,omitempty"`
+	TopK          *int                   `json:"top_k,omitempty"`
+	Tools         []AnthropicTool        `json:"tools,omitempty"`
+	ToolChoice    *AnthropicToolChoice   `json:"tool_choice,omitempty"`
+	Metadata      json.RawMessage        `json:"metadata,omitempty"`
+	Thinking      *AnthropicThinking     `json:"thinking,omitempty"`
+	ServiceTier   string                 `json:"service_tier,omitempty"`
+	InferenceGeo  string                 `json:"inference_geo,omitempty"`
 	OutputConfig  *AnthropicOutputConfig `json:"output_config,omitempty"`
 }
 
@@ -32,17 +32,27 @@ type AnthropicMessage struct {
 }
 
 // ContentBlock represents a typed content block in Anthropic messages.
-// The Type field determines which other fields are populated (text, tool_use, tool_result, thinking).
+// The Type field determines which other fields are populated
+// (text, image, tool_use, tool_result, thinking).
 type ContentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   json.RawMessage `json:"content,omitempty"`
-	Thinking  string          `json:"thinking,omitempty"`
-	Signature string          `json:"signature,omitempty"`
+	Type      string                `json:"type"`
+	Text      string                `json:"text,omitempty"`
+	Source    *AnthropicImageSource `json:"source,omitempty"`
+	ID        string                `json:"id,omitempty"`
+	Name      string                `json:"name,omitempty"`
+	Input     json.RawMessage       `json:"input,omitempty"`
+	ToolUseID string                `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage       `json:"content,omitempty"`
+	Thinking  string                `json:"thinking,omitempty"`
+	Signature string                `json:"signature,omitempty"`
+}
+
+// AnthropicImageSource describes an image content-block source.
+type AnthropicImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
 }
 
 // AnthropicTool defines a tool available for the model to call.

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -131,6 +131,71 @@ func TestHandleAnthropicMessages(t *testing.T) {
 	}
 }
 
+func TestHandleAnthropicMessages_ImageBlocksForwarded(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("failed to parse upstream request: %v", err)
+		}
+		if len(oaiReq.Messages) != 1 {
+			t.Fatalf("expected 1 upstream message, got %d", len(oaiReq.Messages))
+		}
+
+		var parts []models.OpenAIContentPart
+		if err := json.Unmarshal(oaiReq.Messages[0].Content, &parts); err != nil {
+			t.Fatalf("expected multimodal content array, got error: %v", err)
+		}
+		if len(parts) != 2 {
+			t.Fatalf("expected 2 content parts, got %d", len(parts))
+		}
+		if parts[0].Type != "text" || parts[0].Text == nil || *parts[0].Text != "What is in this screenshot?" {
+			t.Fatalf("parts[0] = %#v, want text part", parts[0])
+		}
+		if parts[1].Type != "image_url" || parts[1].ImageURL == nil || parts[1].ImageURL.URL != "data:image/png;base64,AQID" {
+			t.Fatalf("parts[1] = %#v, want image_url data URL", parts[1])
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-image\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"I can see the screenshot.\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-image\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
+
+	anthropicReq := `{
+		"model": "claude-sonnet-4",
+		"max_tokens": 1024,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type":"text","text":"What is in this screenshot?"},
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AQID"}}
+			]
+		}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(anthropicReq))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var anthropicResp models.AnthropicResponse
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &anthropicResp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Type != "text" || anthropicResp.Content[0].Text != "I can see the screenshot." {
+		t.Fatalf("unexpected content: %+v", anthropicResp.Content)
+	}
+}
+
 func TestHandleAnthropicMessagesInvalidJSON(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("backend should not be called for invalid JSON")

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -14,11 +14,11 @@ var dateModelRegex = regexp.MustCompile(`-\d{8}$`)
 
 // modelAliases maps Anthropic model names to Copilot-compatible names.
 var modelAliases = map[string]string{
-	"claude-haiku-4-5":   "claude-haiku-4.5",
-	"claude-sonnet-4-5":  "claude-sonnet-4.5",
-	"claude-opus-4-5":    "claude-opus-4.5",
-	"claude-sonnet-4-6":  "claude-sonnet-4.6",
-	"claude-opus-4-6":    "claude-opus-4.6",
+	"claude-haiku-4-5":  "claude-haiku-4.5",
+	"claude-sonnet-4-5": "claude-sonnet-4.5",
+	"claude-opus-4-5":   "claude-opus-4.5",
+	"claude-sonnet-4-6": "claude-sonnet-4.6",
+	"claude-opus-4-6":   "claude-opus-4.6",
 }
 
 // NormalizeModelName converts Anthropic model names to Copilot-compatible names.
@@ -141,8 +141,11 @@ func parseSystemMessage(raw json.RawMessage) (*models.OpenAIMessage, error) {
 
 	var text string
 	for _, b := range blocks {
-		if b.Type == "text" {
+		switch b.Type {
+		case "text":
 			text += b.Text
+		default:
+			return nil, fmt.Errorf("unsupported system content block type %q", b.Type)
 		}
 	}
 	if text == "" {
@@ -167,13 +170,22 @@ func translateMessage(msg models.AnthropicMessage) ([]models.OpenAIMessage, erro
 	}
 
 	var result []models.OpenAIMessage
-	var textParts string
+	var textParts strings.Builder
+	var multimodalParts []models.OpenAIContentPart
 	var toolCalls []models.OpenAIToolCall
 
 	for _, block := range blocks {
 		switch block.Type {
 		case "text":
-			textParts += block.Text
+			appendTextContentPart(&textParts, &multimodalParts, block.Text)
+
+		case "image":
+			part, err := translateAnthropicImageBlock(block)
+			if err != nil {
+				return nil, err
+			}
+			flushTextContentPart(&textParts, &multimodalParts)
+			multimodalParts = append(multimodalParts, *part)
 
 		case "tool_use":
 			toolCalls = append(toolCalls, models.OpenAIToolCall{
@@ -199,19 +211,25 @@ func translateMessage(msg models.AnthropicMessage) ([]models.OpenAIMessage, erro
 
 		case "thinking", "redacted_thinking":
 			// skip thinking blocks
+
+		default:
+			return nil, fmt.Errorf("unsupported content block type %q", block.Type)
 		}
 	}
-
 	// Build the primary message for text/tool_use blocks.
 	// When tool_calls are present, prepend before tool_result messages so
 	// assistant→tool ordering is preserved.  When only text is present
 	// (e.g. a user message carrying both text and tool_results), append
 	// after the tool_result messages so tool responses stay adjacent to
 	// the preceding assistant tool_calls.
-	if textParts != "" || len(toolCalls) > 0 {
+	if textParts.Len() > 0 || len(multimodalParts) > 0 || len(toolCalls) > 0 {
 		m := models.OpenAIMessage{Role: msg.Role}
-		if textParts != "" {
-			content, _ := json.Marshal(textParts)
+		switch {
+		case len(multimodalParts) > 0:
+			content, _ := json.Marshal(multimodalParts)
+			m.Content = content
+		case textParts.Len() > 0:
+			content, _ := json.Marshal(textParts.String())
 			m.Content = content
 		}
 		if len(toolCalls) > 0 {
@@ -223,6 +241,64 @@ func translateMessage(msg models.AnthropicMessage) ([]models.OpenAIMessage, erro
 	}
 
 	return result, nil
+}
+
+func appendTextContentPart(textParts *strings.Builder, multimodalParts *[]models.OpenAIContentPart, text string) {
+	if len(*multimodalParts) == 0 {
+		textParts.WriteString(text)
+		return
+	}
+	partText := text
+	*multimodalParts = append(*multimodalParts, models.OpenAIContentPart{
+		Type: "text",
+		Text: &partText,
+	})
+}
+
+func flushTextContentPart(textParts *strings.Builder, multimodalParts *[]models.OpenAIContentPart) {
+	if textParts.Len() == 0 {
+		return
+	}
+	partText := textParts.String()
+	*multimodalParts = append(*multimodalParts, models.OpenAIContentPart{
+		Type: "text",
+		Text: &partText,
+	})
+	textParts.Reset()
+}
+
+func translateAnthropicImageBlock(block models.ContentBlock) (*models.OpenAIContentPart, error) {
+	if block.Source == nil {
+		return nil, fmt.Errorf("image content block is missing source")
+	}
+
+	switch block.Source.Type {
+	case "base64":
+		if block.Source.MediaType == "" || block.Source.Data == "" {
+			return nil, fmt.Errorf("base64 image source requires media_type and data")
+		}
+		if !strings.HasPrefix(strings.ToLower(block.Source.MediaType), "image/") {
+			return nil, fmt.Errorf("unsupported image media_type %q", block.Source.MediaType)
+		}
+		return &models.OpenAIContentPart{
+			Type: "image_url",
+			ImageURL: &models.OpenAIImageURL{
+				URL: fmt.Sprintf("data:%s;base64,%s", block.Source.MediaType, block.Source.Data),
+			},
+		}, nil
+	case "url":
+		if block.Source.URL == "" {
+			return nil, fmt.Errorf("url image source requires url")
+		}
+		return &models.OpenAIContentPart{
+			Type: "image_url",
+			ImageURL: &models.OpenAIImageURL{
+				URL: block.Source.URL,
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported image source type %q", block.Source.Type)
+	}
 }
 
 func extractToolResultContent(raw json.RawMessage) (string, error) {

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/sozercan/copilot-proxy/models"
@@ -9,6 +10,16 @@ import (
 
 func strPtr(s string) *string { return &s }
 func intPtr(i int) *int       { return &i }
+
+func decodeContentParts(t *testing.T, raw json.RawMessage) []models.OpenAIContentPart {
+	t.Helper()
+
+	var parts []models.OpenAIContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		t.Fatalf("content is not a JSON content-part array: %v", err)
+	}
+	return parts
+}
 
 func TestTranslateAnthropicToOpenAI(t *testing.T) {
 	t.Run("simple text message", func(t *testing.T) {
@@ -35,6 +46,82 @@ func TestTranslateAnthropicToOpenAI(t *testing.T) {
 		}
 		if text != "Hello" {
 			t.Errorf("content = %q, want %q", text, "Hello")
+		}
+	})
+
+	t.Run("text and image content blocks become multimodal content array", func(t *testing.T) {
+		content := `[{"type":"text","text":"What is in this screenshot?"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AQID"}}]`
+		req := &models.AnthropicRequest{
+			Model:     "claude-3-opus",
+			MaxTokens: intPtr(100),
+			Messages: []models.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(content)},
+			},
+		}
+
+		got, err := TranslateAnthropicToOpenAI(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.Messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(got.Messages))
+		}
+
+		parts := decodeContentParts(t, got.Messages[0].Content)
+		if len(parts) != 2 {
+			t.Fatalf("expected 2 content parts, got %d", len(parts))
+		}
+		if parts[0].Type != "text" || parts[0].Text == nil || *parts[0].Text != "What is in this screenshot?" {
+			t.Fatalf("parts[0] = %#v, want text part", parts[0])
+		}
+		if parts[1].Type != "image_url" || parts[1].ImageURL == nil || parts[1].ImageURL.URL != "data:image/png;base64,AQID" {
+			t.Fatalf("parts[1] = %#v, want image_url data URL", parts[1])
+		}
+	})
+
+	t.Run("image-only content block is preserved", func(t *testing.T) {
+		content := `[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AQID"}}]`
+		req := &models.AnthropicRequest{
+			Model:     "claude-3-opus",
+			MaxTokens: intPtr(100),
+			Messages: []models.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(content)},
+			},
+		}
+
+		got, err := TranslateAnthropicToOpenAI(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got.Messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(got.Messages))
+		}
+
+		parts := decodeContentParts(t, got.Messages[0].Content)
+		if len(parts) != 1 {
+			t.Fatalf("expected 1 content part, got %d", len(parts))
+		}
+		if parts[0].Type != "image_url" || parts[0].ImageURL == nil || parts[0].ImageURL.URL != "data:image/png;base64,AQID" {
+			t.Fatalf("parts[0] = %#v, want image_url data URL", parts[0])
+		}
+	})
+
+	t.Run("unsupported content blocks fail instead of being dropped", func(t *testing.T) {
+		content := `[{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"AQID"}}]`
+		req := &models.AnthropicRequest{
+			Model:     "claude-3-opus",
+			MaxTokens: intPtr(100),
+			Messages: []models.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(content)},
+			},
+		}
+
+		_, err := TranslateAnthropicToOpenAI(req)
+		if err == nil {
+			t.Fatal("expected error for unsupported content block")
+		}
+		if !strings.Contains(err.Error(), `unsupported content block type "document"`) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- preserve Anthropic image content blocks by translating them into OpenAI multimodal image parts on the `/v1/messages` path
- fail fast for unsupported Anthropic content block types instead of silently dropping them
- add regression tests for translation and handler forwarding, and document the supported Anthropic subset

## Testing
- `go test ./... -count=1`
- validated Claude Code CLI against a local proxy on `127.0.0.1:14337` using the earlier screenshot repro; Claude successfully read the warning text from the replayed image
