### PR TITLE
Show packaged app version in menubar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-app: $(SPARKLE_FRAMEWORK)
 	@mkdir -p "$(APP_NAME)/Contents/Resources"
 	@mkdir -p "$(APP_NAME)/Contents/Frameworks"
 	CGO_ENABLED=1 CGO_LDFLAGS="-F$(abspath $(SPARKLE_UNPACK_DIR))" \
-		go build -tags sparkle -ldflags="$(LDFLAGS)" -o "$(APP_NAME)/Contents/MacOS/copilot-proxy-menubar" ./cmd/menubar/
+		go build -tags sparkle -ldflags="$(LDFLAGS) -X main.buildVersion=$(APP_VERSION)" -o "$(APP_NAME)/Contents/MacOS/copilot-proxy-menubar" ./cmd/menubar/
 	ditto "$(SPARKLE_FRAMEWORK)" "$(APP_NAME)/Contents/Frameworks/Sparkle.framework"
 	@printf '<?xml version="1.0" encoding="UTF-8"?>\n\
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n\

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -40,6 +40,8 @@ func onReady() {
 
 	mStatus = systray.AddMenuItem("○ Not signed in", "")
 	mStatus.Disable()
+	mVersion := systray.AddMenuItem(versionMenuTitle(), "Current app version")
+	mVersion.Disable()
 	systray.AddSeparator()
 
 	mToggle = systray.AddMenuItem("Start Proxy", "Start or stop the proxy")

--- a/cmd/menubar/version.go
+++ b/cmd/menubar/version.go
@@ -1,0 +1,16 @@
+package main
+
+import "strings"
+
+// buildVersion is injected by make build-app so the menu shows the same
+// version as the packaged app bundle. Local builds fall back to "dev".
+var buildVersion = "dev"
+
+func versionMenuTitle() string {
+	version := strings.TrimSpace(buildVersion)
+	if version == "" {
+		version = "dev"
+	}
+
+	return "Version " + version
+}

--- a/cmd/menubar/version_test.go
+++ b/cmd/menubar/version_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestVersionMenuTitle(t *testing.T) {
+	original := buildVersion
+	t.Cleanup(func() {
+		buildVersion = original
+	})
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "uses injected version",
+			version: "1.2.3",
+			want:    "Version 1.2.3",
+		},
+		{
+			name:    "falls back for blank version",
+			version: " ",
+			want:    "Version dev",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buildVersion = tc.version
+			if got := versionMenuTitle(); got != tc.want {
+				t.Fatalf("versionMenuTitle() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -24,6 +24,7 @@ open "Copilot Proxy.app"
 
 - start/stop toggle from the menubar
 - status icon: white robot when running, gray when stopped
+- current app version shown in the menu
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
 - `Check for Updates…` menu item in packaged macOS app builds


### PR DESCRIPTION
## Summary
- add a disabled menubar item that shows the packaged app version
- inject `main.buildVersion` from `make build-app` and fall back to `dev` for local builds
- cover the menu title formatting with unit tests and document the new menu entry

## Verification
- `go test ./cmd/menubar/...`
- `VERSION=v0.0.0 make build-app`

## Context
- follow-up to #30 so packaged builds expose their installed version in the menu