### PR TITLE
Strip unsupported service_tier from responses requests

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -426,6 +426,14 @@ func TestHandleResponses(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			t.Errorf("expected Bearer test-token, got %q", r.Header.Get("Authorization"))
 		}
+		body, _ := io.ReadAll(r.Body)
+		var upstreamReq map[string]json.RawMessage
+		if err := json.Unmarshal(body, &upstreamReq); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		if _, ok := upstreamReq["service_tier"]; ok {
+			t.Fatalf("upstream request should not include service_tier")
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"id":"resp-123","object":"response","status":"completed"}`))
@@ -433,7 +441,8 @@ func TestHandleResponses(t *testing.T) {
 
 	responsesReq := `{
 		"model": "gpt-4",
-		"input": "Hello"
+		"input": "Hello",
+		"service_tier": "auto"
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(responsesReq))
 	req.Header.Set("Content-Type", "application/json")
@@ -1911,12 +1920,20 @@ func TestOpenAIResponsesStreaming(t *testing.T) {
 		if r.URL.Path != "/responses" {
 			t.Errorf("expected path /responses, got %q", r.URL.Path)
 		}
+		body, _ := io.ReadAll(r.Body)
+		var upstreamReq map[string]json.RawMessage
+		if err := json.Unmarshal(body, &upstreamReq); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		if _, ok := upstreamReq["service_tier"]; ok {
+			t.Fatalf("upstream request should not include service_tier")
+		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(sseBody))
 	})
 
-	reqBody := `{"model":"gpt-4","input":"Hello","stream":true}`
+	reqBody := `{"model":"gpt-4","input":"Hello","stream":true,"service_tier":"auto"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -329,6 +329,14 @@ func extractResponsesOutputText(body []byte) (string, error) {
 }
 
 func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint string, injectResumePrompt bool) []byte {
+	if rewrittenBody, strippedFields := stripUnsupportedResponsesRequestFields(bodyBytes); len(strippedFields) > 0 {
+		bodyBytes = rewrittenBody
+		h.log.Debug("stripped unsupported responses request fields",
+			logger.F("endpoint", endpoint),
+			logger.F("fields", strippedFields),
+		)
+	}
+
 	if rewrittenBody, rewriteCount := rewriteSyntheticCompactionRequest(bodyBytes); rewriteCount > 0 {
 		bodyBytes = rewrittenBody
 		resumePromptInjected := false
@@ -350,6 +358,31 @@ func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint st
 	}
 
 	return bodyBytes
+}
+
+func stripUnsupportedResponsesRequestFields(bodyBytes []byte) ([]byte, []string) {
+	var req map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		return bodyBytes, nil
+	}
+
+	var strippedFields []string
+	for _, field := range []string{"service_tier"} {
+		if _, ok := req[field]; ok {
+			delete(req, field)
+			strippedFields = append(strippedFields, field)
+		}
+	}
+	if len(strippedFields) == 0 {
+		return bodyBytes, nil
+	}
+
+	rewrittenBody, err := json.Marshal(req)
+	if err != nil {
+		return bodyBytes, nil
+	}
+
+	return rewrittenBody, strippedFields
 }
 
 func (h *ProxyHandler) postResponsesWithFallback(ctx context.Context, token string, bodyBytes []byte) (*http.Response, error) {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -67,6 +67,9 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		if _, ok := body["previous_response_id"]; ok {
 			t.Fatalf("upstream request should not include websocket previous_response_id")
 		}
+		if _, ok := body["service_tier"]; ok {
+			t.Fatalf("upstream request should not include service_tier")
+		}
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n")
@@ -93,6 +96,7 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		"ws_request_header_traceparent": "00-11111111111111111111111111111111-2222222222222222-01",
 		"x-codex-turn-metadata":         `{"turn_id":"turn-1"}`,
 	}
+	request["service_tier"] = "auto"
 
 	if err := conn.WriteJSON(request); err != nil {
 		t.Fatalf("failed to write websocket request: %v", err)


### PR DESCRIPTION
## Summary
- strip unsupported `service_tier` from `/v1/responses` request bodies before proxying upstream
- log stripped unsupported fields during request rewriting
- add regression coverage for standard, streaming, and websocket responses flows

## Testing
- go test ./proxy/...