### PR TITLE
Forward responses subagent headers safely

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -39,6 +39,16 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func assertOnlySubagentHeaderForwarded(t testing.TB, r *http.Request, want string) {
+	t.Helper()
+	if got := r.Header.Get("X-OpenAI-Subagent"); got != want {
+		t.Fatalf("expected X-OpenAI-Subagent %q, got %q", want, got)
+	}
+	if got := r.Header.Get("X-Test-Client-Header"); got != "" {
+		t.Fatalf("expected X-Test-Client-Header to be stripped, got %q", got)
+	}
+}
+
 func TestHandleHealthz(t *testing.T) {
 	h := &ProxyHandler{}
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
@@ -544,6 +554,7 @@ func TestHandleResponses(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			t.Errorf("expected Bearer test-token, got %q", r.Header.Get("Authorization"))
 		}
+		assertOnlySubagentHeaderForwarded(t, r, "review")
 		body, _ := io.ReadAll(r.Body)
 		var upstreamReq map[string]json.RawMessage
 		if err := json.Unmarshal(body, &upstreamReq); err != nil {
@@ -568,6 +579,8 @@ func TestHandleResponses(t *testing.T) {
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(responsesReq))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-OpenAI-Subagent", "review")
+	req.Header.Set("X-Test-Client-Header", "blocked")
 	w := httptest.NewRecorder()
 
 	handler.HandleResponses(w, req)
@@ -594,6 +607,7 @@ func TestHandleCompact(t *testing.T) {
 		if r.URL.Path != "/responses" {
 			t.Errorf("expected upstream path /responses, got %q", r.URL.Path)
 		}
+		assertOnlySubagentHeaderForwarded(t, r, "compact")
 
 		body, _ := io.ReadAll(r.Body)
 		var req map[string]interface{}
@@ -639,6 +653,8 @@ func TestHandleCompact(t *testing.T) {
 	}
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-OpenAI-Subagent", "compact")
+	req.Header.Set("X-Test-Client-Header", "blocked")
 	w := httptest.NewRecorder()
 
 	handler.HandleCompact(w, req)
@@ -1111,6 +1127,7 @@ func TestHandleMemorySummarize(t *testing.T) {
 		if r.URL.Path != "/responses" {
 			t.Errorf("expected upstream path /responses, got %q", r.URL.Path)
 		}
+		assertOnlySubagentHeaderForwarded(t, r, "memory_consolidation")
 
 		// Return a response with the model's JSON summary
 		w.Header().Set("Content-Type", "application/json")
@@ -1120,6 +1137,8 @@ func TestHandleMemorySummarize(t *testing.T) {
 	reqBody := `{"model":"gpt-5.4","traces":[{"id":"t1","metadata":{"source_path":"/tmp/trace.json"},"items":[{"type":"message","role":"user","content":[{"type":"input_text","text":"fix the bug"}]}]}]}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/memories/trace_summarize", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-OpenAI-Subagent", "memory_consolidation")
+	req.Header.Set("X-Test-Client-Header", "blocked")
 	w := httptest.NewRecorder()
 
 	handler.HandleMemorySummarize(w, req)

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -12,6 +12,16 @@ import (
 	"github.com/sozercan/copilot-proxy/logger"
 )
 
+func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
+	if subagent := strings.TrimSpace(r.Header.Get("X-OpenAI-Subagent")); subagent != "" {
+		headers := make(http.Header, 1)
+		headers.Set("X-OpenAI-Subagent", subagent)
+		return headers
+	}
+
+	return nil
+}
+
 // HandleResponses handles POST /v1/responses by forwarding the request to
 // Copilot's responses endpoint with only auth headers injected.
 func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +50,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
 	defer upstreamCancel()
 
-	resp, err := h.postResponses(upstreamCtx, token, bodyBytes)
+	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
 	if err != nil {
 		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
 		return
@@ -107,7 +117,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithFallback(upstreamCtx, token, bodyBytes)
+	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
 	if err != nil {
 		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
 		return
@@ -228,7 +238,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithFallback(upstreamCtx, token, reqBody)
+	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, reqBody, responsesExtraHeadersFromRequest(r))
 	if err != nil {
 		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
 		return

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -367,9 +367,6 @@ func (s *responsesWebSocketSession) postCreateRequestSegments(h *ProxyHandler, c
 func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCreateRequest, includeTurnState bool) http.Header {
 	headers := make(http.Header)
 	mergeHeaderValues(headers, s.baseHeaders)
-	if includeTurnState && s.turnState != "" {
-		headers.Set("X-Codex-Turn-State", s.turnState)
-	}
 
 	for key, value := range request.ClientMetadata {
 		trimmed := strings.TrimSpace(value)
@@ -382,10 +379,14 @@ func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCr
 			headers.Set("X-Codex-Turn-Metadata", trimmed)
 		case strings.HasPrefix(key, responsesWebSocketRequestHeaderPrefix):
 			name := strings.TrimSpace(strings.TrimPrefix(key, responsesWebSocketRequestHeaderPrefix))
-			if name != "" {
+			if name != "" && !strings.EqualFold(name, "X-Codex-Turn-State") {
 				headers.Set(name, trimmed)
 			}
 		}
+	}
+
+	if includeTurnState && s.turnState != "" {
+		headers.Set("X-Codex-Turn-State", s.turnState)
 	}
 
 	return headers

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -394,7 +394,7 @@ func TestHandleResponsesWebSocket_AutoCompactsLongHistory(t *testing.T) {
 	}
 }
 
-func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInput(t *testing.T) {
+func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInputAndIgnoresClientTurnStateHeader(t *testing.T) {
 	upstreamRequests := make([]map[string]interface{}, 0, 2)
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, err := io.ReadAll(r.Body)
@@ -446,6 +446,9 @@ func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInput(t *te
 			},
 		},
 	})
+	first["client_metadata"] = map[string]string{
+		"ws_request_header_x-codex-turn-state": "client-state-first",
+	}
 	if err := conn.WriteJSON(first); err != nil {
 		t.Fatalf("failed to write first request: %v", err)
 	}
@@ -464,6 +467,9 @@ func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInput(t *te
 		},
 	})
 	second["previous_response_id"] = websocketResponseID(t, firstCreated)
+	second["client_metadata"] = map[string]string{
+		"ws_request_header_x-codex-turn-state": "client-state-second",
+	}
 	if err := conn.WriteJSON(second); err != nil {
 		t.Fatalf("failed to write second request: %v", err)
 	}


### PR DESCRIPTION
## Summary
- forward only the `X-OpenAI-Subagent` header from HTTP responses endpoints instead of passing through arbitrary client headers
- preserve proxy-managed websocket turn state even when clients try to override `X-Codex-Turn-State` via request metadata
- add regression tests covering both header-forwarding paths and the websocket turn-state override case

## Testing
- go test ./proxy