### PR TITLE
Fix readiness and responses review follow-ups

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -326,13 +326,23 @@ func (h *ProxyHandler) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), readyzUpstreamTimeout)
 	defer cancel()
 
+	if err := ctx.Err(); err != nil {
+		return
+	}
+
 	token, err := h.auth.GetTokenNonInteractive(ctx)
 	if err != nil {
+		if shouldSuppressReadyzResponse(r.Context(), err) {
+			return
+		}
 		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", fmt.Sprintf("failed to get token: %v", err))
 		return
 	}
 
 	if err := h.checkUpstreamReady(ctx, token); err != nil {
+		if shouldSuppressReadyzResponse(r.Context(), err) {
+			return
+		}
 		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", err.Error())
 		return
 	}
@@ -363,6 +373,22 @@ func (h *ProxyHandler) checkUpstreamReady(ctx context.Context, token string) err
 	}
 
 	return nil
+}
+
+func shouldSuppressReadyzResponse(parent context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Only suppress deadline errors when the caller's context already timed out.
+	// The proxy's own readiness timeout should still surface as not_ready.
+	return parent.Err() != nil
 }
 
 func writeReadyzStatus(w http.ResponseWriter, statusCode int, status string, errMessage string) {
@@ -489,7 +515,7 @@ func transformModelsResponse(body []byte) []byte {
 		Data   []json.RawMessage `json:"data"`
 		Object string            `json:"object"`
 	}
-	if err := json.Unmarshal(body, &upstream); err != nil || len(upstream.Data) == 0 {
+	if err := json.Unmarshal(body, &upstream); err != nil {
 		return body
 	}
 
@@ -522,7 +548,7 @@ func transformModelsResponse(body []byte) []byte {
 		InputModalities             []string          `json:"input_modalities"`
 	}
 
-	var codexModels []codexModel
+	codexModels := make([]codexModel, 0, len(upstream.Data))
 	for _, raw := range upstream.Data {
 		var m struct {
 			ID                 string   `json:"id"`
@@ -562,8 +588,14 @@ func transformModelsResponse(body []byte) []byte {
 			})
 		}
 		if len(reasoningLevels) > 0 {
-			mid := "medium"
-			defaultReasoning = &mid
+			defaultLevel := reasoningLevels[0].Effort
+			for _, level := range reasoningLevels {
+				if level.Effort == "medium" {
+					defaultLevel = level.Effort
+					break
+				}
+			}
+			defaultReasoning = &defaultLevel
 		}
 
 		var ctxWindow *int64

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3,12 +3,14 @@ package proxy
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +31,12 @@ func newTestProxyHandler(t testing.TB, backend http.HandlerFunc) *ProxyHandler {
 		log:            logger.New(logger.LevelInfo),
 		retryBaseDelay: 1 * time.Millisecond,
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestHandleHealthz(t *testing.T) {
@@ -54,6 +62,16 @@ func TestHandleHealthz(t *testing.T) {
 }
 
 func TestHandleReadyz(t *testing.T) {
+	assertProbeAborted := func(t *testing.T, w *httptest.ResponseRecorder) {
+		t.Helper()
+		if got := w.Header().Get("Content-Type"); got != "" {
+			t.Fatalf("expected no content type for aborted probe, got %q", got)
+		}
+		if got := w.Body.String(); got != "" {
+			t.Fatalf("expected no response body for aborted probe, got %q", got)
+		}
+	}
+
 	t.Run("ready when auth and upstream probe succeed", func(t *testing.T) {
 		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/models" {
@@ -145,6 +163,106 @@ func TestHandleReadyz(t *testing.T) {
 		}
 		if !strings.Contains(result["error"], "upstream probe returned 503") {
 			t.Fatalf("unexpected error message: %q", result["error"])
+		}
+	})
+
+	t.Run("canceled request does not rewrite readiness status", func(t *testing.T) {
+		var probeHits atomic.Int32
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			probeHits.Add(1)
+			t.Fatalf("upstream probe should not be sent for a canceled request")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		ctx, cancel := context.WithCancel(req.Context())
+		cancel()
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		h.HandleReadyz(w, req)
+
+		if got := probeHits.Load(); got != 0 {
+			t.Fatalf("expected no upstream probe, got %d hits", got)
+		}
+		assertProbeAborted(t, w)
+	})
+
+	t.Run("timed out upstream probe does not rewrite readiness status", func(t *testing.T) {
+		probeStarted := make(chan struct{})
+		probeCanceled := make(chan struct{})
+
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			close(probeStarted)
+			<-r.Context().Done()
+			close(probeCanceled)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		ctx, cancel := context.WithTimeout(req.Context(), 100*time.Millisecond)
+		defer cancel()
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			h.HandleReadyz(w, req)
+		}()
+
+		select {
+		case <-probeStarted:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for readiness probe to start")
+		}
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for handler to return")
+		}
+
+		select {
+		case <-probeCanceled:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for upstream probe cancellation")
+		}
+
+		assertProbeAborted(t, w)
+	})
+
+	t.Run("proxy readiness timeout still returns not ready", func(t *testing.T) {
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("unexpected upstream request handler invocation")
+		})
+		h.client = &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if err := r.Context().Err(); err != nil {
+					t.Fatalf("expected active request context, got %v", err)
+				}
+				return nil, context.DeadlineExceeded
+			}),
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleReadyz(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		var result map[string]string
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if result["status"] != "not_ready" {
+			t.Fatalf("expected status not_ready, got %q", result["status"])
+		}
+		if !strings.Contains(result["error"], "upstream probe failed") {
+			t.Fatalf("expected upstream timeout error, got %q", result["error"])
 		}
 	})
 }
@@ -431,8 +549,12 @@ func TestHandleResponses(t *testing.T) {
 		if err := json.Unmarshal(body, &upstreamReq); err != nil {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
-		if _, ok := upstreamReq["service_tier"]; ok {
-			t.Fatalf("upstream request should not include service_tier")
+		var serviceTier string
+		if err := json.Unmarshal(upstreamReq["service_tier"], &serviceTier); err != nil {
+			t.Fatalf("upstream request should preserve service_tier: %v", err)
+		}
+		if serviceTier != "auto" {
+			t.Fatalf("expected upstream service_tier auto, got %q", serviceTier)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -1428,6 +1550,44 @@ func TestSetCopilotHeadersWithConfig(t *testing.T) {
 	}
 }
 
+func TestPostJSONEndpointWithHeaders_ProxyHeadersTakePrecedence(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("expected Authorization header from proxy, got %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("expected Content-Type header from proxy, got %q", got)
+		}
+		if got := r.Header.Get("Traceparent"); got != "00-11111111111111111111111111111111-2222222222222222-01" {
+			t.Fatalf("expected passthrough header to survive merge, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	resp, err := handler.postJSONEndpointWithHeaders(
+		context.Background(),
+		"test-token",
+		"/responses",
+		[]byte(`{"input":"hello"}`),
+		http.Header{
+			"Authorization": []string{"Bearer wrong-token"},
+			"Content-Type":  []string{"text/plain"},
+			"Traceparent":   []string{"00-11111111111111111111111111111111-2222222222222222-01"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("postJSONEndpointWithHeaders returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+}
+
 func TestHandleOpenAIChatCompletionsUpstreamError(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1552,6 +1712,82 @@ func TestHandleModels(t *testing.T) {
 		resp := w.Result()
 		if resp.StatusCode != http.StatusInternalServerError {
 			t.Fatalf("expected 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty data still returns models array", func(t *testing.T) {
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		})
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if !bytes.Contains(body, []byte(`"models":[]`)) {
+			t.Fatalf("expected transformed response to include empty models array, got %s", body)
+		}
+
+		var result struct {
+			Data   []json.RawMessage `json:"data"`
+			Models []json.RawMessage `json:"models"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if len(result.Data) != 0 {
+			t.Fatalf("expected 0 data entries, got %d", len(result.Data))
+		}
+		if result.Models == nil {
+			t.Fatal("expected models to be an empty array, got nil")
+		}
+		if len(result.Models) != 0 {
+			t.Fatalf("expected 0 models entries, got %d", len(result.Models))
+		}
+	})
+
+	t.Run("default reasoning falls back to first supported level", func(t *testing.T) {
+		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5-thinking","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"capabilities":{"supports":{"reasoning_effort":["low","high"]}},"model_picker_enabled":true,"name":"GPT-5 Thinking"}]}`))
+		})
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result struct {
+			Models []struct {
+				DefaultReasoningLevel    *string `json:"default_reasoning_level,omitempty"`
+				SupportedReasoningLevels []struct {
+					Effort string `json:"effort"`
+				} `json:"supported_reasoning_levels"`
+			} `json:"models"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if len(result.Models) != 1 {
+			t.Fatalf("expected 1 model entry, got %d", len(result.Models))
+		}
+		if result.Models[0].DefaultReasoningLevel == nil || *result.Models[0].DefaultReasoningLevel != "low" {
+			t.Fatalf("expected default_reasoning_level low, got %v", result.Models[0].DefaultReasoningLevel)
+		}
+		if len(result.Models[0].SupportedReasoningLevels) != 2 {
+			t.Fatalf("expected 2 supported reasoning levels, got %d", len(result.Models[0].SupportedReasoningLevels))
 		}
 	})
 }
@@ -1925,8 +2161,12 @@ func TestOpenAIResponsesStreaming(t *testing.T) {
 		if err := json.Unmarshal(body, &upstreamReq); err != nil {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
-		if _, ok := upstreamReq["service_tier"]; ok {
-			t.Fatalf("upstream request should not include service_tier")
+		var serviceTier string
+		if err := json.Unmarshal(upstreamReq["service_tier"], &serviceTier); err != nil {
+			t.Fatalf("upstream request should preserve service_tier: %v", err)
+		}
+		if serviceTier != "auto" {
+			t.Fatalf("expected upstream service_tier auto, got %q", serviceTier)
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -361,28 +361,7 @@ func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint st
 }
 
 func stripUnsupportedResponsesRequestFields(bodyBytes []byte) ([]byte, []string) {
-	var req map[string]json.RawMessage
-	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		return bodyBytes, nil
-	}
-
-	var strippedFields []string
-	for _, field := range []string{"service_tier"} {
-		if _, ok := req[field]; ok {
-			delete(req, field)
-			strippedFields = append(strippedFields, field)
-		}
-	}
-	if len(strippedFields) == 0 {
-		return bodyBytes, nil
-	}
-
-	rewrittenBody, err := json.Marshal(req)
-	if err != nil {
-		return bodyBytes, nil
-	}
-
-	return rewrittenBody, strippedFields
+	return bodyBytes, nil
 }
 
 func (h *ProxyHandler) postResponsesWithFallback(ctx context.Context, token string, bodyBytes []byte) (*http.Response, error) {

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -53,6 +53,7 @@ type responsesWebSocketStreamEvent struct {
 
 type responsesWebSocketSession struct {
 	conn           *websocket.Conn
+	ctx            context.Context
 	baseHeaders    http.Header
 	turnState      string
 	lastResponseID string
@@ -139,6 +140,7 @@ func newResponsesWebSocketSession(conn *websocket.Conn, r *http.Request) *respon
 
 	return &responsesWebSocketSession{
 		conn:        conn,
+		ctx:         r.Context(),
 		baseHeaders: baseHeaders,
 		turnState:   strings.TrimSpace(r.Header.Get("X-Codex-Turn-State")),
 	}
@@ -262,7 +264,7 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 		})
 	}
 
-	token, err := h.auth.GetToken(context.Background())
+	token, err := h.auth.GetToken(s.ctx)
 	if err != nil {
 		s.sendWrappedError(http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error", nil)
 		return err
@@ -329,12 +331,16 @@ func (s *responsesWebSocketSession) planRequest(h *ProxyHandler, request *respon
 
 func (s *responsesWebSocketSession) postCreateRequest(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, plan responsesWebSocketRequestPlan) (*http.Response, bool, bool, error) {
 	resp, err := s.postCreateRequestSegments(h, ctx, token, request, plan.upstreamSegments(), plan.useTurnStateDelta)
-	if !plan.useTurnStateDelta || (err == nil && resp != nil && resp.StatusCode == http.StatusOK) {
+	if !plan.useTurnStateDelta || err != nil || resp == nil || resp.StatusCode == http.StatusOK {
 		return resp, plan.useTurnStateDelta, false, err
 	}
 
-	if resp != nil {
-		_ = resp.Body.Close()
+	respBody, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	_, code := extractResponsesWebSocketError(resp.StatusCode, respBody)
+	if readErr != nil || resp.StatusCode != http.StatusBadRequest || code != "invalid_turn_state" {
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		return resp, true, false, nil
 	}
 	h.log.Debug("responses websocket delta replay failed; retrying full history",
 		logger.F("model", request.Model),

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -67,8 +67,12 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		if _, ok := body["previous_response_id"]; ok {
 			t.Fatalf("upstream request should not include websocket previous_response_id")
 		}
-		if _, ok := body["service_tier"]; ok {
-			t.Fatalf("upstream request should not include service_tier")
+		var serviceTier string
+		if err := json.Unmarshal(body["service_tier"], &serviceTier); err != nil {
+			t.Fatalf("upstream request should preserve service_tier: %v", err)
+		}
+		if serviceTier != "auto" {
+			t.Fatalf("expected upstream service_tier auto, got %q", serviceTier)
 		}
 
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -41,10 +41,10 @@ func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, token, p
 		if err != nil {
 			return nil, err
 		}
-		h.setCopilotHeaders(req, token)
 		if len(extraHeaders) > 0 {
 			mergeHeaderValues(req.Header, extraHeaders)
 		}
+		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 }


### PR DESCRIPTION
## Summary
- preserve `service_tier` on responses requests, keep proxy auth headers authoritative, and tighten websocket `invalid_turn_state` fallback handling
- make `/readyz` cancellation-safe without hiding genuine proxy-side readiness timeouts
- preserve Codex model transformation behavior for empty model lists and reasoning levels without `medium`

## Testing
- go test ./... -count=1
- go vet ./...