### PR TITLE
Allow larger summarization request bodies

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -129,11 +129,15 @@ Compatibility shim for environments expecting `/responses/compact`. The proxy re
 - a normal assistant summary message
 - a proxy-owned opaque `compaction` item whose `encrypted_content` can later be sent back to `/v1/responses` or `/v1/responses/compact`
 
+Requests to this endpoint are accepted up to `64 MiB` so large session histories can be compacted without tripping the default request-body limit.
+
 If the requested model does not support the upstream Responses API, the proxy retries against a compatible fallback model discovered from `/models`.
 
 ## `POST /v1/memories/trace_summarize`
 
 Compatibility shim that summarizes one or more traces into `{trace_summary, memory_summary}` objects using the upstream `/responses` endpoint plus a JSON-only summarization prompt.
+
+Requests to this endpoint are accepted up to `64 MiB` so larger trace bundles can be summarized in a single call.
 
 ## `GET /healthz`
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -27,6 +27,10 @@ import (
 const (
 	// maxRequestBodySize is the maximum allowed request body size (10MB).
 	maxRequestBodySize = 10 << 20
+	// maxLargeRequestBodySize gives proxy-owned summarization endpoints a higher
+	// ceiling because they can legitimately contain full session histories or
+	// trace bundles that need to be summarized.
+	maxLargeRequestBodySize = 64 << 20
 	// upstreamTimeout is the timeout for LLM inference requests.
 	upstreamTimeout = 5 * time.Minute
 	// readyzUpstreamTimeout bounds readiness probes that validate upstream reachability.
@@ -700,6 +704,13 @@ func writeOpenAIError(w http.ResponseWriter, status int, message, errType string
 // readBody reads the request body up to maxRequestBodySize. If the body exceeds
 // the limit, it returns an error so callers can return HTTP 413.
 func readBody(r *http.Request) ([]byte, error) {
+	return readBodyWithLimit(r, maxRequestBodySize)
+}
+
+// readBodyWithLimit reads and transparently decompresses the request body up to
+// the provided limit. If the body exceeds the limit, it returns an error so
+// callers can return HTTP 413.
+func readBodyWithLimit(r *http.Request, limit int64) ([]byte, error) {
 	var reader io.Reader = r.Body
 
 	// Decompress request body if Content-Encoding is set.
@@ -727,17 +738,17 @@ func readBody(r *http.Request) ([]byte, error) {
 		reader = zr
 	}
 
-	body, err := io.ReadAll(io.LimitReader(reader, maxRequestBodySize+1))
+	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
 	if err != nil {
 		return nil, &requestBodyError{
 			statusCode: http.StatusBadRequest,
 			err:        err,
 		}
 	}
-	if len(body) > maxRequestBodySize {
+	if int64(len(body)) > limit {
 		return nil, &requestBodyError{
 			statusCode: http.StatusRequestEntityTooLarge,
-			err:        fmt.Errorf("request body too large (max %d bytes)", maxRequestBodySize),
+			err:        fmt.Errorf("request body too large (max %d bytes)", limit),
 		}
 	}
 	return body, nil

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -601,6 +601,35 @@ func TestHandleResponses(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_LargeBodyStillRejected(t *testing.T) {
+	var upstreamHits atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-too-large","object":"response","status":"completed"}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(makeOversizedResponsesRequestBody(t)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 413, got %d: %s", resp.StatusCode, body)
+	}
+	if upstreamHits.Load() != 0 {
+		t.Fatalf("expected oversized request to be rejected before upstream call, got %d upstream hits", upstreamHits.Load())
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("request body too large")) {
+		t.Fatalf("expected 413 body to mention oversized request, got %s", body)
+	}
+}
+
 func TestHandleCompact(t *testing.T) {
 	priorSummary := "previous compacted context"
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
@@ -699,6 +728,41 @@ func TestHandleCompact(t *testing.T) {
 	}
 	if got := decodeCompactionSummaryForTest(t, result.Output[1].EncryptedContent); got != "compacted summary of conversation" {
 		t.Errorf("expected encoded compaction summary, got %q", got)
+	}
+}
+
+func TestHandleCompact_LargeBodyAllowed(t *testing.T) {
+	var upstreamHits atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		if r.URL.Path != "/responses" {
+			t.Errorf("expected upstream path /responses, got %q", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		if len(body) <= maxRequestBodySize {
+			t.Fatalf("expected forwarded compact body to exceed default limit, got %d bytes", len(body))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"compacted summary of conversation"}]}]}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(makeOversizedResponsesRequestBody(t)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if upstreamHits.Load() != 1 {
+		t.Fatalf("expected upstream to receive oversized compact request, got %d hits", upstreamHits.Load())
 	}
 }
 
@@ -1170,6 +1234,41 @@ func TestHandleMemorySummarize(t *testing.T) {
 	}
 }
 
+func TestHandleMemorySummarize_LargeBodyAllowed(t *testing.T) {
+	var upstreamHits atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		if r.URL.Path != "/responses" {
+			t.Errorf("expected upstream path /responses, got %q", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		if len(body) <= maxRequestBodySize {
+			t.Fatalf("expected forwarded memory summarize body to exceed default limit, got %d bytes", len(body))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"[{\"trace_summary\":\"trace\",\"memory_summary\":\"memory\"}]"}]}]}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/memories/trace_summarize", bytes.NewReader(makeOversizedMemorySummarizeRequestBody(t)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleMemorySummarize(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if upstreamHits.Load() != 1 {
+		t.Fatalf("expected upstream to receive oversized memory summarize request, got %d hits", upstreamHits.Load())
+	}
+}
+
 func TestHandleMemorySummarize_StripsInlineRenderMarkers(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {
@@ -1295,6 +1394,60 @@ func requireMessageTextWithRole(t *testing.T, raw interface{}, wantRole string) 
 		t.Fatalf("expected text content, got %#v", part["text"])
 	}
 	return text
+}
+
+func makeOversizedResponsesRequestBody(t testing.TB) []byte {
+	t.Helper()
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": strings.Repeat("a", maxRequestBodySize),
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal oversized responses request: %v", err)
+	}
+	if len(reqBody) <= maxRequestBodySize {
+		t.Fatalf("expected oversized responses body, got %d bytes", len(reqBody))
+	}
+	if len(reqBody) > maxLargeRequestBodySize {
+		t.Fatalf("expected oversized responses body to stay below large limit, got %d bytes", len(reqBody))
+	}
+	return reqBody
+}
+
+func makeOversizedMemorySummarizeRequestBody(t testing.TB) []byte {
+	t.Helper()
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"traces": []interface{}{
+			map[string]interface{}{
+				"id": "t1",
+				"metadata": map[string]string{
+					"source_path": "/tmp/trace.json",
+				},
+				"items": []interface{}{
+					map[string]interface{}{
+						"type": "message",
+						"role": "user",
+						"content": []map[string]string{
+							{"type": "input_text", "text": strings.Repeat("a", maxRequestBodySize)},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal oversized memory summarize request: %v", err)
+	}
+	if len(reqBody) <= maxRequestBodySize {
+		t.Fatalf("expected oversized memory summarize body, got %d bytes", len(reqBody))
+	}
+	if len(reqBody) > maxLargeRequestBodySize {
+		t.Fatalf("expected oversized memory summarize body to stay below large limit, got %d bytes", len(reqBody))
+	}
+	return reqBody
 }
 
 func TestRewriteSyntheticCompactionRequest(t *testing.T) {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -95,7 +95,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bodyBytes, err := readBody(r)
+	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
 		writeOpenAIError(w, status, err.Error(), "invalid_request_error")
@@ -196,7 +196,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	bodyBytes, err := readBody(r)
+	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
 		writeOpenAIError(w, status, err.Error(), "invalid_request_error")


### PR DESCRIPTION
## Summary
- add a shared request-body reader that accepts a route-specific size limit
- raise the limit to 64 MiB for `/v1/responses/compact` and `/v1/memories/trace_summarize`
- document the larger ceiling and cover both the allowed summarization cases and the still-rejected standard `/v1/responses` case

## Testing
- go test ./proxy