### PR TITLE
Add Sparkle updater support for the macOS app

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,15 +49,32 @@ jobs:
           go-version-file: go.mod
 
       - name: Build macOS menubar app
+        env:
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
         run: VERSION=${GITHUB_REF#refs/tags/} GOARCH=arm64 make build-app
 
       - name: Zip app bundle
-        run: zip -r "Copilot-Proxy-macos-arm64.zip" "Copilot Proxy.app"
+        run: |
+          mkdir -p dist/macos-release
+          ditto -c -k --sequesterRsrc --keepParent "Copilot Proxy.app" dist/macos-release/"Copilot-Proxy-macos-arm64.zip"
+
+      - name: Generate Sparkle appcast
+        env:
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | .build/sparkle/unpacked/bin/generate_appcast \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
+            --full-release-notes-url "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}" \
+            --maximum-deltas 0 \
+            dist/macos-release
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: "Copilot-Proxy-macos-arm64.zip"
+          files: |
+            dist/macos-release/Copilot-Proxy-macos-arm64.zip
+            dist/macos-release/appcast.xml
 
   publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 copilot-proxy
 Copilot Proxy.app/
+.build/
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,37 @@ APP_NAME := Copilot Proxy.app
 APP_BUNDLE_ID := com.copilot-proxy.menubar
 VERSION ?= 0.0.0
 APP_VERSION := $(patsubst v%,%,$(VERSION))
+SPARKLE_VERSION := 2.9.0
+SPARKLE_BUILD_DIR := .build/sparkle
+SPARKLE_ARCHIVE := $(SPARKLE_BUILD_DIR)/Sparkle-$(SPARKLE_VERSION).tar.xz
+SPARKLE_UNPACK_DIR := $(SPARKLE_BUILD_DIR)/unpacked
+SPARKLE_FRAMEWORK := $(SPARKLE_UNPACK_DIR)/Sparkle.framework
+SPARKLE_DOWNLOAD_URL := https://github.com/sparkle-project/Sparkle/releases/download/$(SPARKLE_VERSION)/Sparkle-$(SPARKLE_VERSION).tar.xz
+SPARKLE_FEED_URL ?= https://github.com/sozercan/copilot-proxy/releases/latest/download/appcast.xml
+SPARKLE_PUBLIC_ED_KEY ?=
 
 .PHONY: build build-app test vet lint clean docker-build
 
 build:
 	go build -ldflags="$(LDFLAGS)" -o $(BINARY) .
 
-build-app:
+$(SPARKLE_ARCHIVE):
+	@mkdir -p "$(SPARKLE_BUILD_DIR)"
+	curl -fL "$(SPARKLE_DOWNLOAD_URL)" -o "$(SPARKLE_ARCHIVE)"
+
+$(SPARKLE_FRAMEWORK): $(SPARKLE_ARCHIVE)
+	@rm -rf "$(SPARKLE_UNPACK_DIR)"
+	@mkdir -p "$(SPARKLE_UNPACK_DIR)"
+	tar -xf "$(SPARKLE_ARCHIVE)" -C "$(SPARKLE_UNPACK_DIR)"
+
+build-app: $(SPARKLE_FRAMEWORK)
 	@rm -rf "$(APP_NAME)"
 	@mkdir -p "$(APP_NAME)/Contents/MacOS"
 	@mkdir -p "$(APP_NAME)/Contents/Resources"
-	go build -ldflags="$(LDFLAGS)" -o "$(APP_NAME)/Contents/MacOS/copilot-proxy-menubar" ./cmd/menubar/
+	@mkdir -p "$(APP_NAME)/Contents/Frameworks"
+	CGO_ENABLED=1 CGO_LDFLAGS="-F$(abspath $(SPARKLE_UNPACK_DIR))" \
+		go build -tags sparkle -ldflags="$(LDFLAGS)" -o "$(APP_NAME)/Contents/MacOS/copilot-proxy-menubar" ./cmd/menubar/
+	ditto "$(SPARKLE_FRAMEWORK)" "$(APP_NAME)/Contents/Frameworks/Sparkle.framework"
 	@printf '<?xml version="1.0" encoding="UTF-8"?>\n\
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n\
 <plist version="1.0">\n\
@@ -31,10 +51,24 @@ build-app:
 	<string>$(APP_VERSION)</string>\n\
 	<key>CFBundleShortVersionString</key>\n\
 	<string>$(APP_VERSION)</string>\n\
+	<key>LSMinimumSystemVersion</key>\n\
+	<string>10.13</string>\n\
 	<key>LSUIElement</key>\n\
+	<true/>\n\
+	<key>SUEnableInstallerLauncherService</key>\n\
+	<true/>\n\
+	<key>SUFeedURL</key>\n\
+	<string>$(SPARKLE_FEED_URL)</string>\n\
+	<key>SUPublicEDKey</key>\n\
+	<string>$(SPARKLE_PUBLIC_ED_KEY)</string>\n\
+	<key>SURequireSignedFeed</key>\n\
+	<true/>\n\
+	<key>SUVerifyUpdateBeforeExtraction</key>\n\
 	<true/>\n\
 </dict>\n\
 </plist>' > "$(APP_NAME)/Contents/Info.plist"
+	codesign --force --deep --sign - --timestamp=none "$(APP_NAME)"
+	codesign --verify --deep --strict "$(APP_NAME)"
 
 test:
 	go test ./... -count=1

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -55,6 +55,17 @@ func onReady() {
 
 	mAuth = systray.AddMenuItem("Sign In", "Sign in or out of GitHub")
 	systray.AddSeparator()
+
+	var mCheckUpdates *systray.MenuItem
+	if updaterSupported() {
+		mCheckUpdates = systray.AddMenuItem("Check for Updates…", "Check for Copilot Proxy updates")
+		if err := startUpdater(); err != nil {
+			log.Error("failed to start updater", logger.Err(err))
+			mCheckUpdates.Disable()
+		}
+		systray.AddSeparator()
+	}
+
 	mQuit := systray.AddMenuItem("Quit", "Quit the application")
 
 	// Set initial UI state based on whether we already have credentials.
@@ -62,6 +73,11 @@ func onReady() {
 		setSignedInUI()
 	} else {
 		setSignedOutUI()
+	}
+
+	var mCheckUpdatesClicked <-chan struct{}
+	if mCheckUpdates != nil {
+		mCheckUpdatesClicked = mCheckUpdates.ClickedCh
 	}
 
 	go func() {
@@ -92,6 +108,11 @@ func onReady() {
 					signOut()
 				} else {
 					go signIn()
+				}
+			case <-mCheckUpdatesClicked:
+				if err := checkForUpdates(); err != nil {
+					log.Error("failed to check for updates", logger.Err(err))
+					showErrorDialog("Update Check Failed", err.Error())
 				}
 			case <-mQuit.ClickedCh:
 				if srv != nil && srv.IsRunning() {

--- a/cmd/menubar/updater_bridge.h
+++ b/cmd/menubar/updater_bridge.h
@@ -1,0 +1,7 @@
+#ifndef COPILOT_PROXY_UPDATER_BRIDGE_H
+#define COPILOT_PROXY_UPDATER_BRIDGE_H
+
+char *copilot_proxy_updater_start(void);
+char *copilot_proxy_updater_check(void);
+
+#endif

--- a/cmd/menubar/updater_bridge_darwin.m
+++ b/cmd/menubar/updater_bridge_darwin.m
@@ -1,0 +1,91 @@
+//go:build darwin && cgo && sparkle
+
+#import "updater_bridge.h"
+
+#import <Cocoa/Cocoa.h>
+#import <dispatch/dispatch.h>
+#include <string.h>
+
+@interface SPUUpdater : NSObject
+
+- (BOOL)startUpdater:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+@end
+
+@interface SPUStandardUpdaterController : NSObject
+
+@property (nonatomic, readonly) SPUUpdater *updater;
+
+- (instancetype)initWithStartingUpdater:(BOOL)startUpdater
+                        updaterDelegate:(id _Nullable)updaterDelegate
+                      userDriverDelegate:(id _Nullable)userDriverDelegate;
+- (IBAction)checkForUpdates:(id _Nullable)sender;
+
+@end
+
+static SPUStandardUpdaterController *copilotProxyUpdaterController = nil;
+static BOOL copilotProxyUpdaterStarted = NO;
+
+static char *copy_error_message(NSString *message)
+{
+    NSString *fallbackMessage = message ?: @"Sparkle returned an unknown error";
+    const char *utf8 = fallbackMessage.UTF8String;
+    if (utf8 == NULL) {
+        return strdup("Sparkle returned an unknown error");
+    }
+    return strdup(utf8);
+}
+
+static void run_on_main_queue_sync(dispatch_block_t block)
+{
+    if ([NSThread isMainThread]) {
+        block();
+        return;
+    }
+
+    dispatch_sync(dispatch_get_main_queue(), block);
+}
+
+char *copilot_proxy_updater_start(void)
+{
+    __block char *errorMessage = NULL;
+
+    run_on_main_queue_sync(^{
+        if (copilotProxyUpdaterController == nil) {
+            copilotProxyUpdaterController =
+                [[SPUStandardUpdaterController alloc] initWithStartingUpdater:NO
+                                                              updaterDelegate:nil
+                                                            userDriverDelegate:nil];
+        }
+
+        if (copilotProxyUpdaterStarted) {
+            return;
+        }
+
+        NSError *error = nil;
+        if (![copilotProxyUpdaterController.updater startUpdater:&error]) {
+            errorMessage = copy_error_message(error.localizedDescription);
+            return;
+        }
+
+        copilotProxyUpdaterStarted = YES;
+    });
+
+    return errorMessage;
+}
+
+char *copilot_proxy_updater_check(void)
+{
+    __block char *errorMessage = NULL;
+
+    run_on_main_queue_sync(^{
+        if (copilotProxyUpdaterController == nil || !copilotProxyUpdaterStarted) {
+            errorMessage = copy_error_message(@"The updater is not available yet.");
+            return;
+        }
+
+        [copilotProxyUpdaterController checkForUpdates:nil];
+    });
+
+    return errorMessage;
+}

--- a/cmd/menubar/updater_darwin.go
+++ b/cmd/menubar/updater_darwin.go
@@ -1,0 +1,37 @@
+//go:build darwin && cgo && sparkle
+
+package main
+
+/*
+#cgo darwin CFLAGS: -fobjc-arc
+#cgo darwin LDFLAGS: -framework Cocoa -framework Sparkle
+#include <stdlib.h>
+#include "updater_bridge.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+func updaterSupported() bool {
+	return true
+}
+
+func startUpdater() error {
+	return updaterCall(C.copilot_proxy_updater_start())
+}
+
+func checkForUpdates() error {
+	return updaterCall(C.copilot_proxy_updater_check())
+}
+
+func updaterCall(message *C.char) error {
+	if message == nil {
+		return nil
+	}
+
+	defer C.free(unsafe.Pointer(message))
+	return errors.New(C.GoString(message))
+}

--- a/cmd/menubar/updater_disabled.go
+++ b/cmd/menubar/updater_disabled.go
@@ -4,7 +4,7 @@ package main
 
 import "errors"
 
-var errUpdaterDisabled = errors.New("Sparkle updater is not available in this build")
+var errUpdaterDisabled = errors.New("sparkle updater is not available in this build")
 
 func updaterSupported() bool {
 	return false

--- a/cmd/menubar/updater_disabled.go
+++ b/cmd/menubar/updater_disabled.go
@@ -1,0 +1,19 @@
+//go:build !darwin || !cgo || !sparkle
+
+package main
+
+import "errors"
+
+var errUpdaterDisabled = errors.New("Sparkle updater is not available in this build")
+
+func updaterSupported() bool {
+	return false
+}
+
+func startUpdater() error {
+	return errUpdaterDisabled
+}
+
+func checkForUpdates() error {
+	return errUpdaterDisabled
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,8 @@ make build-app
 make docker-build
 ```
 
+`go test ./...` and ordinary Go builds do not require Sparkle. The updater code is only compiled for the packaged macOS app build via `make build-app`, which passes the `sparkle` build tag and embeds the framework.
+
 ## Test
 
 ```bash

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -1,11 +1,22 @@
 # macOS Menubar App
 
-The repo includes a native macOS menubar app for running the proxy without keeping a terminal open.
+The repo includes a native macOS menubar app for running the proxy without keeping a terminal open. The packaged app also includes Sparkle-based update checks.
 
 ## Build And Run
 
 ```bash
 make build-app
+open "Copilot Proxy.app"
+```
+
+`make build-app` downloads Sparkle 2.9.0 into `.build/sparkle/`, builds the menubar app with the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.
+
+If `SPARKLE_PUBLIC_ED_KEY` is not set, the app still builds, but `Check for Updates…` is disabled because Sparkle cannot start without a public EdDSA key.
+
+To build a locally update-enabled app:
+
+```bash
+SPARKLE_PUBLIC_ED_KEY=your_public_key make build-app
 open "Copilot Proxy.app"
 ```
 
@@ -15,3 +26,13 @@ open "Copilot Proxy.app"
 - status icon: white robot when running, gray when stopped
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
+- `Check for Updates…` menu item in packaged macOS app builds
+
+## Release Assets
+
+The release workflow publishes two macOS updater assets:
+
+- `Copilot-Proxy-macos-arm64.zip`
+- `appcast.xml`
+
+It signs the appcast with `SPARKLE_PRIVATE_ED_KEY`, so repository releases need both `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_PRIVATE_ED_KEY` secrets configured.


### PR DESCRIPTION
## Summary
- add Sparkle-backed updater support to the macOS menubar app and only show the menu item when the updater is available
- package Sparkle into `make build-app`, write updater keys/feed metadata into `Info.plist`, and sign plus verify the app bundle
- publish the macOS zip and `appcast.xml` from the release workflow and document the new build/release flow

## Verification
- `make test`
- `VERSION=v0.0.0 SPARKLE_PUBLIC_ED_KEY=test-key GOARCH=arm64 make build-app`
- `codesign --verify --deep --strict "Copilot Proxy.app"`

## Follow-up
- configure repository secrets `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_PRIVATE_ED_KEY` for production releases