### PR TITLE
Fix retry, error sanitization, auth persistence, env warnings

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -464,21 +464,21 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	tmpPath := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("writing temp file: %w", err)
 	}
 	if err := tmp.Chmod(perm); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("setting temp file permissions: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("closing temp file: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("renaming temp file: %w", err)
 	}
 	return nil

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -74,7 +74,7 @@ type CopilotTokenResponse struct {
 
 // NewAuthenticator creates an Authenticator that stores tokens in tokenDir.
 // If tokenDir is empty, it defaults to ~/.config/copilot-proxy.
-func NewAuthenticator(tokenDir string) *Authenticator {
+func NewAuthenticator(tokenDir string) (*Authenticator, error) {
 	if tokenDir == "" {
 		tokenDir = defaultTokenDir
 	}
@@ -84,14 +84,16 @@ func NewAuthenticator(tokenDir string) *Authenticator {
 			tokenDir = filepath.Join(home, tokenDir[1:])
 		}
 	}
-	_ = os.MkdirAll(tokenDir, 0o700)
+	if err := os.MkdirAll(tokenDir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating token directory: %w", err)
+	}
 
 	return &Authenticator{
 		tokenDir: tokenDir,
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-	}
+	}, nil
 }
 
 // IsSignedIn reports whether the authenticator has a GitHub access token
@@ -410,7 +412,7 @@ func (a *Authenticator) loadAccessToken() error {
 }
 
 func (a *Authenticator) saveAccessToken() error {
-	return os.WriteFile(filepath.Join(a.tokenDir, "access-token"), []byte(a.accessToken), 0o600)
+	return atomicWriteFile(filepath.Join(a.tokenDir, "access-token"), []byte(a.accessToken), 0o600)
 }
 
 func (a *Authenticator) loadCopilotToken() error {
@@ -438,7 +440,7 @@ func (a *Authenticator) saveCopilotToken() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(a.tokenDir, "api-key.json"), data, 0o600)
+	return atomicWriteFile(filepath.Join(a.tokenDir, "api-key.json"), data, 0o600)
 }
 
 func lookupAccessTokenFromEnv() (string, string) {
@@ -448,4 +450,36 @@ func lookupAccessTokenFromEnv() (string, string) {
 		}
 	}
 	return "", ""
+}
+
+// atomicWriteFile writes data to a temporary file in the same directory as
+// path and then renames it into place, ensuring the target file is never
+// partially written.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("setting temp file permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -326,7 +326,10 @@ func TestLoadCopilotToken_Expired(t *testing.T) {
 }
 
 func TestNewAuthenticator_DefaultDir(t *testing.T) {
-	a := NewAuthenticator("")
+	a, err := NewAuthenticator("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if a.tokenDir == "" {
 		t.Fatal("expected tokenDir to be set")
 	}
@@ -334,7 +337,10 @@ func TestNewAuthenticator_DefaultDir(t *testing.T) {
 
 func TestNewAuthenticator_CustomDir(t *testing.T) {
 	dir := t.TempDir()
-	a := NewAuthenticator(dir)
+	a, err := NewAuthenticator(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if a.tokenDir != dir {
 		t.Errorf("expected %q, got %q", dir, a.tokenDir)
 	}

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -29,7 +29,11 @@ var (
 )
 
 func main() {
-	authenticator = auth.NewAuthenticator("")
+	var err error
+	authenticator, err = auth.NewAuthenticator("")
+	if err != nil {
+		log.Fatal("failed to initialize authenticator", logger.Err(err))
+	}
 	authenticator.DisableAutoDeviceFlow = true
 	systray.Run(onReady, onExit)
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -34,7 +35,10 @@ func main() {
 
 	log := logger.New(logger.ParseLevel(*logLevel))
 
-	authenticator := auth.NewAuthenticator(*tokenDir)
+	authenticator, err := auth.NewAuthenticator(*tokenDir)
+	if err != nil {
+		log.Fatal("failed to initialize authenticator", logger.Err(err))
+	}
 
 	log.Info("authenticating with GitHub Copilot...")
 	ctx := context.Background()
@@ -96,6 +100,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -108,6 +113,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -120,6 +126,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 )
@@ -37,5 +40,77 @@ func TestGetEnvDuration(t *testing.T) {
 				t.Fatalf("getEnvDuration() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestGetEnvBool(t *testing.T) {
+	const envKey = "TEST_BOOL_VAR"
+
+	tests := []struct {
+		name string
+		value string
+		want bool
+	}{
+		{name: "empty uses fallback", value: "", want: false},
+		{name: "true parses", value: "true", want: true},
+		{name: "false parses", value: "false", want: false},
+		{name: "1 parses", value: "1", want: true},
+		{name: "invalid uses fallback", value: "nope", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envKey, tc.value)
+			if got := getEnvBool(envKey, false); got != tc.want {
+				t.Fatalf("getEnvBool() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	const envKey = "TEST_INT_VAR"
+
+	tests := []struct {
+		name string
+		value string
+		want int
+	}{
+		{name: "empty uses fallback", value: "", want: 42},
+		{name: "valid int parses", value: "100", want: 100},
+		{name: "invalid uses fallback", value: "abc", want: 42},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envKey, tc.value)
+			if got := getEnvInt(envKey, 42); got != tc.want {
+				t.Fatalf("getEnvInt() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
+	const envKey = "TEST_WARN_VAR"
+
+	// Capture stderr to verify warning is emitted.
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	t.Setenv(envKey, "not-a-bool")
+	getEnvBool(envKey, false)
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	want := fmt.Sprintf("warning: ignoring invalid %s=%q", envKey, "not-a-bool")
+	if !bytes.Contains([]byte(output), []byte(want)) {
+		t.Errorf("expected stderr to contain %q, got %q", want, output)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -102,11 +102,11 @@ func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	t.Setenv(envKey, "not-a-bool")
 	getEnvBool(envKey, false)
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = old
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	output := buf.String()
 
 	want := fmt.Sprintf("warning: ignoring invalid %s=%q", envKey, "not-a-bool")

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -133,7 +133,8 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeAnthropicError(w, http.StatusInternalServerError, "api_error", fmt.Sprintf("failed to get token: %v", err))
+		h.log.Error("failed to get token", logger.F("endpoint", "anthropic"), logger.Err(err))
+		writeAnthropicError(w, http.StatusInternalServerError, "api_error", "authentication failed")
 		return
 	}
 
@@ -142,20 +143,21 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
 	if err != nil {
-		writeAnthropicError(w, upstreamStatusCode(err, http.StatusBadGateway), "api_error", fmt.Sprintf("upstream request failed: %v", err))
+		h.log.Error("upstream request failed", logger.F("endpoint", "anthropic"), logger.Err(err))
+		writeAnthropicError(w, upstreamStatusCode(err, http.StatusBadGateway), "api_error", "upstream request failed")
 		return
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		h.log.Error("upstream error",
 			logger.F("endpoint", "anthropic"),
 			logger.F("status", resp.StatusCode),
 			logger.F("body", string(errBody)),
 			logger.F("request", string(oaiBody)),
 		)
-		writeAnthropicError(w, resp.StatusCode, "api_error", fmt.Sprintf("upstream error (%d): %s", resp.StatusCode, string(errBody)))
+		writeAnthropicError(w, resp.StatusCode, "api_error", fmt.Sprintf("upstream error (%d)", resp.StatusCode))
 		return
 	}
 
@@ -179,7 +181,8 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *http.Request) {
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error")
+		h.log.Error("failed to get token", logger.F("endpoint", "openai"), logger.Err(err))
+		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
 		return
 	}
 
@@ -198,7 +201,8 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 
 	resp, err := h.postChatCompletions(upstreamCtx, token, bodyBytes)
 	if err != nil {
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		h.log.Error("upstream request failed", logger.F("endpoint", "openai"), logger.Err(err))
+		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
 		return
 	}
 

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -83,7 +83,8 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", fmt.Sprintf("failed to get token: %v", err))
+		h.log.Error("failed to get token", logger.F("endpoint", "gemini"), logger.Err(err))
+		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", "authentication failed")
 		return
 	}
 
@@ -104,9 +105,9 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		h.log.Error("upstream error", logger.F("endpoint", "gemini"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)), logger.F("request", string(oaiBody)))
-		writeGeminiError(w, resp.StatusCode, mapGeminiUpstreamStatus(resp.StatusCode), fmt.Sprintf("upstream error (%d): %s", resp.StatusCode, string(errBody)))
+		writeGeminiError(w, resp.StatusCode, mapGeminiUpstreamStatus(resp.StatusCode), fmt.Sprintf("upstream error (%d)", resp.StatusCode))
 		return
 	}
 
@@ -178,7 +179,8 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", fmt.Sprintf("failed to get token: %v", err))
+		h.log.Error("failed to get token", logger.F("endpoint", "gemini_count_tokens"), logger.Err(err))
+		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", "authentication failed")
 		return
 	}
 
@@ -322,11 +324,12 @@ func (h *ProxyHandler) decodeGeminiProbeResponse(resp *http.Response) (*models.O
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		errBody, _ := io.ReadAll(resp.Body)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		h.log.Error("upstream error", logger.F("endpoint", "gemini_count_tokens"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
 		return nil, false, &geminiProtocolError{
 			statusCode: resp.StatusCode,
 			status:     mapGeminiUpstreamStatus(resp.StatusCode),
-			message:    fmt.Sprintf("upstream error (%d): %s", resp.StatusCode, string(errBody)),
+			message:    fmt.Sprintf("upstream error (%d)", resp.StatusCode),
 		}
 	}
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -468,7 +468,8 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error")
+		h.log.Error("failed to get token", logger.F("endpoint", "models"), logger.Err(err))
+		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
 		return
 	}
 
@@ -492,7 +493,8 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		writeOpenAIError(w, http.StatusBadGateway, fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		h.log.Error("upstream request failed", logger.F("endpoint", "models"), logger.Err(err))
+		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed", "server_error")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -155,7 +155,10 @@ func TestHandleReadyz(t *testing.T) {
 	})
 
 	t.Run("not ready when auth fails", func(t *testing.T) {
-		authenticator := auth.NewAuthenticator(t.TempDir())
+		authenticator, err := auth.NewAuthenticator(t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		authenticator.DisableAutoDeviceFlow = true
 
 		h := &ProxyHandler{

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -27,7 +27,8 @@ func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error")
+		h.log.Error("failed to get token", logger.F("endpoint", "responses"), logger.Err(err))
+		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
 		return
 	}
 
@@ -54,12 +55,14 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, extraHeaders)
 	if err != nil {
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		h.log.Error("upstream request failed", logger.F("endpoint", "responses"), logger.Err(err))
+		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
 		return
 	}
 	resp, err = h.maybeRetryCompactedResponsesRequest(upstreamCtx, token, bodyBytes, extraHeaders, resp)
 	if err != nil {
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		h.log.Error("upstream request failed", logger.F("endpoint", "responses"), logger.Err(err))
+		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
 		return
 	}
 
@@ -98,7 +101,8 @@ Be concise, structured, and action-oriented. Do not chat with the user. Do not a
 func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error")
+		h.log.Error("failed to get token", logger.F("endpoint", "compact"), logger.Err(err))
+		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
 		return
 	}
 
@@ -126,7 +130,8 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
 	if err != nil {
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		h.log.Error("upstream request failed", logger.F("endpoint", "compact"), logger.Err(err))
+		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -199,7 +204,8 @@ Respond with a JSON array where each element has "trace_summary" and "memory_sum
 func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Request) {
 	token, err := h.auth.GetToken(r.Context())
 	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error")
+		h.log.Error("failed to get token", logger.F("endpoint", "memory_summarize"), logger.Err(err))
+		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
 		return
 	}
 
@@ -247,7 +253,8 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, reqBody, responsesExtraHeadersFromRequest(r))
 	if err != nil {
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), fmt.Sprintf("upstream request failed: %v", err), "server_error")
+		h.log.Error("upstream request failed", logger.F("endpoint", "memory_summarize"), logger.Err(err))
+		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -320,7 +327,7 @@ func extractResponsesOutputText(body []byte) (string, error) {
 		return "", err
 	}
 
-	var text string
+	var sb strings.Builder
 	for _, item := range upstream.Output {
 		var outputItem struct {
 			Type    string `json:"type"`
@@ -337,12 +344,12 @@ func extractResponsesOutputText(body []byte) (string, error) {
 		}
 		for _, content := range outputItem.Content {
 			if (content.Type == "output_text" || content.Type == "text") && content.Text != "" {
-				text += content.Text
+				sb.WriteString(content.Text)
 			}
 		}
 	}
 
-	return sanitizeProxySummaryText(text), nil
+	return sanitizeProxySummaryText(sb.String()), nil
 }
 
 func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint string, injectResumePrompt bool) []byte {
@@ -636,7 +643,7 @@ func (h *ProxyHandler) pickResponsesCompatibleModel(ctx context.Context, token, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return "", fmt.Errorf("unexpected /models status %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -1,8 +1,11 @@
 package proxy
 
 import (
+	"context"
+	"io"
 	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -23,6 +26,28 @@ func backoff(base time.Duration, attempt int) time.Duration {
 	delay := base << uint(attempt)
 	jitter := time.Duration(rand.Int64N(int64(delay / 4)))
 	return delay + jitter
+}
+
+// parseRetryAfter extracts a delay from a Retry-After header value.
+// It supports both delay-seconds ("120") and is intentionally simple —
+// HTTP-date values are ignored and fall back to the caller's default.
+func parseRetryAfter(value string) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds <= 0 {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+// drainAndClose discards up to 4 KB from the body before closing it so that
+// HTTP/2 streams are cleanly consumed and the underlying connection can be
+// reused instead of being reset.
+func drainAndClose(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 4096))
+	_ = body.Close()
 }
 
 // doWithRetry executes an HTTP request with retry on transient failures.
@@ -48,7 +73,9 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		if err != nil {
 			lastErr = err
 			if attempt < maxRetries-1 {
-				time.Sleep(backoff(retryDelay, attempt))
+				if ctxErr := sleepWithContext(req.Context(), backoff(retryDelay, attempt)); ctxErr != nil {
+					return nil, ctxErr
+				}
 			}
 			continue
 		}
@@ -57,15 +84,36 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			return resp, nil
 		}
 
-		// Drain and close body before retry
-		resp.Body.Close()
+		retryAfterHeader := resp.Header.Get("Retry-After")
+
+		// Drain and close body before retry to allow connection reuse.
+		drainAndClose(resp.Body)
 		lastErr = &upstreamError{statusCode: resp.StatusCode}
 
 		if attempt < maxRetries-1 {
-			time.Sleep(backoff(retryDelay, attempt))
+			delay := backoff(retryDelay, attempt)
+			if ra, ok := parseRetryAfter(retryAfterHeader); ok && ra > delay {
+				delay = ra
+			}
+			if ctxErr := sleepWithContext(req.Context(), delay); ctxErr != nil {
+				return nil, ctxErr
+			}
 		}
 	}
 	return nil, lastErr
+}
+
+// sleepWithContext blocks for the given duration or until the context is done,
+// whichever comes first. It returns the context error if cancelled.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }
 
 type upstreamError struct {

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -158,5 +160,112 @@ func TestRetryable(t *testing.T) {
 		if got := retryable(tt.code); got != tt.expected {
 			t.Errorf("retryable(%d) = %v, want %v", tt.code, got, tt.expected)
 		}
+	}
+}
+
+func TestDoWithRetry_CancelledDuringBackoff(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	h := &ProxyHandler{
+		auth:           auth.NewTestAuthenticator("tok"),
+		client:         server.Client(),
+		copilotURL:     server.URL,
+		log:            logger.New(logger.LevelError),
+		retryBaseDelay: 5 * time.Second, // long enough that cancel fires first
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay to interrupt the backoff sleep.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := h.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/test", nil)
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected 1 call before cancel, got %d", calls.Load())
+	}
+}
+
+func TestDoWithRetry_RespectsRetryAfter(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	h := &ProxyHandler{
+		auth:           auth.NewTestAuthenticator("tok"),
+		client:         server.Client(),
+		copilotURL:     server.URL,
+		log:            logger.New(logger.LevelError),
+		retryBaseDelay: 1 * time.Millisecond,
+	}
+
+	start := time.Now()
+	resp, err := h.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequest(http.MethodPost, server.URL+"/test", nil)
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 calls, got %d", calls.Load())
+	}
+	// Retry-After: 1 means at least 1 second of delay.
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected at least ~1s delay from Retry-After, got %v", elapsed)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		value   string
+		wantDur time.Duration
+		wantOK  bool
+	}{
+		{"", 0, false},
+		{"0", 0, false},
+		{"-1", 0, false},
+		{"abc", 0, false},
+		{"5", 5 * time.Second, true},
+		{"120", 120 * time.Second, true},
+		// HTTP-date is intentionally not supported.
+		{"Wed, 21 Oct 2015 07:28:00 GMT", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("value=%q", tt.value), func(t *testing.T) {
+			dur, ok := parseRetryAfter(tt.value)
+			if ok != tt.wantOK || dur != tt.wantDur {
+				t.Errorf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", tt.value, dur, ok, tt.wantDur, tt.wantOK)
+			}
+		})
 	}
 }

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -210,7 +210,7 @@ func TestDoWithRetry_RespectsRetryAfter(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer server.Close()
 
@@ -230,7 +230,7 @@ func TestDoWithRetry_RespectsRetryAfter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -78,7 +78,9 @@ func StreamOpenAIPassthrough(w http.ResponseWriter, body io.ReadCloser) {
 	if f, ok := w.(http.Flusher); ok {
 		fw.flusher = f
 	}
-	io.Copy(fw, body)
+	// Errors here (client disconnect, upstream drop) are unrecoverable for SSE
+	// since headers have already been sent. The client must handle truncated streams.
+	_, _ = io.Copy(fw, body)
 }
 
 // StreamOpenAIToAnthropic translates an OpenAI SSE stream into Anthropic SSE format.

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -139,19 +139,19 @@ func parseSystemMessage(raw json.RawMessage) (*models.OpenAIMessage, error) {
 		return nil, fmt.Errorf("system is neither string nor []ContentBlock: %w", err)
 	}
 
-	var text string
+	var sb strings.Builder
 	for _, b := range blocks {
 		switch b.Type {
 		case "text":
-			text += b.Text
+			sb.WriteString(b.Text)
 		default:
 			return nil, fmt.Errorf("unsupported system content block type %q", b.Type)
 		}
 	}
-	if text == "" {
+	if sb.Len() == 0 {
 		return nil, nil
 	}
-	content, _ := json.Marshal(text)
+	content, _ := json.Marshal(sb.String())
 	return &models.OpenAIMessage{Role: "system", Content: content}, nil
 }
 
@@ -318,13 +318,13 @@ func extractToolResultContent(raw json.RawMessage) (string, error) {
 		return "", fmt.Errorf("tool_result content is neither string nor []ContentBlock: %w", err)
 	}
 
-	var text string
+	var sb strings.Builder
 	for _, b := range blocks {
 		if b.Type == "text" {
-			text += b.Text
+			sb.WriteString(b.Text)
 		}
 	}
-	return text, nil
+	return sb.String(), nil
 }
 
 func translateToolChoice(tc *models.AnthropicToolChoice) (json.RawMessage, error) {


### PR DESCRIPTION
## Summary

- **Retry handling**: context-aware backoff sleep, Retry-After header support, proper body drain before close
- **Error sanitization**: stop leaking internal/upstream error details to clients; log them server-side; bound error body reads with LimitReader
- **Auth persistence**: `NewAuthenticator` returns error on MkdirAll failure; token writes use atomic write-then-rename
- **Env warnings**: stderr warning on unparseable env values instead of silent fallback
- **Cleanup**: strings.Builder for loop concatenation, explicit io.Copy return assignment

## Test plan

- [x] `go test ./... -count=1` passes
- [x] `go vet ./...` passes
- [x] New tests: `TestDoWithRetry_CancelledDuringBackoff` — verifies context.Canceled is returned (not stale upstream error) when context is cancelled during backoff
- [x] New tests: `TestDoWithRetry_RespectsRetryAfter` — verifies Retry-After header delays retry by at least the specified duration
- [x] New tests: `TestParseRetryAfter` — table-driven coverage of valid/invalid Retry-After values
- [x] New tests: `TestGetEnvBool`, `TestGetEnvInt` — table-driven coverage for env parsers
- [x] New tests: `TestGetEnvWarnsOnInvalidValue` — captures stderr to verify warning output
- [x] Existing tests updated for `NewAuthenticator` signature change (now returns error)