### PR TITLE
auth: use only explicit Copilot env token

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -24,6 +24,10 @@ const (
 	defaultTokenDir = "~/.config/copilot-proxy"
 )
 
+var accessTokenEnvVars = []string{
+	"COPILOT_GITHUB_TOKEN",
+}
+
 // Authenticator manages GitHub OAuth and Copilot API tokens.
 // It handles the device code flow, token caching to disk, and automatic
 // refresh using a read-write mutex for concurrent access.
@@ -93,6 +97,10 @@ func NewAuthenticator(tokenDir string) *Authenticator {
 // IsSignedIn reports whether the authenticator has a GitHub access token
 // either in memory or persisted on disk.
 func (a *Authenticator) IsSignedIn() bool {
+	if token, _ := lookupAccessTokenFromEnv(); token != "" {
+		return true
+	}
+
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	if a.accessToken != "" {
@@ -144,6 +152,10 @@ func (a *Authenticator) GetTokenNonInteractive(ctx context.Context) (string, err
 }
 
 func (a *Authenticator) getToken(ctx context.Context, allowDeviceFlow bool) (string, error) {
+	if envToken, _ := lookupAccessTokenFromEnv(); envToken != "" {
+		return a.getTokenFromEnv(ctx, envToken)
+	}
+
 	a.mu.RLock()
 	if a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
 		token := a.copilotToken
@@ -169,7 +181,43 @@ func (a *Authenticator) getToken(ctx context.Context, allowDeviceFlow bool) (str
 	return a.copilotToken, nil
 }
 
+func (a *Authenticator) getTokenFromEnv(ctx context.Context, envToken string) (string, error) {
+	a.mu.RLock()
+	if a.accessToken == envToken && a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
+		token := a.copilotToken
+		a.mu.RUnlock()
+		return token, nil
+	}
+	a.mu.RUnlock()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if a.accessToken == envToken && a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
+		return a.copilotToken, nil
+	}
+
+	// Environment-provided access tokens intentionally override any persisted
+	// login state so CI or explicit shell configuration always wins.
+	if a.accessToken != envToken {
+		a.accessToken = envToken
+		a.copilotToken = ""
+		a.tokenExpiry = time.Time{}
+	}
+
+	if err := a.exchangeForCopilotToken(ctx); err != nil {
+		return "", err
+	}
+	return a.copilotToken, nil
+}
+
 func (a *Authenticator) refreshToken(ctx context.Context, allowDeviceFlow bool) error {
+	if envToken, _ := lookupAccessTokenFromEnv(); envToken != "" {
+		a.accessToken = envToken
+		return a.exchangeForCopilotToken(ctx)
+	}
+
 	if err := a.loadAccessToken(); err == nil {
 		if err := a.exchangeForCopilotToken(ctx); err == nil {
 			return nil
@@ -391,4 +439,13 @@ func (a *Authenticator) saveCopilotToken() error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(a.tokenDir, "api-key.json"), data, 0o600)
+}
+
+func lookupAccessTokenFromEnv() (string, string) {
+	for _, name := range accessTokenEnvVars {
+		if token := strings.TrimSpace(os.Getenv(name)); token != "" {
+			return token, name
+		}
+	}
+	return "", ""
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -80,6 +80,83 @@ func TestGetToken_LoadsPersistedCopilotToken(t *testing.T) {
 	}
 }
 
+func TestGetToken_EnvAccessTokenOverridesPersistedState(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "env-access-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token env-access-token" {
+			t.Errorf("expected 'token env-access-token', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
+			Token:     "env-copilot-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	data, err := json.Marshal(CopilotTokenResponse{
+		Token:     "persisted-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "api-key.json"), data, 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	a := &Authenticator{
+		tokenDir:       dir,
+		accessToken:    "stale-access-token",
+		copilotToken:   "stale-copilot-token",
+		tokenExpiry:    time.Now().Add(1 * time.Hour),
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+	}
+
+	token, err := a.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "env-copilot-token" {
+		t.Errorf("expected env-copilot-token, got %q", token)
+	}
+}
+
+func TestGetToken_EnvAccessTokenCachesInMemory(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "env-access-token")
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
+			Token:     "env-copilot-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		})
+	}))
+	defer server.Close()
+
+	a := &Authenticator{
+		tokenDir:       t.TempDir(),
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+	}
+
+	for range 2 {
+		token, err := a.GetToken(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "env-copilot-token" {
+			t.Errorf("expected env-copilot-token, got %q", token)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 token exchange, got %d", calls)
+	}
+}
+
 func TestGetToken_ConcurrentAccess(t *testing.T) {
 	a := NewTestAuthenticator("concurrent-token")
 
@@ -184,6 +261,18 @@ func TestLoadAccessToken_Missing(t *testing.T) {
 	}
 }
 
+func TestLookupAccessTokenFromEnv_UsesCopilotTokenVar(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "copilot-token")
+
+	token, name := lookupAccessTokenFromEnv()
+	if token != "copilot-token" {
+		t.Fatalf("expected copilot-token, got %q", token)
+	}
+	if name != "COPILOT_GITHUB_TOKEN" {
+		t.Fatalf("expected COPILOT_GITHUB_TOKEN, got %q", name)
+	}
+}
+
 func TestSaveAndLoadCopilotToken(t *testing.T) {
 	dir := t.TempDir()
 	expiry := time.Now().Add(1 * time.Hour)
@@ -255,6 +344,56 @@ func TestIsSignedIn_NoToken(t *testing.T) {
 	a := &Authenticator{tokenDir: t.TempDir()}
 	if a.IsSignedIn() {
 		t.Error("expected IsSignedIn() == false with no token")
+	}
+}
+
+func TestIsSignedIn_WithEnvToken(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "env-access-token")
+
+	a := &Authenticator{tokenDir: t.TempDir()}
+	if !a.IsSignedIn() {
+		t.Error("expected IsSignedIn() == true with env token")
+	}
+}
+
+func TestGetToken_IgnoresGenericGitHubEnvVars(t *testing.T) {
+	t.Setenv("GH_TOKEN", "generic-gh-token")
+	t.Setenv("GITHUB_TOKEN", "generic-github-token")
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		t.Fatalf("unexpected token exchange using %q", r.Header.Get("Authorization"))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	data, err := json.Marshal(CopilotTokenResponse{
+		Token:     "persisted-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "api-key.json"), data, 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	a := &Authenticator{
+		tokenDir:       dir,
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+	}
+
+	token, err := a.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "persisted-token" {
+		t.Fatalf("expected persisted-token, got %q", token)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no token exchanges, got %d", calls)
 	}
 }
 
@@ -488,5 +627,37 @@ func TestRefreshToken_DisableAutoDeviceFlow(t *testing.T) {
 	}
 	if err.Error() != "not authenticated" {
 		t.Errorf("expected 'not authenticated', got %q", err.Error())
+	}
+}
+
+func TestRefreshToken_UsesEnvAccessTokenWithoutSavingAccessToken(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "env-access-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token env-access-token" {
+			t.Errorf("expected 'token env-access-token', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
+			Token:     "env-copilot-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	a := &Authenticator{
+		tokenDir:       dir,
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+	}
+
+	if err := a.refreshToken(context.Background(), false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.accessToken != "env-access-token" {
+		t.Fatalf("expected access token to be loaded from env, got %q", a.accessToken)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "access-token")); !os.IsNotExist(err) {
+		t.Fatalf("expected no access-token file to be written, got err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add non-interactive auth support for `COPILOT_GITHUB_TOKEN`
- avoid treating generic `GH_TOKEN` and `GITHUB_TOKEN` values as proxy auth
- add regression coverage so generic GitHub env vars do not override persisted Copilot auth

## Testing
- go test ./... -count=1
- make vet

## Notes
- Live Copilot Smoke passed the secret gate on this branch
- full Live Copilot Smoke passed end-to-end when combined with #21 in run 23358512171