### PR TITLE
Retry oversized responses replays with compacted history

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1183,6 +1184,287 @@ func TestHandleResponses_PreservesOpaqueCompaction(t *testing.T) {
 	if w.Result().StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(w.Result().Body)
 		t.Fatalf("expected 200, got %d: %s", w.Result().StatusCode, body)
+	}
+}
+
+func TestHandleResponses_RetriesCompacted413Replay(t *testing.T) {
+	var upstreamRequestsMu sync.Mutex
+	upstreamRequests := make([]map[string]interface{}, 0, 3)
+	var normalRequests atomic.Int32
+
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream request body: %v", err)
+		}
+
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Fatalf("failed to decode upstream request body: %v", err)
+		}
+
+		upstreamRequestsMu.Lock()
+		upstreamRequests = append(upstreamRequests, body)
+		upstreamRequestsMu.Unlock()
+
+		if instructions, _ := body["instructions"].(string); strings.Contains(instructions, "CONTEXT CHECKPOINT COMPACTION") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"comp-413","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checkpoint summary after 413"}]}]}`))
+			return
+		}
+
+		switch normalRequests.Add(1) {
+		case 1:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(`{"error":{"message":"failed to parse request","code":"payload_too_large"}}`))
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-413-retried","object":"response","status":"completed"}`))
+		default:
+			t.Fatalf("unexpected normal upstream request count %d", normalRequests.Load())
+		}
+	})
+	handler.responsesWS = ResponsesWebSocketConfig{
+		DisableAutoCompact:  true,
+		AutoCompactKeepTail: 2,
+	}
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model":                "gpt-5.4",
+		"previous_response_id": "resp-prev",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first turn"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first answer"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second turn"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second answer"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "latest turn"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse retried response: %v", err)
+	}
+	if result["id"] != "resp-413-retried" {
+		t.Fatalf("expected retried response id resp-413-retried, got %v", result["id"])
+	}
+
+	upstreamRequestsMu.Lock()
+	requests := append([]map[string]interface{}(nil), upstreamRequests...)
+	upstreamRequestsMu.Unlock()
+
+	if len(requests) != 3 {
+		t.Fatalf("expected 3 upstream requests (413 + compaction + retry), got %d", len(requests))
+	}
+
+	initialReplayInput := upstreamInputItems(t, requests[0])
+	if len(initialReplayInput) != 5 {
+		t.Fatalf("expected first upstream request to keep full replay, got %d items", len(initialReplayInput))
+	}
+	if got := requireMessageTextWithRole(t, initialReplayInput[0], "user"); got != "first turn" {
+		t.Fatalf("expected first upstream request to start with oldest input, got %q", got)
+	}
+	if got := requireMessageTextWithRole(t, initialReplayInput[4], "user"); got != "latest turn" {
+		t.Fatalf("expected first upstream request to keep latest input, got %q", got)
+	}
+
+	compactionInput := upstreamInputItems(t, requests[1])
+	if len(compactionInput) != 3 {
+		t.Fatalf("expected compaction request to summarize only the replay prefix, got %d items", len(compactionInput))
+	}
+	if got := requireMessageTextWithRole(t, compactionInput[0], "user"); got != "first turn" {
+		t.Fatalf("expected compaction request to preserve oldest user turn, got %q", got)
+	}
+	if got := requireMessageTextWithRole(t, compactionInput[1], "assistant"); got != "first answer" {
+		t.Fatalf("expected compaction request to include first assistant reply, got %q", got)
+	}
+	if got := requireMessageTextWithRole(t, compactionInput[2], "user"); got != "second turn" {
+		t.Fatalf("expected compaction request to stop before kept tail, got %q", got)
+	}
+
+	retriedInput := upstreamInputItems(t, requests[2])
+	if len(retriedInput) != 3 {
+		t.Fatalf("expected retried request to include compacted checkpoint plus tail, got %d items", len(retriedInput))
+	}
+	if got := requireCompactionContextMessage(t, retriedInput[0]); !strings.Contains(got, "checkpoint summary after 413") {
+		t.Fatalf("expected retried request to start with compacted checkpoint, got %q", got)
+	}
+	if got := requireMessageTextWithRole(t, retriedInput[1], "assistant"); got != "second answer" {
+		t.Fatalf("expected retried request to keep assistant tail item, got %q", got)
+	}
+	if got := requireMessageTextWithRole(t, retriedInput[2], "user"); got != "latest turn" {
+		t.Fatalf("expected retried request to keep latest user tail item, got %q", got)
+	}
+}
+
+func TestHandleResponses_DoesNotRetry413WithoutPreviousResponseID(t *testing.T) {
+	var upstreamRequests atomic.Int32
+
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"error":{"message":"failed to parse request","code":"payload_too_large"}}`))
+	})
+	handler.responsesWS = ResponsesWebSocketConfig{
+		DisableAutoCompact:  true,
+		AutoCompactKeepTail: 2,
+	}
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first turn"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first answer"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second turn"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 413, got %d: %s", resp.StatusCode, body)
+	}
+	if upstreamRequests.Load() != 1 {
+		t.Fatalf("expected no retry without previous_response_id, got %d upstream requests", upstreamRequests.Load())
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("payload_too_large")) {
+		t.Fatalf("expected original 413 body to be preserved, got %s", body)
+	}
+}
+
+func TestHandleResponses_DoesNotRetry413WithinKeepTail(t *testing.T) {
+	var upstreamRequests atomic.Int32
+
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"error":{"message":"failed to parse request","code":"payload_too_large"}}`))
+	})
+	handler.responsesWS = ResponsesWebSocketConfig{
+		DisableAutoCompact:  true,
+		AutoCompactKeepTail: 2,
+	}
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model":                "gpt-5.4",
+		"previous_response_id": "resp-prev",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second answer"},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "latest turn"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 413, got %d: %s", resp.StatusCode, body)
+	}
+	if upstreamRequests.Load() != 1 {
+		t.Fatalf("expected no retry when replay already fits keep-tail window, got %d upstream requests", upstreamRequests.Load())
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("payload_too_large")) {
+		t.Fatalf("expected original 413 body to be preserved, got %s", body)
 	}
 }
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -47,10 +47,17 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	_ = json.Unmarshal(bodyBytes, &partial)
 	isStreaming := partial.Stream != nil && *partial.Stream
 
+	extraHeaders := responsesExtraHeadersFromRequest(r)
+
 	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
+	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, extraHeaders)
+	if err != nil {
+		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		return
+	}
+	resp, err = h.maybeRetryCompactedResponsesRequest(upstreamCtx, token, bodyBytes, extraHeaders, resp)
 	if err != nil {
 		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
 		return
@@ -426,6 +433,92 @@ func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, tok
 	retryResp, retryErr := h.postResponsesWithHeaders(ctx, token, fallbackBody, extraHeaders)
 	if retryErr != nil {
 		h.log.Debug("responses fallback request failed", logger.Err(retryErr))
+		return resp, nil
+	}
+
+	return retryResp, nil
+}
+
+func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, token string, bodyBytes []byte, extraHeaders http.Header, resp *http.Response) (*http.Response, error) {
+	if resp == nil || resp.StatusCode != http.StatusRequestEntityTooLarge {
+		return resp, nil
+	}
+
+	var requestFields map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &requestFields); err != nil {
+		return resp, nil
+	}
+
+	var previousResponseID string
+	if err := json.Unmarshal(requestFields["previous_response_id"], &previousResponseID); err != nil || strings.TrimSpace(previousResponseID) == "" {
+		return resp, nil
+	}
+
+	var model string
+	if err := json.Unmarshal(requestFields["model"], &model); err != nil || strings.TrimSpace(model) == "" {
+		return resp, nil
+	}
+
+	var input []json.RawMessage
+	if err := json.Unmarshal(requestFields["input"], &input); err != nil {
+		return resp, nil
+	}
+
+	keepTail := h.responsesWebSocketConfig().AutoCompactKeepTail
+	if keepTail <= 0 || len(input) <= keepTail {
+		return resp, nil
+	}
+
+	prefixLen := len(input) - keepTail
+	summary, err := h.compactResponsesInput(ctx, token, model, input[:prefixLen], extraHeaders)
+	if err != nil {
+		h.log.Debug("responses 413 compaction failed", logger.Err(err))
+		return resp, nil
+	}
+
+	checkpoint, err := proxyCompactionContextRawMessage(summary)
+	if err != nil {
+		h.log.Debug("responses 413 compaction checkpoint build failed", logger.Err(err))
+		return resp, nil
+	}
+
+	compactedInput := make([]json.RawMessage, 0, keepTail+1)
+	compactedInput = append(compactedInput, checkpoint)
+	compactedInput = append(compactedInput, input[prefixLen:]...)
+
+	compactedInputRaw, err := json.Marshal(compactedInput)
+	if err != nil {
+		h.log.Debug("responses 413 compaction marshal failed", logger.Err(err))
+		return resp, nil
+	}
+	requestFields["input"] = compactedInputRaw
+
+	retryBody, err := json.Marshal(requestFields)
+	if err != nil {
+		h.log.Debug("responses 413 retry body marshal failed", logger.Err(err))
+		return resp, nil
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+	h.log.Info("retrying responses request with compacted history after 413",
+		logger.F("model", model),
+		logger.F("previous_response_id", previousResponseID),
+		logger.F("original_items", len(input)),
+		logger.F("compacted_items", len(compactedInput)),
+		logger.F("original_bytes", rawMessagesSize(input)),
+		logger.F("compacted_bytes", rawMessagesSize(compactedInput)),
+	)
+
+	retryResp, retryErr := h.postResponsesWithHeaders(ctx, token, retryBody, extraHeaders)
+	if retryErr != nil {
+		h.log.Debug("responses 413 retry request failed", logger.Err(retryErr))
 		return resp, nil
 	}
 

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -79,6 +79,13 @@ type responsesWebSocketRequestMetrics struct {
 	compactedToBytes   int
 }
 
+type responsesWebSocketHistoryCompaction struct {
+	fromItems int
+	fromBytes int
+	toItems   int
+	toBytes   int
+}
+
 func (p responsesWebSocketRequestPlan) upstreamSegments() [][]json.RawMessage {
 	if p.useTurnStateDelta {
 		return [][]json.RawMessage{p.currentInput}
@@ -331,8 +338,15 @@ func (s *responsesWebSocketSession) planRequest(h *ProxyHandler, request *respon
 
 func (s *responsesWebSocketSession) postCreateRequest(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, plan responsesWebSocketRequestPlan) (*http.Response, bool, bool, error) {
 	resp, err := s.postCreateRequestSegments(h, ctx, token, request, plan.upstreamSegments(), plan.useTurnStateDelta)
-	if !plan.useTurnStateDelta || err != nil || resp == nil || resp.StatusCode == http.StatusOK {
+	if err != nil || resp == nil {
 		return resp, plan.useTurnStateDelta, false, err
+	}
+	if !plan.useTurnStateDelta {
+		resp, err = s.maybeRetryCompactedCreateRequest(h, ctx, token, request, resp, true)
+		return resp, false, false, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp, true, false, nil
 	}
 
 	respBody, readErr := io.ReadAll(resp.Body)
@@ -352,6 +366,10 @@ func (s *responsesWebSocketSession) postCreateRequest(h *ProxyHandler, ctx conte
 	s.turnState = ""
 
 	resp, err = s.postCreateRequestSegments(h, ctx, token, request, plan.fullReplaySegments, false)
+	if err != nil || resp == nil {
+		return resp, true, true, err
+	}
+	resp, err = s.maybeRetryCompactedCreateRequest(h, ctx, token, request, resp, true)
 	return resp, true, true, err
 }
 
@@ -409,31 +427,10 @@ func (s *responsesWebSocketSession) rememberResponse(resetHistory bool, response
 }
 
 func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, token string, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
-	cfg := h.responsesWebSocketConfig()
-	if !cfg.autoCompactEnabled() {
-		return metrics
-	}
-	if !responsesWebSocketHistoryExceedsThreshold(s.historyItems, cfg) {
-		return metrics
-	}
-	if strings.TrimSpace(request.Model) == "" {
-		return metrics
-	}
-
-	prefixLen := len(s.historyItems) - cfg.AutoCompactKeepTail
-	if prefixLen <= 0 {
-		return metrics
-	}
-
-	prefix := s.historyItems[:prefixLen]
-	tail := s.historyItems[prefixLen:]
-	priorItems := len(s.historyItems)
-	priorBytes := rawMessagesSize(s.historyItems)
-
 	ctx, cancel := newInferenceUpstreamContext()
 	defer cancel()
 
-	summary, err := h.compactResponsesInput(ctx, token, request.Model, prefix, s.requestHeaders(request, false))
+	compaction, compacted, err := s.compactHistory(h, ctx, token, request, false)
 	if err != nil {
 		h.log.Debug("responses websocket auto-compaction failed",
 			logger.Err(err),
@@ -443,31 +440,106 @@ func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, tok
 		)
 		return metrics
 	}
+	if !compacted {
+		return metrics
+	}
+
+	h.log.Debug("responses websocket auto-compacted history",
+		logger.F("prior_items", compaction.fromItems),
+		logger.F("prior_bytes", compaction.fromBytes),
+		logger.F("new_items", compaction.toItems),
+		logger.F("new_bytes", compaction.toBytes),
+		logger.F("auto_compacted", true),
+	)
+	metrics.autoCompacted = true
+	metrics.compactedFromItems = compaction.fromItems
+	metrics.compactedFromBytes = compaction.fromBytes
+	metrics.compactedToItems = compaction.toItems
+	metrics.compactedToBytes = compaction.toBytes
+	return metrics
+}
+
+func (s *responsesWebSocketSession) maybeRetryCompactedCreateRequest(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, resp *http.Response, fullReplayUsed bool) (*http.Response, error) {
+	if resp == nil || !fullReplayUsed || resp.StatusCode != http.StatusRequestEntityTooLarge || strings.TrimSpace(request.PreviousResponseID) == "" {
+		return resp, nil
+	}
+
+	compaction, compacted, err := s.compactHistory(h, ctx, token, request, true)
+	if err != nil {
+		h.log.Debug("responses websocket 413 compaction failed",
+			logger.Err(err),
+			logger.F("model", request.Model),
+			logger.F("previous_response_id", request.PreviousResponseID),
+			logger.F("history_items", len(s.historyItems)),
+			logger.F("history_bytes", rawMessagesSize(s.historyItems)),
+		)
+		return resp, nil
+	}
+	if !compacted {
+		return resp, nil
+	}
+
+	h.log.Debug("responses websocket compacted oversized replay; retrying request",
+		logger.F("model", request.Model),
+		logger.F("previous_response_id", request.PreviousResponseID),
+		logger.F("prior_items", compaction.fromItems),
+		logger.F("prior_bytes", compaction.fromBytes),
+		logger.F("new_items", compaction.toItems),
+		logger.F("new_bytes", compaction.toBytes),
+	)
+
+	_ = resp.Body.Close()
+	return s.postCreateRequestSegments(h, ctx, token, request, [][]json.RawMessage{s.historyItems, request.Input}, false)
+}
+
+func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, force bool) (responsesWebSocketHistoryCompaction, bool, error) {
+	var result responsesWebSocketHistoryCompaction
+
+	cfg := h.responsesWebSocketConfig()
+	if force {
+		if cfg.AutoCompactKeepTail <= 0 {
+			return result, false, nil
+		}
+	} else {
+		if !cfg.autoCompactEnabled() {
+			return result, false, nil
+		}
+		if !responsesWebSocketHistoryExceedsThreshold(s.historyItems, cfg) {
+			return result, false, nil
+		}
+	}
+	if strings.TrimSpace(request.Model) == "" {
+		return result, false, nil
+	}
+
+	prefixLen := len(s.historyItems) - cfg.AutoCompactKeepTail
+	if prefixLen <= 0 {
+		return result, false, nil
+	}
+
+	prefix := s.historyItems[:prefixLen]
+	tail := s.historyItems[prefixLen:]
+	result.fromItems = len(s.historyItems)
+	result.fromBytes = rawMessagesSize(s.historyItems)
+
+	summary, err := h.compactResponsesInput(ctx, token, request.Model, prefix, s.requestHeaders(request, false))
+	if err != nil {
+		return result, false, err
+	}
 
 	checkpoint, err := proxyCompactionContextRawMessage(summary)
 	if err != nil {
-		h.log.Debug("responses websocket auto-compaction checkpoint encode failed", logger.Err(err))
-		return metrics
+		return result, false, err
 	}
 
 	compacted := make([]json.RawMessage, 0, 1+len(tail))
 	compacted = append(compacted, checkpoint)
 	compacted = append(compacted, tail...)
 
-	h.log.Debug("responses websocket auto-compacted history",
-		logger.F("prior_items", len(s.historyItems)),
-		logger.F("prior_bytes", rawMessagesSize(s.historyItems)),
-		logger.F("new_items", len(compacted)),
-		logger.F("new_bytes", rawMessagesSize(compacted)),
-		logger.F("auto_compacted", true),
-	)
+	result.toItems = len(compacted)
+	result.toBytes = rawMessagesSize(compacted)
 	s.historyItems = compacted
-	metrics.autoCompacted = true
-	metrics.compactedFromItems = priorItems
-	metrics.compactedFromBytes = priorBytes
-	metrics.compactedToItems = len(compacted)
-	metrics.compactedToBytes = rawMessagesSize(compacted)
-	return metrics
+	return result, true, nil
 }
 
 func (s *responsesWebSocketSession) logRequestMetrics(h *ProxyHandler, request *responsesWebSocketCreateRequest, responseID string, metrics responsesWebSocketRequestMetrics) {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -394,6 +394,141 @@ func TestHandleResponsesWebSocket_AutoCompactsLongHistory(t *testing.T) {
 	}
 }
 
+func TestHandleResponsesWebSocket_CompactsOversizedReplayAndRetries(t *testing.T) {
+	var upstreamRequestsMu sync.Mutex
+	upstreamRequests := make([]map[string]interface{}, 0, 4)
+	var normalRequests int
+
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream request body: %v", err)
+		}
+
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Fatalf("failed to decode upstream request body: %v", err)
+		}
+		upstreamRequestsMu.Lock()
+		upstreamRequests = append(upstreamRequests, body)
+		upstreamRequestsMu.Unlock()
+
+		if instructions, _ := body["instructions"].(string); strings.Contains(instructions, "CONTEXT CHECKPOINT COMPACTION") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"comp-413","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checkpoint summary after 413"}]}]}`)
+			return
+		}
+
+		normalRequests++
+		switch normalRequests {
+		case 1:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"id\":\"msg-1\",\"content\":[{\"type\":\"output_text\",\"text\":\"first\"}]}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"id\":\"msg-2\",\"content\":[{\"type\":\"output_text\",\"text\":\"second\"}]}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"id\":\"msg-3\",\"content\":[{\"type\":\"output_text\",\"text\":\"third\"}]}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = fmt.Fprint(w, `{"error":{"message":"failed to parse request","code":"payload_too_large"}}`)
+		case 3:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-2\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-2\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+		default:
+			t.Fatalf("unexpected normal upstream request count %d", normalRequests)
+		}
+	})
+	handler.responsesWS = ResponsesWebSocketConfig{
+		DisableAutoCompact:  true,
+		AutoCompactKeepTail: 2,
+	}
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	first := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "first turn"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(first); err != nil {
+		t.Fatalf("failed to write first request: %v", err)
+	}
+
+	firstCreated := mustReadWebSocketJSON(t, conn)
+	_ = mustReadWebSocketJSON(t, conn)
+	_ = mustReadWebSocketJSON(t, conn)
+	_ = mustReadWebSocketJSON(t, conn)
+	_ = mustReadWebSocketJSON(t, conn)
+
+	second := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "second turn"},
+			},
+		},
+	})
+	second["previous_response_id"] = websocketResponseID(t, firstCreated)
+	if err := conn.WriteJSON(second); err != nil {
+		t.Fatalf("failed to write second request: %v", err)
+	}
+
+	created := mustReadWebSocketJSON(t, conn)
+	completed := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected retried response.created event, got %v", created["type"])
+	}
+	if completed["type"] != "response.completed" {
+		t.Fatalf("expected retried response.completed event, got %v", completed["type"])
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	requests := snapshotResponsesWebSocketRequests(&upstreamRequestsMu, upstreamRequests)
+	for len(requests) < 4 {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected 4 upstream requests (turn + 413 + compaction + retry), got %d", len(requests))
+		}
+		time.Sleep(10 * time.Millisecond)
+		requests = snapshotResponsesWebSocketRequests(&upstreamRequestsMu, upstreamRequests)
+	}
+
+	initialReplayInput := upstreamInputItems(t, requests[1])
+	if len(initialReplayInput) != 5 {
+		t.Fatalf("expected oversized replay to include full history plus latest input, got %d items", len(initialReplayInput))
+	}
+	if got := inputTextFromMessage(t, initialReplayInput[0]); got != "first turn" {
+		t.Fatalf("expected oversized replay to start with original user turn, got %q", got)
+	}
+
+	compactionInput := upstreamInputItems(t, requests[2])
+	if len(compactionInput) != 2 {
+		t.Fatalf("expected 413 compaction request to summarize only the old prefix, got %d items", len(compactionInput))
+	}
+	if got := inputTextFromMessage(t, compactionInput[0]); got != "first turn" {
+		t.Fatalf("expected compaction request to preserve the oldest user turn, got %q", got)
+	}
+
+	retriedInput := upstreamInputItems(t, requests[3])
+	if len(retriedInput) != 4 {
+		t.Fatalf("expected retried request to use compacted history plus latest input, got %d items", len(retriedInput))
+	}
+	if got := requireMessageTextWithRole(t, retriedInput[0], "developer"); !strings.Contains(got, "checkpoint summary after 413") {
+		t.Fatalf("expected retried request to start with compacted checkpoint, got %q", got)
+	}
+	if got := inputTextFromMessage(t, retriedInput[3]); got != "second turn" {
+		t.Fatalf("expected retried request to keep latest user turn, got %q", got)
+	}
+}
+
 func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInputAndIgnoresClientTurnStateHeader(t *testing.T) {
 	upstreamRequests := make([]map[string]interface{}, 0, 2)
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- retry oversized `/v1/responses` replay requests after compacting only the older history prefix and preserving the recent tail
- add the same compaction-and-retry behavior to websocket replay flows so HTTP and websocket handling stay aligned
- standardize synthetic checkpoint messages as developer-context compaction markers and cover the new behavior with regression tests

## Testing
- `go test ./...`
- `go test ./proxy -run 'TestHandleResponses'`
