### PR TITLE
fix: use streaming timeouts for long-lived inference paths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@
 | `--host` | `HOST` | `0.0.0.0` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/copilot-proxy` | Token storage directory |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 | `--copilot-editor-version` | `COPILOT_EDITOR_VERSION` | `vscode/1.95.0` | Upstream `editor-version` header |
 | `--copilot-plugin-version` | `COPILOT_PLUGIN_VERSION` | `copilot-chat/0.26.7` | Upstream `editor-plugin-version` header |
 | `--copilot-user-agent` | `COPILOT_USER_AGENT` | `GitHubCopilotChat/0.26.7` | Upstream `user-agent` header |

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 	host := flag.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
 	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/copilot-proxy)")
 	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
+	streamingUpstreamTimeout := flag.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
 	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
 	copilotPluginVersion := flag.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header")
 	copilotUserAgent := flag.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header")
@@ -47,6 +48,7 @@ func main() {
 		log,
 		*host,
 		*port,
+		server.WithStreamingUpstreamTimeout(*streamingUpstreamTimeout),
 		server.WithCopilotHeaderConfig(proxy.CopilotHeaderConfig{
 			EditorVersion:       *copilotEditorVersion,
 			EditorPluginVersion: *copilotPluginVersion,
@@ -105,6 +107,18 @@ func getEnvInt(key string, fallback int) int {
 		return fallback
 	}
 	parsed, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	v := getEnv(key, "")
+	if v == "" {
+		return fallback
+	}
+	parsed, err := time.ParseDuration(v)
 	if err != nil {
 		return fallback
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetEnvDuration(t *testing.T) {
+	const envKey = "TEST_STREAMING_UPSTREAM_TIMEOUT"
+	const fallback = 5 * time.Minute
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{
+			name: "empty uses fallback",
+			want: fallback,
+		},
+		{
+			name:  "valid duration parses",
+			value: "17m",
+			want:  17 * time.Minute,
+		},
+		{
+			name:  "invalid duration uses fallback",
+			value: "not-a-duration",
+			want:  fallback,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envKey, tc.value)
+			if got := getEnvDuration(envKey, fallback); got != tc.want {
+				t.Fatalf("getEnvDuration() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -137,7 +137,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
@@ -193,7 +193,7 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 
 	bodyBytes, mode := prepareOpenAIChatCompletionsRequest(bodyBytes)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, bodyBytes)

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -137,7 +137,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
@@ -193,7 +193,7 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 
 	bodyBytes, mode := prepareOpenAIChatCompletionsRequest(bodyBytes)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, bodyBytes)

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -94,7 +93,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 		return
 	}
 
-	upstreamCtx, upstreamCancel := context.WithTimeout(context.Background(), upstreamTimeout)
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(stream || forceStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
@@ -272,7 +271,7 @@ func (h *ProxyHandler) runGeminiCountTokensProbe(token string, baseReq *models.O
 }
 
 func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
-	upstreamCtx, upstreamCancel := context.WithTimeout(context.Background(), upstreamTimeout)
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	body, err := json.Marshal(probeReq)
@@ -298,7 +297,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *mod
 }
 
 func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(token string, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
-	upstreamCtx, upstreamCancel := context.WithTimeout(context.Background(), upstreamTimeout)
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	body, err := json.Marshal(probeReq)

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -93,7 +93,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 		return
 	}
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(stream || forceStream)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(stream || forceStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
@@ -271,7 +271,7 @@ func (h *ProxyHandler) runGeminiCountTokensProbe(token string, baseReq *models.O
 }
 
 func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	body, err := json.Marshal(probeReq)
@@ -297,7 +297,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *mod
 }
 
 func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(token string, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	body, err := json.Marshal(probeReq)

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sozercan/copilot-proxy/models"
 )
@@ -1396,6 +1397,46 @@ func TestHandleGeminiModelsGenerateContent(t *testing.T) {
 	if geminiResp.UsageMetadata == nil || geminiResp.UsageMetadata.TotalTokenCount != 13 {
 		t.Errorf("UsageMetadata = %#v, want totalTokenCount=13", geminiResp.UsageMetadata)
 	}
+}
+
+func TestHandleGeminiModelsGenerateContent_ForcedStreamingUsesStreamingUpstreamTimeout(t *testing.T) {
+	deadlineCh := make(chan time.Duration, 1)
+	handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		deadline, ok := r.Context().Deadline()
+		if !ok {
+			t.Fatal("expected upstream request deadline")
+		}
+		deadlineCh <- time.Until(deadline)
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+		if oaiReq.Stream == nil || !*oaiReq.Stream {
+			t.Fatal("expected proxy to force upstream stream=true for Gemini tool calls")
+		}
+
+		return sseHTTPResponse("data: {\"id\":\"chatcmpl-gemini-deadline\",\"model\":\"gemini-2.5-pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello from Gemini\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-gemini-deadline\",\"model\":\"gemini-2.5-pro\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":4,\"total_tokens\":13}}\n\ndata: [DONE]\n\n"), nil
+	}))
+
+	reqBody := `{
+		"model": "models/gemini-2.5-pro",
+		"contents": [{"role":"user","parts":[{"text":"Hi"}]}],
+		"tools": [{"functionDeclarations":[{"name":"lookup_weather","parameters":{"type":"object"}}]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/models/models/gemini-2.5-pro:generateContent", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	if resp := w.Result(); resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(body))
+	}
+
+	assertDeadlineApprox(t, <-deadlineCh, streamingUpstreamTimeout)
 }
 
 func TestHandleGeminiModelsGenerateContentIgnoresTopKAndThinkingConfig(t *testing.T) {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -178,16 +178,17 @@ func (c ResponsesWebSocketConfig) autoCompactEnabled() bool {
 
 // ProxyHandler holds dependencies for all HTTP handlers.
 type ProxyHandler struct {
-	auth           *auth.Authenticator
-	client         *http.Client
-	copilotURL     string
-	copilotHeaders CopilotHeaderConfig
-	responsesWS    ResponsesWebSocketConfig
-	log            *logger.Logger
-	maxRetries     int
-	retryBaseDelay time.Duration
-	models         modelsCache
-	geminiCounts   geminiCountTokensCache
+	auth                     *auth.Authenticator
+	client                   *http.Client
+	copilotURL               string
+	copilotHeaders           CopilotHeaderConfig
+	responsesWS              ResponsesWebSocketConfig
+	streamingUpstreamTimeout time.Duration
+	log                      *logger.Logger
+	maxRetries               int
+	retryBaseDelay           time.Duration
+	models                   modelsCache
+	geminiCounts             geminiCountTokensCache
 }
 
 // Option customizes ProxyHandler behavior.
@@ -209,6 +210,27 @@ func WithResponsesWebSocketConfig(cfg ResponsesWebSocketConfig) Option {
 	}
 }
 
+func normalizeStreamingUpstreamTimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return streamingUpstreamTimeout
+	}
+	return timeout
+}
+
+// DefaultStreamingUpstreamTimeout returns the default timeout used for
+// streaming upstream inference requests.
+func DefaultStreamingUpstreamTimeout() time.Duration {
+	return streamingUpstreamTimeout
+}
+
+// WithStreamingUpstreamTimeout overrides the timeout used for streaming
+// upstream inference requests. Non-positive values fall back to the default.
+func WithStreamingUpstreamTimeout(timeout time.Duration) Option {
+	return func(h *ProxyHandler) {
+		h.streamingUpstreamTimeout = normalizeStreamingUpstreamTimeout(timeout)
+	}
+}
+
 // NewProxyHandler creates a ProxyHandler with connection pooling and HTTP/2.
 func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) *ProxyHandler {
 	h := &ProxyHandler{
@@ -223,10 +245,11 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 				TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
 			},
 		},
-		copilotURL:     "https://api.githubcopilot.com",
-		copilotHeaders: DefaultCopilotHeaderConfig(),
-		responsesWS:    DefaultResponsesWebSocketConfig(),
-		log:            log,
+		copilotURL:               "https://api.githubcopilot.com",
+		copilotHeaders:           DefaultCopilotHeaderConfig(),
+		responsesWS:              DefaultResponsesWebSocketConfig(),
+		streamingUpstreamTimeout: streamingUpstreamTimeout,
+		log:                      log,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -238,6 +261,19 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 
 func (h *ProxyHandler) responsesWebSocketConfig() ResponsesWebSocketConfig {
 	return h.responsesWS.withDefaults()
+}
+
+func (h *ProxyHandler) effectiveStreamingUpstreamTimeout() time.Duration {
+	if h == nil {
+		return DefaultStreamingUpstreamTimeout()
+	}
+	return normalizeStreamingUpstreamTimeout(h.streamingUpstreamTimeout)
+}
+
+// ServerWriteTimeout returns the HTTP server write timeout derived from the
+// configured streaming upstream timeout plus the non-streaming request budget.
+func (h *ProxyHandler) ServerWriteTimeout() time.Duration {
+	return h.effectiveStreamingUpstreamTimeout() + upstreamTimeout
 }
 
 func setCopilotHeaders(req *http.Request, token string) {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -31,8 +31,10 @@ const (
 	// ceiling because they can legitimately contain full session histories or
 	// trace bundles that need to be summarized.
 	maxLargeRequestBodySize = 64 << 20
-	// upstreamTimeout is the timeout for LLM inference requests.
+	// upstreamTimeout is the timeout for non-streaming LLM inference requests.
 	upstreamTimeout = 5 * time.Minute
+	// streamingUpstreamTimeout gives streaming inference enough time to finish.
+	streamingUpstreamTimeout = 60 * time.Minute
 	// readyzUpstreamTimeout bounds readiness probes that validate upstream reachability.
 	readyzUpstreamTimeout = 10 * time.Second
 	// modelsUpstreamTimeout is the timeout for the /models metadata request.

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -691,6 +691,34 @@ func TestHandleResponses_UpstreamDeadlineDependsOnStreamFlag(t *testing.T) {
 
 		assertDeadlineApprox(t, <-deadlineCh, streamingUpstreamTimeout)
 	})
+
+	t.Run("streaming uses configured timeout", func(t *testing.T) {
+		const customTimeout = 17 * time.Minute
+
+		deadlineCh := make(chan time.Duration, 1)
+		handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			deadline, ok := r.Context().Deadline()
+			if !ok {
+				t.Fatal("expected upstream request deadline")
+			}
+			deadlineCh <- time.Until(deadline)
+			return sseHTTPResponse("data: {\"id\":\"resp-stream-custom\",\"object\":\"response\",\"status\":\"in_progress\"}\n\ndata: [DONE]\n\n"), nil
+		}))
+		WithStreamingUpstreamTimeout(customTimeout)(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello","stream":true}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handler.HandleResponses(w, req)
+
+		if resp := w.Result(); resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		assertDeadlineApprox(t, <-deadlineCh, customTimeout)
+	})
 }
 
 func TestHandleResponses_LargeBodyStillRejected(t *testing.T) {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -40,6 +40,45 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func newRoundTripTestProxyHandler(t testing.TB, transport roundTripFunc) *ProxyHandler {
+	t.Helper()
+	return &ProxyHandler{
+		auth:           auth.NewTestAuthenticator("test-token"),
+		client:         &http.Client{Transport: transport},
+		copilotURL:     "http://upstream.test",
+		log:            logger.New(logger.LevelInfo),
+		retryBaseDelay: 1 * time.Millisecond,
+	}
+}
+
+func assertDeadlineApprox(t *testing.T, got, want time.Duration) {
+	t.Helper()
+	const tolerance = 15 * time.Second
+	if got < want-tolerance || got > want+tolerance {
+		t.Fatalf("deadline remaining = %v, want about %v", got, want)
+	}
+}
+
+func jsonHTTPResponse(body string) *http.Response {
+	h := make(http.Header)
+	h.Set("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func sseHTTPResponse(body string) *http.Response {
+	h := make(http.Header)
+	h.Set("Content-Type", "text/event-stream")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
 func assertOnlySubagentHeaderForwarded(t testing.TB, r *http.Request, want string) {
 	t.Helper()
 	if got := r.Header.Get("X-OpenAI-Subagent"); got != want {
@@ -600,6 +639,58 @@ func TestHandleResponses(t *testing.T) {
 	if result["id"] != "resp-123" {
 		t.Errorf("expected id resp-123, got %v", result["id"])
 	}
+}
+
+func TestHandleResponses_UpstreamDeadlineDependsOnStreamFlag(t *testing.T) {
+	t.Run("non-streaming", func(t *testing.T) {
+		deadlineCh := make(chan time.Duration, 1)
+		handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			deadline, ok := r.Context().Deadline()
+			if !ok {
+				t.Fatal("expected upstream request deadline")
+			}
+			deadlineCh <- time.Until(deadline)
+			return jsonHTTPResponse(`{"id":"resp-non-stream","object":"response","status":"completed"}`), nil
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello","stream":false}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handler.HandleResponses(w, req)
+
+		if resp := w.Result(); resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		assertDeadlineApprox(t, <-deadlineCh, upstreamTimeout)
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		deadlineCh := make(chan time.Duration, 1)
+		handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			deadline, ok := r.Context().Deadline()
+			if !ok {
+				t.Fatal("expected upstream request deadline")
+			}
+			deadlineCh <- time.Until(deadline)
+			return sseHTTPResponse("data: {\"id\":\"resp-stream\",\"object\":\"response\",\"status\":\"in_progress\"}\n\ndata: [DONE]\n\n"), nil
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello","stream":true}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handler.HandleResponses(w, req)
+
+		if resp := w.Result(); resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		assertDeadlineApprox(t, <-deadlineCh, streamingUpstreamTimeout)
+	})
 }
 
 func TestHandleResponses_LargeBodyStillRejected(t *testing.T) {
@@ -3018,6 +3109,42 @@ func TestOpenAIChatCompletions_InjectsParallelToolCalls(t *testing.T) {
 		body, _ := io.ReadAll(w.Result().Body)
 		t.Fatalf("expected 200, got %d: %s", w.Result().StatusCode, body)
 	}
+}
+
+func TestHandleOpenAIChatCompletions_ForcedStreamingUsesStreamingUpstreamTimeout(t *testing.T) {
+	deadlineCh := make(chan time.Duration, 1)
+	handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		deadline, ok := r.Context().Deadline()
+		if !ok {
+			t.Fatal("expected upstream request deadline")
+		}
+		deadlineCh <- time.Until(deadline)
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+		if oaiReq.Stream == nil || !*oaiReq.Stream {
+			t.Fatal("expected proxy to force upstream stream=true when tools are present")
+		}
+
+		return sseHTTPResponse("data: {\"id\":\"chatcmpl-deadline\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-deadline\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"), nil
+	}))
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"f","parameters":{}}}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	if resp := w.Result(); resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	assertDeadlineApprox(t, <-deadlineCh, streamingUpstreamTimeout)
 }
 
 func TestOpenAIChatCompletions_EmptyToolsDoesNotForceStreaming(t *testing.T) {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -49,7 +49,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 
 	extraHeaders := responsesExtraHeadersFromRequest(r)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(isStreaming)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(isStreaming)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, extraHeaders)
@@ -121,7 +121,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	body["instructions"] = prompt
 	bodyBytes, _ = json.Marshal(body)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
@@ -242,7 +242,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	}
 	reqBody, _ := json.Marshal(responsesReq)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, reqBody, responsesExtraHeadersFromRequest(r))

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -49,7 +49,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 
 	extraHeaders := responsesExtraHeadersFromRequest(r)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(isStreaming)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, extraHeaders)
@@ -121,7 +121,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	body["instructions"] = prompt
 	bodyBytes, _ = json.Marshal(body)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
@@ -242,7 +242,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	}
 	reqBody, _ := json.Marshal(responsesReq)
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, reqBody, responsesExtraHeadersFromRequest(r))

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -277,7 +277,7 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 		return err
 	}
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(true)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(true)
 	defer upstreamCancel()
 
 	resp, deltaAttempted, deltaFallback, err := s.postCreateRequest(h, upstreamCtx, token, request, plan)
@@ -427,7 +427,7 @@ func (s *responsesWebSocketSession) rememberResponse(resetHistory bool, response
 }
 
 func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, token string, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
-	ctx, cancel := newInferenceUpstreamContext(false)
+	ctx, cancel := h.newInferenceUpstreamContext(false)
 	defer cancel()
 
 	compaction, compacted, err := s.compactHistory(h, ctx, token, request, false)

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -277,7 +277,7 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 		return err
 	}
 
-	upstreamCtx, upstreamCancel := newInferenceUpstreamContext()
+	upstreamCtx, upstreamCancel := newInferenceUpstreamContext(true)
 	defer upstreamCancel()
 
 	resp, deltaAttempted, deltaFallback, err := s.postCreateRequest(h, upstreamCtx, token, request, plan)
@@ -427,7 +427,7 @@ func (s *responsesWebSocketSession) rememberResponse(resetHistory bool, response
 }
 
 func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, token string, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
-	ctx, cancel := newInferenceUpstreamContext()
+	ctx, cancel := newInferenceUpstreamContext(false)
 	defer cancel()
 
 	compaction, compacted, err := s.compactHistory(h, ctx, token, request, false)

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -124,6 +124,51 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 	}
 }
 
+func TestHandleResponsesWebSocket_CreateRequestUsesStreamingUpstreamTimeout(t *testing.T) {
+	deadlineCh := make(chan time.Duration, 1)
+	handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		deadline, ok := r.Context().Deadline()
+		if !ok {
+			t.Fatal("expected upstream request deadline")
+		}
+		deadlineCh <- time.Until(deadline)
+
+		return sseHTTPResponse(
+			"event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-deadline\"}}\n\n" +
+				"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-deadline\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n",
+		), nil
+	}))
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	created := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected first event to be response.created, got %v", created["type"])
+	}
+	completed := mustReadWebSocketJSON(t, conn)
+	if completed["type"] != "response.completed" {
+		t.Fatalf("expected second event to be response.completed, got %v", completed["type"])
+	}
+
+	assertDeadlineApprox(t, <-deadlineCh, streamingUpstreamTimeout)
+}
+
 func TestHandleResponsesWebSocket_WarmupStaysLocalAndNextRequestExpandsState(t *testing.T) {
 	var upstreamRequests int
 	var upstreamBody map[string]interface{}

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 )
 
-func newInferenceUpstreamContext(streaming bool) (context.Context, context.CancelFunc) {
+func (h *ProxyHandler) newInferenceUpstreamContext(streaming bool) (context.Context, context.CancelFunc) {
 	// Use background context with timeout to avoid cancellation from client
 	// disconnects while still preventing goroutine leaks on upstream hangs.
 	timeout := upstreamTimeout
 	if streaming {
-		timeout = streamingUpstreamTimeout
+		timeout = h.effectiveStreamingUpstreamTimeout()
 	}
 	return context.WithTimeout(context.Background(), timeout)
 }

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -8,10 +8,14 @@ import (
 	"net/http"
 )
 
-func newInferenceUpstreamContext() (context.Context, context.CancelFunc) {
+func newInferenceUpstreamContext(streaming bool) (context.Context, context.CancelFunc) {
 	// Use background context with timeout to avoid cancellation from client
 	// disconnects while still preventing goroutine leaks on upstream hangs.
-	return context.WithTimeout(context.Background(), upstreamTimeout)
+	timeout := upstreamTimeout
+	if streaming {
+		timeout = streamingUpstreamTimeout
+	}
+	return context.WithTimeout(context.Background(), timeout)
 }
 
 func upstreamStatusCode(err error, fallback int) int {

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,12 @@ func WithResponsesWebSocketConfig(cfg proxy.ResponsesWebSocketConfig) Option {
 	return WithProxyOptions(proxy.WithResponsesWebSocketConfig(cfg))
 }
 
+// WithStreamingUpstreamTimeout overrides the timeout used for streaming
+// upstream inference requests and derives the server write timeout from it.
+func WithStreamingUpstreamTimeout(timeout time.Duration) Option {
+	return WithProxyOptions(proxy.WithStreamingUpstreamTimeout(timeout))
+}
+
 // New creates a Server with routes and timeouts configured.
 func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string, opts ...Option) *Server {
 	cfg := options{}
@@ -77,7 +83,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 			Addr:         addr,
 			Handler:      mux,
 			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 65 * time.Minute,
+			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,
 		},
 		log: log,

--- a/server/server.go
+++ b/server/server.go
@@ -77,7 +77,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 			Addr:         addr,
 			Handler:      mux,
 			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 5 * time.Minute,
+			WriteTimeout: 65 * time.Minute,
 			IdleTimeout:  120 * time.Second,
 		},
 		log: log,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sozercan/copilot-proxy/auth"
 	"github.com/sozercan/copilot-proxy/logger"
+	"github.com/sozercan/copilot-proxy/proxy"
 )
 
 func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
@@ -50,5 +51,39 @@ func TestNew_ConfiguresExtendedWriteTimeout(t *testing.T) {
 
 	if got, want := srv.httpServer.WriteTimeout, 65*time.Minute; got != want {
 		t.Fatalf("WriteTimeout = %v, want %v", got, want)
+	}
+}
+
+func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
+	const customTimeout = 17 * time.Minute
+
+	tests := []struct {
+		name string
+		opts []Option
+	}{
+		{
+			name: "server wrapper",
+			opts: []Option{WithStreamingUpstreamTimeout(customTimeout)},
+		},
+		{
+			name: "proxy option",
+			opts: []Option{WithProxyOptions(proxy.WithStreamingUpstreamTimeout(customTimeout))},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := New(
+				auth.NewTestAuthenticator("test-token"),
+				logger.New(logger.ParseLevel("error")),
+				"127.0.0.1",
+				"0",
+				tc.opts...,
+			)
+
+			if got, want := srv.httpServer.WriteTimeout, customTimeout+5*time.Minute; got != want {
+				t.Fatalf("WriteTimeout = %v, want %v", got, want)
+			}
+		})
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sozercan/copilot-proxy/auth"
 	"github.com/sozercan/copilot-proxy/logger"
@@ -36,5 +37,18 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "address already in use") {
 		t.Fatalf("expected address-in-use error, got %v", err)
+	}
+}
+
+func TestNew_ConfiguresExtendedWriteTimeout(t *testing.T) {
+	srv := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+
+	if got, want := srv.httpServer.WriteTimeout, 65*time.Minute; got != want {
+		t.Fatalf("WriteTimeout = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- select the streaming upstream timeout when a request will become a long-lived upstream stream, including forced-stream tool paths
- apply the streaming timeout to /v1/responses and the websocket responses bridge
- extend the server write timeout and add regression coverage for the affected handlers

## Testing
- go test ./...