### PR TITLE
docs: link quick start to GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/copilot-proxy:latest
 ```
 
-On macOS, you can also use the native menubar app instead of keeping a terminal open. Build it locally with `make build-app` and open `Copilot Proxy.app`. See [macOS Menubar App](docs/menubar.md).
+On Apple Silicon Macs, you can also use the native menubar app instead of keeping a terminal open. Download `Copilot-Proxy-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/copilot-proxy/releases/latest), unzip it, and open `Copilot Proxy.app`. See [macOS Menubar App](docs/menubar.md).
 
 On first run, authenticate with GitHub's device code flow. Tokens are cached in `~/.config/copilot-proxy/`.
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible 
 
 ## Quick Start
 
-```bash
-go build -o copilot-proxy .
-./copilot-proxy
-```
+Download the latest binary for your platform from [GitHub Releases](https://github.com/sozercan/copilot-proxy/releases/latest), then run it locally.
 
 Or with Docker from GHCR:
 
@@ -26,7 +23,7 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/copilot-proxy:latest
 ```
 
-On macOS, you can also use the native menubar app instead of keeping a terminal open. Build it with `make build-app` and open `Copilot Proxy.app`, or download the packaged app from the GitHub release assets. See [macOS Menubar App](docs/menubar.md).
+On macOS, you can also use the native menubar app instead of keeping a terminal open. Build it locally with `make build-app` and open `Copilot Proxy.app`. See [macOS Menubar App](docs/menubar.md).
 
 On first run, authenticate with GitHub's device code flow. Tokens are cached in `~/.config/copilot-proxy/`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,8 @@ Download the latest binary for your platform from [GitHub Releases](https://gith
 
 Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. After downloading, make the binary executable if needed and run it locally.
 
+On Apple Silicon Macs, GitHub Releases also includes a `Copilot-Proxy-macos-arm64.zip` menubar app bundle if you prefer a native app instead of the CLI binary.
+
 ## Build From Source
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,11 @@
 # Getting Started
 
+## Download From GitHub Releases
+
+Download the latest binary for your platform from [GitHub Releases](https://github.com/sozercan/copilot-proxy/releases/latest).
+
+Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. After downloading, make the binary executable if needed and run it locally.
+
 ## Build From Source
 
 ```bash

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -2,7 +2,13 @@
 
 The repo includes a native macOS menubar app for running the proxy without keeping a terminal open.
 
-## Build And Run
+## Download And Run
+
+Download `Copilot-Proxy-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/copilot-proxy/releases/latest), unzip it, and open `Copilot Proxy.app`.
+
+The published app bundle is currently available for Apple Silicon (`arm64`). On Intel Macs, build the app from source instead.
+
+## Build From Source
 
 ```bash
 make build-app


### PR DESCRIPTION
## Summary
- replace quick-start download steps with a GitHub Releases link in README
- align getting-started docs with the same release-based guidance
- keep the Docker section unchanged

## Testing
- not run (docs only)