### PR TITLE
Add readiness probe and configurable Copilot headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Tokens are cached to `~/.config/copilot-proxy/` and automatically refreshed befo
 | `--host` | `HOST` | `0.0.0.0` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/copilot-proxy` | Token storage directory |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level (`debug`, `info`, or `error`) |
+| `--copilot-editor-version` | `COPILOT_EDITOR_VERSION` | `vscode/1.95.0` | Upstream `editor-version` header |
+| `--copilot-plugin-version` | `COPILOT_PLUGIN_VERSION` | `copilot-chat/0.26.7` | Upstream `editor-plugin-version` header |
+| `--copilot-user-agent` | `COPILOT_USER_AGENT` | `GitHubCopilotChat/0.26.7` | Upstream `User-Agent` header |
+| `--copilot-github-api-version` | `COPILOT_GITHUB_API_VERSION` | `2025-04-01` | Upstream `x-github-api-version` header |
 
 ## Usage Examples
 
@@ -323,6 +327,10 @@ Proxies the upstream GitHub Copilot models endpoint, returning all available mod
 ### `GET /healthz`
 
 Health check endpoint. Returns `{"status":"ok"}`.
+
+### `GET /readyz`
+
+Readiness endpoint. Validates that the proxy can obtain a Copilot token and successfully probe the upstream Copilot `/models` API. Returns `{"status":"ready"}` on success or `503` with `{"status":"not_ready","error":"..."}` on failure.
 
 ## Architecture
 

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -98,7 +98,10 @@ func (a *Authenticator) IsSignedIn() bool {
 	if a.accessToken != "" {
 		return true
 	}
-	return a.hasAccessTokenOnDisk()
+	if a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
+		return true
+	}
+	return a.hasAccessTokenOnDisk() || a.hasValidCopilotTokenOnDisk()
 }
 
 // hasAccessTokenOnDisk returns true when the access-token file exists and is
@@ -111,9 +114,36 @@ func (a *Authenticator) hasAccessTokenOnDisk() bool {
 	return strings.TrimSpace(string(data)) != ""
 }
 
+// hasValidCopilotTokenOnDisk returns true when the persisted Copilot token file
+// exists, is valid JSON, and has not expired yet. Must NOT be called with the
+// write lock held.
+func (a *Authenticator) hasValidCopilotTokenOnDisk() bool {
+	data, err := os.ReadFile(filepath.Join(a.tokenDir, "api-key.json"))
+	if err != nil {
+		return false
+	}
+
+	var ctResp CopilotTokenResponse
+	if err := json.Unmarshal(data, &ctResp); err != nil {
+		return false
+	}
+
+	return ctResp.Token != "" && time.Now().Unix() < ctResp.ExpiresAt-300
+}
+
 // GetToken returns a valid Copilot API token, refreshing it if necessary.
 // It is safe for concurrent use.
 func (a *Authenticator) GetToken(ctx context.Context) (string, error) {
+	return a.getToken(ctx, !a.DisableAutoDeviceFlow)
+}
+
+// GetTokenNonInteractive returns a valid Copilot API token without falling
+// back to the interactive device-code flow.
+func (a *Authenticator) GetTokenNonInteractive(ctx context.Context) (string, error) {
+	return a.getToken(ctx, false)
+}
+
+func (a *Authenticator) getToken(ctx context.Context, allowDeviceFlow bool) (string, error) {
 	a.mu.RLock()
 	if a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
 		token := a.copilotToken
@@ -129,20 +159,23 @@ func (a *Authenticator) GetToken(ctx context.Context) (string, error) {
 	if a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
 		return a.copilotToken, nil
 	}
+	if err := a.loadCopilotToken(); err == nil {
+		return a.copilotToken, nil
+	}
 
-	if err := a.refreshToken(ctx); err != nil {
+	if err := a.refreshToken(ctx, allowDeviceFlow); err != nil {
 		return "", err
 	}
 	return a.copilotToken, nil
 }
 
-func (a *Authenticator) refreshToken(ctx context.Context) error {
+func (a *Authenticator) refreshToken(ctx context.Context, allowDeviceFlow bool) error {
 	if err := a.loadAccessToken(); err == nil {
 		if err := a.exchangeForCopilotToken(ctx); err == nil {
 			return nil
 		}
 	}
-	if a.DisableAutoDeviceFlow {
+	if !allowDeviceFlow {
 		return fmt.Errorf("not authenticated")
 	}
 	return a.deviceCodeFlow(ctx)

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -56,6 +56,30 @@ func TestGetToken_RefreshesExpiredToken(t *testing.T) {
 	}
 }
 
+func TestGetToken_LoadsPersistedCopilotToken(t *testing.T) {
+	dir := t.TempDir()
+	data, err := json.Marshal(CopilotTokenResponse{
+		Token:     "persisted-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "api-key.json"), data, 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	a := &Authenticator{tokenDir: dir}
+
+	token, err := a.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "persisted-token" {
+		t.Errorf("expected persisted-token, got %q", token)
+	}
+}
+
 func TestGetToken_ConcurrentAccess(t *testing.T) {
 	a := NewTestAuthenticator("concurrent-token")
 
@@ -242,6 +266,25 @@ func TestIsSignedIn_WithDiskToken(t *testing.T) {
 	a := &Authenticator{tokenDir: dir}
 	if !a.IsSignedIn() {
 		t.Error("expected IsSignedIn() == true with disk token")
+	}
+}
+
+func TestIsSignedIn_WithDiskCopilotToken(t *testing.T) {
+	dir := t.TempDir()
+	data, err := json.Marshal(CopilotTokenResponse{
+		Token:     "persisted-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "api-key.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Authenticator{tokenDir: dir}
+	if !a.IsSignedIn() {
+		t.Error("expected IsSignedIn() == true with valid copilot token on disk")
 	}
 }
 
@@ -439,7 +482,7 @@ func TestRefreshToken_DisableAutoDeviceFlow(t *testing.T) {
 		DisableAutoDeviceFlow: true,
 	}
 
-	err := a.refreshToken(context.Background())
+	err := a.refreshToken(context.Background(), false)
 	if err == nil {
 		t.Fatal("expected error when DisableAutoDeviceFlow is true")
 	}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sozercan/copilot-proxy/auth"
 	"github.com/sozercan/copilot-proxy/logger"
+	"github.com/sozercan/copilot-proxy/proxy"
 	"github.com/sozercan/copilot-proxy/server"
 )
 
@@ -18,6 +19,10 @@ func main() {
 	host := flag.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
 	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/copilot-proxy)")
 	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
+	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
+	copilotPluginVersion := flag.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header")
+	copilotUserAgent := flag.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header")
+	copilotGitHubAPIVersion := flag.String("copilot-github-api-version", getEnv("COPILOT_GITHUB_API_VERSION", ""), "Upstream Copilot x-github-api-version header")
 	flag.Parse()
 
 	log := logger.New(logger.ParseLevel(*logLevel))
@@ -31,7 +36,12 @@ func main() {
 	}
 	log.Info("authenticated successfully")
 
-	srv := server.New(authenticator, log, *host, *port)
+	srv := server.New(authenticator, log, *host, *port, server.WithCopilotHeaderConfig(proxy.CopilotHeaderConfig{
+		EditorVersion:       *copilotEditorVersion,
+		EditorPluginVersion: *copilotPluginVersion,
+		UserAgent:           *copilotUserAgent,
+		GitHubAPIVersion:    *copilotGitHubAPIVersion,
+	}))
 
 	if err := srv.Start(); err != nil {
 		log.Fatal("server start error", logger.Err(err))

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -349,7 +349,7 @@ func (h *ProxyHandler) postChatCompletions(ctx context.Context, token string, bo
 		if err != nil {
 			return nil, err
 		}
-		setCopilotHeaders(req, token)
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -30,13 +30,21 @@ const (
 	maxRequestBodySize = 10 << 20
 	// upstreamTimeout is the timeout for LLM inference requests.
 	upstreamTimeout = 5 * time.Minute
+	// readyzUpstreamTimeout bounds readiness probes that validate upstream reachability.
+	readyzUpstreamTimeout = 10 * time.Second
 	// modelsUpstreamTimeout is the timeout for the /models metadata request.
 	modelsUpstreamTimeout = 30 * time.Second
 	// modelsCacheTTL is how long the /models response is cached.
 	modelsCacheTTL = 5 * time.Minute
 	// syntheticCompactionPrefix marks proxy-owned compaction payloads so they
 	// can be expanded back into normal context on subsequent /responses calls.
-	syntheticCompactionPrefix = "copilot-proxy.compaction.v1:"
+	syntheticCompactionPrefix         = "copilot-proxy.compaction.v1:"
+	defaultCopilotEditorVersion       = "vscode/1.95.0"
+	defaultCopilotEditorPluginVersion = "copilot-chat/0.26.7"
+	defaultCopilotUserAgent           = "GitHubCopilotChat/0.26.7"
+	defaultCopilotIntegrationID       = "vscode-chat"
+	defaultCopilotGitHubAPIVersion    = "2025-04-01"
+	defaultCopilotOpenAIIntent        = "conversation-panel"
 )
 
 var preferredResponsesFallbackModels = []string{
@@ -64,11 +72,57 @@ type cachedModelsResponse struct {
 	etag       string
 }
 
+// CopilotHeaderConfig controls the synthetic editor-identifying headers sent to
+// the upstream Copilot backend. Empty fields fall back to project defaults.
+type CopilotHeaderConfig struct {
+	EditorVersion       string
+	EditorPluginVersion string
+	UserAgent           string
+	IntegrationID       string
+	GitHubAPIVersion    string
+	OpenAIIntent        string
+}
+
+func DefaultCopilotHeaderConfig() CopilotHeaderConfig {
+	return CopilotHeaderConfig{
+		EditorVersion:       defaultCopilotEditorVersion,
+		EditorPluginVersion: defaultCopilotEditorPluginVersion,
+		UserAgent:           defaultCopilotUserAgent,
+		IntegrationID:       defaultCopilotIntegrationID,
+		GitHubAPIVersion:    defaultCopilotGitHubAPIVersion,
+		OpenAIIntent:        defaultCopilotOpenAIIntent,
+	}
+}
+
+func (c CopilotHeaderConfig) withDefaults() CopilotHeaderConfig {
+	defaults := DefaultCopilotHeaderConfig()
+	if c.EditorVersion == "" {
+		c.EditorVersion = defaults.EditorVersion
+	}
+	if c.EditorPluginVersion == "" {
+		c.EditorPluginVersion = defaults.EditorPluginVersion
+	}
+	if c.UserAgent == "" {
+		c.UserAgent = defaults.UserAgent
+	}
+	if c.IntegrationID == "" {
+		c.IntegrationID = defaults.IntegrationID
+	}
+	if c.GitHubAPIVersion == "" {
+		c.GitHubAPIVersion = defaults.GitHubAPIVersion
+	}
+	if c.OpenAIIntent == "" {
+		c.OpenAIIntent = defaults.OpenAIIntent
+	}
+	return c
+}
+
 // ProxyHandler holds dependencies for all HTTP handlers.
 type ProxyHandler struct {
 	auth           *auth.Authenticator
 	client         *http.Client
 	copilotURL     string
+	copilotHeaders CopilotHeaderConfig
 	log            *logger.Logger
 	maxRetries     int
 	retryBaseDelay time.Duration
@@ -76,9 +130,20 @@ type ProxyHandler struct {
 	geminiCounts   geminiCountTokensCache
 }
 
+// Option customizes ProxyHandler behavior.
+type Option func(*ProxyHandler)
+
+// WithCopilotHeaderConfig overrides the synthetic Copilot-identifying headers
+// used for upstream requests.
+func WithCopilotHeaderConfig(cfg CopilotHeaderConfig) Option {
+	return func(h *ProxyHandler) {
+		h.copilotHeaders = cfg.withDefaults()
+	}
+}
+
 // NewProxyHandler creates a ProxyHandler with connection pooling and HTTP/2.
-func NewProxyHandler(a *auth.Authenticator, log *logger.Logger) *ProxyHandler {
-	return &ProxyHandler{
+func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) *ProxyHandler {
+	h := &ProxyHandler{
 		auth: a,
 		client: &http.Client{
 			Transport: &http.Transport{
@@ -90,21 +155,37 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger) *ProxyHandler {
 				TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
 			},
 		},
-		copilotURL: "https://api.githubcopilot.com",
-		log:        log,
+		copilotURL:     "https://api.githubcopilot.com",
+		copilotHeaders: DefaultCopilotHeaderConfig(),
+		log:            log,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(h)
+		}
+	}
+	return h
 }
 
 func setCopilotHeaders(req *http.Request, token string) {
+	setCopilotHeadersWithConfig(req, token, DefaultCopilotHeaderConfig())
+}
+
+func setCopilotHeadersWithConfig(req *http.Request, token string, cfg CopilotHeaderConfig) {
+	cfg = cfg.withDefaults()
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("editor-version", "vscode/1.95.0")
-	req.Header.Set("editor-plugin-version", "copilot-chat/0.26.7")
-	req.Header.Set("user-agent", "GitHubCopilotChat/0.26.7")
-	req.Header.Set("copilot-integration-id", "vscode-chat")
-	req.Header.Set("x-github-api-version", "2025-04-01")
+	req.Header.Set("editor-version", cfg.EditorVersion)
+	req.Header.Set("editor-plugin-version", cfg.EditorPluginVersion)
+	req.Header.Set("user-agent", cfg.UserAgent)
+	req.Header.Set("copilot-integration-id", cfg.IntegrationID)
+	req.Header.Set("x-github-api-version", cfg.GitHubAPIVersion)
 	req.Header.Set("x-request-id", uuid.New().String())
-	req.Header.Set("openai-intent", "conversation-panel")
+	req.Header.Set("openai-intent", cfg.OpenAIIntent)
 	req.Header.Set("Content-Type", "application/json")
+}
+
+func (h *ProxyHandler) setCopilotHeaders(req *http.Request, token string) {
+	setCopilotHeadersWithConfig(req, token, h.copilotHeaders)
 }
 
 var hopByHopHeaders = map[string]struct{}{
@@ -231,7 +312,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		if err != nil {
 			return nil, err
 		}
-		setCopilotHeaders(req, token)
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 	if err != nil {
@@ -315,7 +396,7 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 		if err != nil {
 			return nil, err
 		}
-		setCopilotHeaders(req, token)
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 	if err != nil {
@@ -400,7 +481,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return nil, err
 		}
-		setCopilotHeaders(req, token)
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 	if err != nil {
@@ -753,6 +834,62 @@ func (h *ProxyHandler) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"status":"ok"}`))
 }
 
+// HandleReadyz validates that the proxy can obtain an auth token and reach the
+// upstream Copilot API.
+func (h *ProxyHandler) HandleReadyz(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), readyzUpstreamTimeout)
+	defer cancel()
+
+	token, err := h.auth.GetTokenNonInteractive(ctx)
+	if err != nil {
+		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", fmt.Sprintf("failed to get token: %v", err))
+		return
+	}
+
+	if err := h.checkUpstreamReady(ctx, token); err != nil {
+		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", err.Error())
+		return
+	}
+
+	writeReadyzStatus(w, http.StatusOK, "ready", "")
+}
+
+func (h *ProxyHandler) checkUpstreamReady(ctx context.Context, token string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.copilotURL+"/models", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create upstream probe request: %w", err)
+	}
+	h.setCopilotHeaders(req, token)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("upstream probe failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		message := fmt.Sprintf("upstream probe returned %d", resp.StatusCode)
+		if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+			message += ": " + trimmed
+		}
+		return fmt.Errorf("%s", message)
+	}
+
+	return nil
+}
+
+func writeReadyzStatus(w http.ResponseWriter, statusCode int, status string, errMessage string) {
+	response := map[string]string{"status": status}
+	if errMessage != "" {
+		response["error"] = errMessage
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
 // HandleModels handles GET /v1/models by proxying to the upstream Copilot API.
 // Responses are cached for modelsCacheTTL to avoid repeated upstream calls.
 // The response includes both the standard OpenAI "data" field and a Codex-compatible
@@ -794,7 +931,7 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusInternalServerError, "failed to create request", "server_error")
 		return
 	}
-	setCopilotHeaders(req, token)
+	h.setCopilotHeaders(req, token)
 	if hasCachedEntry && cachedEntry.etag != "" {
 		req.Header.Set("If-None-Match", cachedEntry.etag)
 	}
@@ -1020,7 +1157,7 @@ func (h *ProxyHandler) postResponses(ctx context.Context, token string, bodyByte
 		if err != nil {
 			return nil, err
 		}
-		setCopilotHeaders(req, token)
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 }
@@ -1147,7 +1284,7 @@ func (h *ProxyHandler) pickResponsesCompatibleModel(ctx context.Context, token, 
 		if err != nil {
 			return nil, err
 		}
-		setCopilotHeaders(req, token)
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 	if err != nil {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,102 @@ func TestHandleHealthz(t *testing.T) {
 	if result["status"] != "ok" {
 		t.Fatalf("expected status ok, got %q", result["status"])
 	}
+}
+
+func TestHandleReadyz(t *testing.T) {
+	t.Run("ready when auth and upstream probe succeed", func(t *testing.T) {
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/models" {
+				t.Fatalf("expected readiness probe to hit /models, got %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleReadyz(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result map[string]string
+		body, _ := io.ReadAll(resp.Body)
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if result["status"] != "ready" {
+			t.Fatalf("expected status ready, got %q", result["status"])
+		}
+		if _, hasError := result["error"]; hasError {
+			t.Fatalf("unexpected error field in ready response: %v", result)
+		}
+	})
+
+	t.Run("not ready when auth fails", func(t *testing.T) {
+		authenticator := auth.NewAuthenticator(t.TempDir())
+		authenticator.DisableAutoDeviceFlow = true
+
+		h := &ProxyHandler{
+			auth: authenticator,
+			log:  logger.New(logger.LevelInfo),
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleReadyz(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", resp.StatusCode)
+		}
+
+		var result map[string]string
+		body, _ := io.ReadAll(resp.Body)
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if result["status"] != "not_ready" {
+			t.Fatalf("expected status not_ready, got %q", result["status"])
+		}
+		if !strings.Contains(result["error"], "failed to get token") {
+			t.Fatalf("unexpected error message: %q", result["error"])
+		}
+	})
+
+	t.Run("not ready when upstream probe fails", func(t *testing.T) {
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"service unavailable"}`))
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleReadyz(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", resp.StatusCode)
+		}
+
+		var result map[string]string
+		body, _ := io.ReadAll(resp.Body)
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if result["status"] != "not_ready" {
+			t.Fatalf("expected status not_ready, got %q", result["status"])
+		}
+		if !strings.Contains(result["error"], "upstream probe returned 503") {
+			t.Fatalf("unexpected error message: %q", result["error"])
+		}
+	})
 }
 
 func TestHandleAnthropicMessages(t *testing.T) {
@@ -1251,6 +1348,37 @@ func TestSetCopilotHeaders(t *testing.T) {
 	}
 }
 
+func TestSetCopilotHeadersWithConfig(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	setCopilotHeadersWithConfig(req, "my-test-token", CopilotHeaderConfig{
+		EditorVersion:       "vscode/1.96.0",
+		EditorPluginVersion: "copilot-chat/0.27.0",
+		UserAgent:           "GitHubCopilotChat/0.27.0",
+		GitHubAPIVersion:    "2025-05-01",
+	})
+
+	tests := []struct {
+		header   string
+		expected string
+	}{
+		{"Authorization", "Bearer my-test-token"},
+		{"editor-version", "vscode/1.96.0"},
+		{"editor-plugin-version", "copilot-chat/0.27.0"},
+		{"user-agent", "GitHubCopilotChat/0.27.0"},
+		{"copilot-integration-id", defaultCopilotIntegrationID},
+		{"x-github-api-version", "2025-05-01"},
+		{"openai-intent", defaultCopilotOpenAIIntent},
+		{"Content-Type", "application/json"},
+	}
+
+	for _, tt := range tests {
+		got := req.Header.Get(tt.header)
+		if got != tt.expected {
+			t.Errorf("header %q: expected %q, got %q", tt.header, tt.expected, got)
+		}
+	}
+}
+
 func TestHandleOpenAIChatCompletionsUpstreamError(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1377,6 +1505,124 @@ func TestHandleModels(t *testing.T) {
 			t.Fatalf("expected 500, got %d", resp.StatusCode)
 		}
 	})
+}
+
+func TestHandleModels_CodexContractFixture(t *testing.T) {
+	upstreamBody, err := os.ReadFile("testdata/codex_models_upstream.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(upstreamBody)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	type reasoningPreset struct {
+		Effort      string `json:"effort"`
+		Description string `json:"description"`
+	}
+	type truncationPolicy struct {
+		Mode  string `json:"mode"`
+		Limit int64  `json:"limit"`
+	}
+	type codexModelContract struct {
+		Slug                       string            `json:"slug"`
+		DisplayName                string            `json:"display_name"`
+		DefaultReasoningLevel      *string           `json:"default_reasoning_level,omitempty"`
+		SupportedReasoningLevels   []reasoningPreset `json:"supported_reasoning_levels"`
+		ShellType                  string            `json:"shell_type"`
+		Visibility                 string            `json:"visibility"`
+		SupportedInAPI             bool              `json:"supported_in_api"`
+		Priority                   int               `json:"priority"`
+		BaseInstructions           string            `json:"base_instructions"`
+		SupportsReasoningSummaries bool              `json:"supports_reasoning_summaries"`
+		SupportVerbosity           bool              `json:"support_verbosity"`
+		TruncationPolicy           truncationPolicy  `json:"truncation_policy"`
+		SupportsParallelToolCalls  bool              `json:"supports_parallel_tool_calls"`
+		ContextWindow              *int64            `json:"context_window,omitempty"`
+		ExperimentalSupportedTools []string          `json:"experimental_supported_tools"`
+		InputModalities            []string          `json:"input_modalities"`
+	}
+	var result struct {
+		Data   []json.RawMessage    `json:"data"`
+		Models []codexModelContract `json:"models"`
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Data) != 3 {
+		t.Fatalf("expected 3 data entries, got %d", len(result.Data))
+	}
+	if len(result.Models) != 3 {
+		t.Fatalf("expected 3 transformed models, got %d", len(result.Models))
+	}
+
+	bySlug := make(map[string]codexModelContract, len(result.Models))
+	for _, model := range result.Models {
+		bySlug[model.Slug] = model
+	}
+
+	gpt54, ok := bySlug["gpt-5.4"]
+	if !ok {
+		t.Fatal("expected gpt-5.4 in transformed models")
+	}
+	if gpt54.DisplayName != "GPT-5.4" {
+		t.Errorf("gpt-5.4 display_name = %q, want GPT-5.4", gpt54.DisplayName)
+	}
+	if gpt54.DefaultReasoningLevel == nil || *gpt54.DefaultReasoningLevel != "medium" {
+		t.Errorf("gpt-5.4 default_reasoning_level = %v, want medium", gpt54.DefaultReasoningLevel)
+	}
+	if len(gpt54.SupportedReasoningLevels) != 3 {
+		t.Fatalf("gpt-5.4 supported_reasoning_levels = %d, want 3", len(gpt54.SupportedReasoningLevels))
+	}
+	if gpt54.ShellType != "shell_command" {
+		t.Errorf("gpt-5.4 shell_type = %q, want shell_command", gpt54.ShellType)
+	}
+	if gpt54.Visibility != "list" {
+		t.Errorf("gpt-5.4 visibility = %q, want list", gpt54.Visibility)
+	}
+	if !gpt54.SupportedInAPI {
+		t.Error("expected gpt-5.4 supported_in_api = true")
+	}
+	if gpt54.TruncationPolicy.Mode != "bytes" || gpt54.TruncationPolicy.Limit != 10000 {
+		t.Errorf("gpt-5.4 truncation_policy = %+v, want bytes/10000", gpt54.TruncationPolicy)
+	}
+	if !gpt54.SupportsParallelToolCalls {
+		t.Error("expected gpt-5.4 supports_parallel_tool_calls = true")
+	}
+	if got := strings.Join(gpt54.InputModalities, ","); got != "text,image" {
+		t.Errorf("gpt-5.4 input_modalities = %q, want text,image", got)
+	}
+
+	claude, ok := bySlug["claude-sonnet-4.5"]
+	if !ok {
+		t.Fatal("expected claude-sonnet-4.5 in transformed models")
+	}
+	if claude.Visibility != "hide" {
+		t.Errorf("claude-sonnet-4.5 visibility = %q, want hide", claude.Visibility)
+	}
+	if claude.SupportedInAPI {
+		t.Error("expected claude-sonnet-4.5 supported_in_api = false")
+	}
+	if claude.SupportsReasoningSummaries {
+		t.Error("expected claude-sonnet-4.5 supports_reasoning_summaries = false")
+	}
+	if len(claude.SupportedReasoningLevels) != 0 {
+		t.Errorf("claude-sonnet-4.5 supported_reasoning_levels = %d, want 0", len(claude.SupportedReasoningLevels))
+	}
 }
 
 func TestHandleModels_ForwardsQueryAndETag(t *testing.T) {

--- a/proxy/testdata/codex_models_upstream.json
+++ b/proxy/testdata/codex_models_upstream.json
@@ -1,0 +1,84 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "gpt-5.4",
+      "object": "model",
+      "created": 0,
+      "owned_by": "github-copilot",
+      "supported_endpoints": [
+        "/responses",
+        "/chat/completions"
+      ],
+      "capabilities": {
+        "supports": {
+          "parallel_tool_calls": true,
+          "vision": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "tool_calls": true
+        },
+        "limits": {
+          "max_context_window_tokens": 400000
+        }
+      },
+      "model_picker_enabled": true,
+      "model_picker_category": "powerful",
+      "name": "GPT-5.4"
+    },
+    {
+      "id": "claude-sonnet-4.5",
+      "object": "model",
+      "created": 0,
+      "owned_by": "github-copilot",
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "capabilities": {
+        "supports": {
+          "parallel_tool_calls": true,
+          "vision": true,
+          "reasoning_effort": [],
+          "tool_calls": true
+        },
+        "limits": {
+          "max_context_window_tokens": 200000
+        }
+      },
+      "model_picker_enabled": true,
+      "model_picker_category": "versatile",
+      "name": "Claude Sonnet 4.5"
+    },
+    {
+      "id": "gpt-5.1-codex",
+      "object": "model",
+      "created": 0,
+      "owned_by": "github-copilot",
+      "supported_endpoints": [
+        "/responses"
+      ],
+      "capabilities": {
+        "supports": {
+          "parallel_tool_calls": true,
+          "vision": false,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "tool_calls": true
+        },
+        "limits": {
+          "max_context_window_tokens": 256000
+        }
+      },
+      "model_picker_enabled": true,
+      "model_picker_category": "powerful",
+      "name": "GPT-5.1 Codex"
+    }
+  ]
+}

--- a/server/server.go
+++ b/server/server.go
@@ -20,9 +20,36 @@ type Server struct {
 	running    atomic.Bool
 }
 
+type options struct {
+	proxyOptions []proxy.Option
+}
+
+// Option customizes server creation.
+type Option func(*options)
+
+// WithProxyOptions forwards proxy-level options to the underlying handler.
+func WithProxyOptions(opts ...proxy.Option) Option {
+	return func(o *options) {
+		o.proxyOptions = append(o.proxyOptions, opts...)
+	}
+}
+
+// WithCopilotHeaderConfig overrides the synthetic Copilot-identifying headers
+// sent on upstream requests.
+func WithCopilotHeaderConfig(cfg proxy.CopilotHeaderConfig) Option {
+	return WithProxyOptions(proxy.WithCopilotHeaderConfig(cfg))
+}
+
 // New creates a Server with routes and timeouts configured.
-func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string) *Server {
-	handler := proxy.NewProxyHandler(authenticator, log)
+func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string, opts ...Option) *Server {
+	cfg := options{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	handler := proxy.NewProxyHandler(authenticator, log, cfg.proxyOptions...)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
@@ -34,6 +61,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("POST /v1/responses", handler.HandleResponses)
 	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
+	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
 
 	addr := fmt.Sprintf("%s:%s", host, port)


### PR DESCRIPTION
## Summary
- add configurable synthetic Copilot headers so upstream requests can follow updated editor/plugin fingerprints without code changes
- add a non-interactive /readyz probe that validates both token availability and upstream Copilot /models reachability
- cover persisted Copilot-token reuse and the Codex models response contract with new handler/auth tests and fixtures

## Testing
- make test
- make vet
- make build