### PR TITLE
Improve Codex CLI compatibility for WebSocket and Responses API

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -651,7 +651,7 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 		gotSessionID = r.Header.Get("Session-Id")
 		gotClientRequestID = r.Header.Get("X-Client-Request-Id")
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"id":"resp-headers","object":"response","status":"completed"}`))
+		_, _ = w.Write([]byte(`{"id":"resp-headers","object":"response","status":"completed"}`))
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello"}`))

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -644,6 +644,42 @@ func TestHandleResponses(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
+	var gotOpenAIBeta, gotSessionID, gotClientRequestID string
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		gotOpenAIBeta = r.Header.Get("OpenAI-Beta")
+		gotSessionID = r.Header.Get("Session-Id")
+		gotClientRequestID = r.Header.Get("X-Client-Request-Id")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"resp-headers","object":"response","status":"completed"}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("OpenAI-Beta", "responses_websockets=2026-02-06")
+	req.Header.Set("Session-Id", "sess-abc-123")
+	req.Header.Set("X-Client-Request-Id", "client-req-456")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	if gotOpenAIBeta != "responses_websockets=2026-02-06" {
+		t.Fatalf("expected OpenAI-Beta to be forwarded, got %q", gotOpenAIBeta)
+	}
+	if gotSessionID != "sess-abc-123" {
+		t.Fatalf("expected Session-Id to be forwarded, got %q", gotSessionID)
+	}
+	if gotClientRequestID != "client-req-456" {
+		t.Fatalf("expected X-Client-Request-Id to be forwarded, got %q", gotClientRequestID)
+	}
+}
+
 func TestHandleResponses_UpstreamDeadlineDependsOnStreamFlag(t *testing.T) {
 	t.Run("non-streaming", func(t *testing.T) {
 		deadlineCh := make(chan time.Duration, 1)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -648,7 +648,7 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	var gotOpenAIBeta, gotSessionID, gotClientRequestID string
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		gotOpenAIBeta = r.Header.Get("OpenAI-Beta")
-		gotSessionID = r.Header.Get("Session-Id")
+		gotSessionID = r.Header.Get("session_id")
 		gotClientRequestID = r.Header.Get("X-Client-Request-Id")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"resp-headers","object":"response","status":"completed"}`))
@@ -657,7 +657,7 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("OpenAI-Beta", "responses_websockets=2026-02-06")
-	req.Header.Set("Session-Id", "sess-abc-123")
+	req.Header.Set("session_id", "sess-abc-123")
 	req.Header.Set("X-Client-Request-Id", "client-req-456")
 	w := httptest.NewRecorder()
 
@@ -673,7 +673,7 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 		t.Fatalf("expected OpenAI-Beta to be forwarded, got %q", gotOpenAIBeta)
 	}
 	if gotSessionID != "sess-abc-123" {
-		t.Fatalf("expected Session-Id to be forwarded, got %q", gotSessionID)
+		t.Fatalf("expected session_id to be forwarded, got %q", gotSessionID)
 	}
 	if gotClientRequestID != "client-req-456" {
 		t.Fatalf("expected X-Client-Request-Id to be forwarded, got %q", gotClientRequestID)

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -15,7 +15,7 @@ import (
 func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 	var headers http.Header
 
-	for _, name := range []string{"X-OpenAI-Subagent", "OpenAI-Beta", "Session-Id", "X-Client-Request-Id"} {
+	for _, name := range []string{"X-OpenAI-Subagent", "OpenAI-Beta", "session_id", "X-Client-Request-Id"} {
 		for _, value := range r.Header.Values(name) {
 			if trimmed := strings.TrimSpace(value); trimmed != "" {
 				if headers == nil {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -13,13 +13,20 @@ import (
 )
 
 func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
-	if subagent := strings.TrimSpace(r.Header.Get("X-OpenAI-Subagent")); subagent != "" {
-		headers := make(http.Header, 1)
-		headers.Set("X-OpenAI-Subagent", subagent)
-		return headers
+	var headers http.Header
+
+	for _, name := range []string{"X-OpenAI-Subagent", "OpenAI-Beta", "Session-Id", "X-Client-Request-Id"} {
+		for _, value := range r.Header.Values(name) {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				if headers == nil {
+					headers = make(http.Header, 2)
+				}
+				headers.Add(name, trimmed)
+			}
+		}
 	}
 
-	return nil
+	return headers
 }
 
 // HandleResponses handles POST /v1/responses by forwarding the request to

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -147,7 +147,7 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 
 func newResponsesWebSocketSession(conn *websocket.Conn, r *http.Request) *responsesWebSocketSession {
 	baseHeaders := make(http.Header)
-	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "OpenAI-Beta", "session_id", "X-Client-Request-Id"} {
+	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "OpenAI-Beta", "session_id", "X-Client-Request-Id", "X-OpenAI-Subagent"} {
 		for _, value := range r.Header.Values(name) {
 			baseHeaders.Add(name, value)
 		}

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,9 +20,16 @@ import (
 
 const responsesWebSocketRequestHeaderPrefix = "ws_request_header_"
 
+// errStreamFailedUpstream is a sentinel error indicating the upstream stream
+// ended with response.failed or response.incomplete. The error event has already
+// been forwarded to the WebSocket client, so no additional error frame should
+// be sent.
+var errStreamFailedUpstream = errors.New("upstream stream ended with response.failed or response.incomplete")
+
 var responsesWebSocketUpgrader = websocket.Upgrader{
-	ReadBufferSize:  4096,
-	WriteBufferSize: 4096,
+	ReadBufferSize:    4096,
+	WriteBufferSize:   4096,
+	EnableCompression: true,
 	CheckOrigin: func(r *http.Request) bool {
 		return strings.TrimSpace(r.Header.Get("Origin")) == ""
 	},
@@ -139,7 +147,7 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 
 func newResponsesWebSocketSession(conn *websocket.Conn, r *http.Request) *responsesWebSocketSession {
 	baseHeaders := make(http.Header)
-	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata"} {
+	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "OpenAI-Beta"} {
 		for _, value := range r.Header.Values(name) {
 			baseHeaders.Add(name, value)
 		}
@@ -301,9 +309,11 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 		return fmt.Errorf("upstream websocket bridge status %d", resp.StatusCode)
 	}
 
-	responseID, outputItems, err := s.streamUpstreamResponse(resp.Body)
+	responseID, outputItems, err := s.streamUpstreamResponse(resp.Body, resp.Header)
 	if err != nil {
-		s.sendWrappedError(http.StatusBadGateway, err.Error(), "server_error", nil)
+		if !errors.Is(err, errStreamFailedUpstream) {
+			s.sendWrappedError(http.StatusBadGateway, err.Error(), "server_error", nil)
+		}
 		return err
 	}
 
@@ -559,7 +569,17 @@ func (s *responsesWebSocketSession) logRequestMetrics(h *ProxyHandler, request *
 	)
 }
 
-func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader) (string, []json.RawMessage, error) {
+func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader, headers http.Header) (string, []json.RawMessage, error) {
+	// Emit a synthetic metadata event with upstream response headers so
+	// WebSocket clients can read openai-model, x-reasoning-included, rate
+	// limit headers, etc. that would otherwise be lost in the HTTP→WS bridge.
+	if mappedHeaders := responsesWebSocketMetadataHeaders(headers); len(mappedHeaders) > 0 {
+		_ = s.writeJSON(map[string]interface{}{
+			"type":    "codex.response.metadata",
+			"headers": mappedHeaders,
+		})
+	}
+
 	var responseID string
 	var outputItems []json.RawMessage
 	sawCompleted := false
@@ -591,21 +611,27 @@ func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader) (stri
 			if event.Response.ID != "" {
 				responseID = event.Response.ID
 			}
+		case "response.failed", "response.incomplete":
+			// Return the sentinel immediately to break out of the SSE
+			// scanner loop. The event has already been forwarded to the
+			// client above, so no additional error frame is needed.
+			return errStreamFailedUpstream
 		}
 
 		return nil
-	}); err != nil {
+	}); err != nil && !errors.Is(err, errStreamFailedUpstream) {
 		return "", nil, err
+	} else if errors.Is(err, errStreamFailedUpstream) {
+		return "", nil, errStreamFailedUpstream
 	}
 
-	if !sawCompleted {
-		return "", nil, fmt.Errorf("stream ended before response.completed")
+	if sawCompleted {
+		if responseID == "" {
+			return "", nil, fmt.Errorf("response.completed missing response id")
+		}
+		return responseID, outputItems, nil
 	}
-	if responseID == "" {
-		return "", nil, fmt.Errorf("response.completed missing response id")
-	}
-
-	return responseID, outputItems, nil
+	return "", nil, fmt.Errorf("stream ended before response.completed")
 }
 
 func (s *responsesWebSocketSession) writeJSON(payload interface{}) error {
@@ -716,6 +742,49 @@ func flattenResponsesWebSocketHeaders(headers http.Header) map[string]interface{
 		default:
 			result[key] = strings.Join(values, ", ")
 		}
+	}
+	return result
+}
+
+// responsesWebSocketMetadataHeaders extracts headers that are meaningful to
+// Codex CLI WebSocket clients. Only headers the client actively reads are
+// included so that generic HTTP headers (Content-Type, Date, etc.) don't
+// produce spurious metadata frames.
+func responsesWebSocketMetadataHeaders(headers http.Header) map[string]interface{} {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	result := make(map[string]interface{}, 4)
+	for _, key := range []string{
+		"Openai-Model",
+		"X-Openai-Model",
+		"X-Reasoning-Included",
+		"X-Models-Etag",
+		"X-Codex-Turn-State",
+	} {
+		if value := headers.Get(key); value != "" {
+			result[key] = value
+		}
+	}
+
+	// Include rate-limit headers (x-codex-* prefix pattern).
+	for key, values := range headers {
+		canonical := http.CanonicalHeaderKey(key)
+		if strings.HasPrefix(strings.ToLower(canonical), "x-codex-") {
+			if _, already := result[canonical]; already {
+				continue
+			}
+			if len(values) == 1 {
+				result[canonical] = values[0]
+			} else if len(values) > 1 {
+				result[canonical] = strings.Join(values, ", ")
+			}
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
 	}
 	return result
 }

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -147,7 +147,7 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 
 func newResponsesWebSocketSession(conn *websocket.Conn, r *http.Request) *responsesWebSocketSession {
 	baseHeaders := make(http.Header)
-	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "OpenAI-Beta"} {
+	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "OpenAI-Beta", "session_id", "X-Client-Request-Id"} {
 		for _, value := range r.Header.Values(name) {
 			baseHeaders.Add(name, value)
 		}
@@ -580,16 +580,6 @@ func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader, heade
 		})
 	}
 
-	// Emit rate-limit headers as a codex.rate_limits frame. The Codex CLI
-	// only parses rate limits from frames with type=codex.rate_limits (the
-	// frame loop and parse_rate_limit_event both guard on this type).
-	if rateLimitHeaders := responsesWebSocketRateLimitHeaders(headers); len(rateLimitHeaders) > 0 {
-		_ = s.writeJSON(map[string]interface{}{
-			"type":    "codex.rate_limits",
-			"headers": rateLimitHeaders,
-		})
-	}
-
 	var responseID string
 	var outputItems []json.RawMessage
 	sawCompleted := false
@@ -758,61 +748,26 @@ func flattenResponsesWebSocketHeaders(headers http.Header) map[string]interface{
 
 // responsesWebSocketMetadataHeaders extracts headers that are meaningful to
 // Codex CLI WebSocket clients via the codex.response.metadata frame. The CLI
-// only parses openai-model from metadata frames (via response_model()); other
-// headers like x-reasoning-included and x-models-etag are only read from the
-// HTTP upgrade response which this proxy cannot influence post-upgrade.
+// parses openai-model from metadata frames using case-insensitive comparison
+// (eq_ignore_ascii_case in response_model()); we use lowercase keys to match
+// the wire format the real OpenAI backend uses.
 func responsesWebSocketMetadataHeaders(headers http.Header) map[string]interface{} {
 	if len(headers) == 0 {
 		return nil
 	}
 
 	result := make(map[string]interface{}, 2)
-	for _, key := range []string{
-		"Openai-Model",
-		"X-Openai-Model",
-	} {
-		if value := headers.Get(key); value != "" {
-			result[key] = value
-		}
+	// Go's Header.Get is case-insensitive, but we store the JSON key in
+	// lowercase to match what the real OpenAI backend sends.
+	if value := headers.Get("Openai-Model"); value != "" {
+		result["openai-model"] = value
+	}
+	if value := headers.Get("X-Openai-Model"); value != "" {
+		result["x-openai-model"] = value
 	}
 
 	if len(result) == 0 {
 		return nil
-	}
-	return result
-}
-
-// responsesWebSocketRateLimitHeaders extracts x-codex-* rate-limit headers
-// from upstream response headers and formats them for a codex.rate_limits
-// frame. The Codex CLI only parses rate limits from frames with
-// type=codex.rate_limits (double-guarded in the frame loop and in
-// parse_rate_limit_event), so these must be emitted as a separate frame.
-// Non-rate-limit headers that share the x-codex- prefix (like
-// X-Codex-Turn-State and X-Codex-Beta-Features) are excluded.
-func responsesWebSocketRateLimitHeaders(headers http.Header) map[string]interface{} {
-	if len(headers) == 0 {
-		return nil
-	}
-
-	var result map[string]interface{}
-	for key, values := range headers {
-		canonical := http.CanonicalHeaderKey(key)
-		lower := strings.ToLower(canonical)
-		if !strings.HasPrefix(lower, "x-codex-") {
-			continue
-		}
-		// Skip non-rate-limit headers that share the x-codex- prefix.
-		if lower == "x-codex-turn-state" || lower == "x-codex-beta-features" || lower == "x-codex-turn-metadata" {
-			continue
-		}
-		if result == nil {
-			result = make(map[string]interface{}, 4)
-		}
-		if len(values) == 1 {
-			result[canonical] = values[0]
-		} else if len(values) > 1 {
-			result[canonical] = strings.Join(values, ", ")
-		}
 	}
 	return result
 }

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -570,13 +570,23 @@ func (s *responsesWebSocketSession) logRequestMetrics(h *ProxyHandler, request *
 }
 
 func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader, headers http.Header) (string, []json.RawMessage, error) {
-	// Emit a synthetic metadata event with upstream response headers so
-	// WebSocket clients can read openai-model, x-reasoning-included, rate
-	// limit headers, etc. that would otherwise be lost in the HTTP→WS bridge.
+	// Emit a synthetic metadata event so WebSocket clients can discover the
+	// actual model used. The Codex CLI parses openai-model from
+	// codex.response.metadata frames via response_model().
 	if mappedHeaders := responsesWebSocketMetadataHeaders(headers); len(mappedHeaders) > 0 {
 		_ = s.writeJSON(map[string]interface{}{
 			"type":    "codex.response.metadata",
 			"headers": mappedHeaders,
+		})
+	}
+
+	// Emit rate-limit headers as a codex.rate_limits frame. The Codex CLI
+	// only parses rate limits from frames with type=codex.rate_limits (the
+	// frame loop and parse_rate_limit_event both guard on this type).
+	if rateLimitHeaders := responsesWebSocketRateLimitHeaders(headers); len(rateLimitHeaders) > 0 {
+		_ = s.writeJSON(map[string]interface{}{
+			"type":    "codex.rate_limits",
+			"headers": rateLimitHeaders,
 		})
 	}
 
@@ -747,44 +757,62 @@ func flattenResponsesWebSocketHeaders(headers http.Header) map[string]interface{
 }
 
 // responsesWebSocketMetadataHeaders extracts headers that are meaningful to
-// Codex CLI WebSocket clients. Only headers the client actively reads are
-// included so that generic HTTP headers (Content-Type, Date, etc.) don't
-// produce spurious metadata frames.
+// Codex CLI WebSocket clients via the codex.response.metadata frame. The CLI
+// only parses openai-model from metadata frames (via response_model()); other
+// headers like x-reasoning-included and x-models-etag are only read from the
+// HTTP upgrade response which this proxy cannot influence post-upgrade.
 func responsesWebSocketMetadataHeaders(headers http.Header) map[string]interface{} {
 	if len(headers) == 0 {
 		return nil
 	}
 
-	result := make(map[string]interface{}, 4)
+	result := make(map[string]interface{}, 2)
 	for _, key := range []string{
 		"Openai-Model",
 		"X-Openai-Model",
-		"X-Reasoning-Included",
-		"X-Models-Etag",
-		"X-Codex-Turn-State",
 	} {
 		if value := headers.Get(key); value != "" {
 			result[key] = value
 		}
 	}
 
-	// Include rate-limit headers (x-codex-* prefix pattern).
-	for key, values := range headers {
-		canonical := http.CanonicalHeaderKey(key)
-		if strings.HasPrefix(strings.ToLower(canonical), "x-codex-") {
-			if _, already := result[canonical]; already {
-				continue
-			}
-			if len(values) == 1 {
-				result[canonical] = values[0]
-			} else if len(values) > 1 {
-				result[canonical] = strings.Join(values, ", ")
-			}
-		}
-	}
-
 	if len(result) == 0 {
 		return nil
+	}
+	return result
+}
+
+// responsesWebSocketRateLimitHeaders extracts x-codex-* rate-limit headers
+// from upstream response headers and formats them for a codex.rate_limits
+// frame. The Codex CLI only parses rate limits from frames with
+// type=codex.rate_limits (double-guarded in the frame loop and in
+// parse_rate_limit_event), so these must be emitted as a separate frame.
+// Non-rate-limit headers that share the x-codex- prefix (like
+// X-Codex-Turn-State and X-Codex-Beta-Features) are excluded.
+func responsesWebSocketRateLimitHeaders(headers http.Header) map[string]interface{} {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	var result map[string]interface{}
+	for key, values := range headers {
+		canonical := http.CanonicalHeaderKey(key)
+		lower := strings.ToLower(canonical)
+		if !strings.HasPrefix(lower, "x-codex-") {
+			continue
+		}
+		// Skip non-rate-limit headers that share the x-codex- prefix.
+		if lower == "x-codex-turn-state" || lower == "x-codex-beta-features" || lower == "x-codex-turn-metadata" {
+			continue
+		}
+		if result == nil {
+			result = make(map[string]interface{}, 4)
+		}
+		if len(values) == 1 {
+			result[canonical] = values[0]
+		} else if len(values) > 1 {
+			result[canonical] = strings.Join(values, ", ")
+		}
 	}
 	return result
 }

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -950,29 +950,42 @@ func TestHandleResponsesWebSocket_RelaysUpstreamHeadersOnSuccess(t *testing.T) {
 		t.Fatalf("failed to write websocket request: %v", err)
 	}
 
-	// First frame should be the synthetic metadata event with upstream headers.
+	// First frame: codex.response.metadata with only openai-model (the only
+	// header the Codex CLI parses from metadata frames).
 	metadata := mustReadWebSocketJSON(t, conn)
 	if metadata["type"] != "codex.response.metadata" {
 		t.Fatalf("expected codex.response.metadata, got %v", metadata["type"])
 	}
-	headers, ok := metadata["headers"].(map[string]interface{})
+	metaHeaders, ok := metadata["headers"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected headers map in metadata, got %T", metadata["headers"])
 	}
-	if got := headers["Openai-Model"]; got != "gpt-5.4-actual" {
+	if got := metaHeaders["Openai-Model"]; got != "gpt-5.4-actual" {
 		t.Fatalf("expected Openai-Model header, got %v", got)
 	}
-	if got := headers["X-Reasoning-Included"]; got != "true" {
-		t.Fatalf("expected X-Reasoning-Included header, got %v", got)
+	// X-Reasoning-Included and X-Models-Etag should NOT be in the metadata
+	// frame — the Codex CLI only reads them from HTTP upgrade headers.
+	if _, found := metaHeaders["X-Reasoning-Included"]; found {
+		t.Fatalf("X-Reasoning-Included should not be in metadata frame")
 	}
-	if got := headers["X-Models-Etag"]; got != `"models-v42"` {
-		t.Fatalf("expected X-Models-Etag header, got %v", got)
+	if _, found := metaHeaders["X-Models-Etag"]; found {
+		t.Fatalf("X-Models-Etag should not be in metadata frame")
 	}
-	if got := headers["X-Codex-Primary-Used-Percent"]; got != "42.5" {
+
+	// Second frame: codex.rate_limits with rate-limit headers.
+	rateLimits := mustReadWebSocketJSON(t, conn)
+	if rateLimits["type"] != "codex.rate_limits" {
+		t.Fatalf("expected codex.rate_limits, got %v", rateLimits["type"])
+	}
+	rlHeaders, ok := rateLimits["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected headers map in rate_limits, got %T", rateLimits["headers"])
+	}
+	if got := rlHeaders["X-Codex-Primary-Used-Percent"]; got != "42.5" {
 		t.Fatalf("expected X-Codex-Primary-Used-Percent header, got %v", got)
 	}
 
-	// Next events are the normal SSE stream.
+	// Remaining frames are the normal SSE stream.
 	created := mustReadWebSocketJSON(t, conn)
 	if created["type"] != "response.created" {
 		t.Fatalf("expected response.created, got %v", created["type"])

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -633,7 +633,7 @@ func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInputAndIgn
 		t.Fatalf("failed to write first request: %v", err)
 	}
 
-	firstCreated := mustReadWebSocketJSON(t, conn)
+	firstCreated := mustReadWebSocketJSONSkipMetadata(t, conn)
 	_ = mustReadWebSocketJSON(t, conn)
 	_ = mustReadWebSocketJSON(t, conn)
 
@@ -654,7 +654,7 @@ func TestHandleResponsesWebSocket_TurnStateDeltaReplayUsesOnlyCurrentInputAndIgn
 		t.Fatalf("failed to write second request: %v", err)
 	}
 
-	_ = mustReadWebSocketJSON(t, conn)
+	_ = mustReadWebSocketJSONSkipMetadata(t, conn)
 	_ = mustReadWebSocketJSON(t, conn)
 
 	if len(upstreamRequests) != 2 {
@@ -730,7 +730,7 @@ func TestHandleResponsesWebSocket_TurnStateDeltaFallsBackToFullReplay(t *testing
 		t.Fatalf("failed to write first request: %v", err)
 	}
 
-	firstCreated := mustReadWebSocketJSON(t, conn)
+	firstCreated := mustReadWebSocketJSONSkipMetadata(t, conn)
 	_ = mustReadWebSocketJSON(t, conn)
 	_ = mustReadWebSocketJSON(t, conn)
 
@@ -748,7 +748,7 @@ func TestHandleResponsesWebSocket_TurnStateDeltaFallsBackToFullReplay(t *testing
 		t.Fatalf("failed to write second request: %v", err)
 	}
 
-	created := mustReadWebSocketJSON(t, conn)
+	created := mustReadWebSocketJSONSkipMetadata(t, conn)
 	completed := mustReadWebSocketJSON(t, conn)
 	if created["type"] != "response.created" {
 		t.Fatalf("expected fallback response.created event, got %v", created["type"])
@@ -770,6 +770,252 @@ func TestHandleResponsesWebSocket_TurnStateDeltaFallsBackToFullReplay(t *testing
 	}
 	if got := inputTextFromMessage(t, fallbackInput[2]); got != "follow up" {
 		t.Fatalf("expected fallback replay to include latest user turn, got %q", got)
+	}
+}
+
+func TestHandleResponsesWebSocket_ResponseFailedIsTerminal(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-fail\"}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-fail\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"context too long\"}}}\n\n")
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	// Should receive the response.created event.
+	created := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected response.created, got %v", created["type"])
+	}
+
+	// Should receive the response.failed event relayed from upstream.
+	failed := mustReadWebSocketJSON(t, conn)
+	if failed["type"] != "response.failed" {
+		t.Fatalf("expected response.failed, got %v", failed["type"])
+	}
+
+	// The connection should close without a proxy-generated error frame.
+	// If the proxy sent a second error, we'd read it here.
+	if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatalf("expected connection to close after response.failed, but got another message")
+	}
+}
+
+func TestHandleResponsesWebSocket_ResponseIncompleteIsTerminal(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-inc\"}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.incomplete\ndata: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp-inc\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n\n")
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	created := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected response.created, got %v", created["type"])
+	}
+
+	incomplete := mustReadWebSocketJSON(t, conn)
+	if incomplete["type"] != "response.incomplete" {
+		t.Fatalf("expected response.incomplete, got %v", incomplete["type"])
+	}
+
+	// No proxy-generated error frame should follow.
+	if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatalf("expected connection to close after response.incomplete, but got another message")
+	}
+}
+
+func TestHandleResponsesWebSocket_ResponseFailedExitsImmediatelyOnStalledUpstream(t *testing.T) {
+	// Regression test: if upstream emits response.failed and then stalls
+	// (keeps the body open), the proxy should exit the SSE loop immediately
+	// rather than blocking until EOF or the 60-minute timeout.
+	stallReleased := make(chan struct{})
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-stall\"}}\n\n")
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-stall\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"context too long\"}}}\n\n")
+		flusher.Flush()
+		// Stall: keep the body open until the test signals release.
+		<-stallReleased
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() {
+		_ = conn.Close()
+		close(stallReleased)
+	}()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	created := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected response.created, got %v", created["type"])
+	}
+
+	failed := mustReadWebSocketJSON(t, conn)
+	if failed["type"] != "response.failed" {
+		t.Fatalf("expected response.failed, got %v", failed["type"])
+	}
+
+	// The connection should close promptly without waiting for upstream EOF.
+	// Use a tight deadline: if the proxy blocked on the stalled body, this
+	// would time out at 2 seconds (mustReadWebSocketJSON's deadline).
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatalf("expected connection to close after response.failed on stalled upstream, but got another message")
+	}
+}
+
+func TestHandleResponsesWebSocket_RelaysUpstreamHeadersOnSuccess(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Openai-Model", "gpt-5.4-actual")
+		w.Header().Set("X-Reasoning-Included", "true")
+		w.Header().Set("X-Models-Etag", `"models-v42"`)
+		w.Header().Set("X-Codex-Primary-Used-Percent", "42.5")
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-headers\"}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-headers\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	// First frame should be the synthetic metadata event with upstream headers.
+	metadata := mustReadWebSocketJSON(t, conn)
+	if metadata["type"] != "codex.response.metadata" {
+		t.Fatalf("expected codex.response.metadata, got %v", metadata["type"])
+	}
+	headers, ok := metadata["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected headers map in metadata, got %T", metadata["headers"])
+	}
+	if got := headers["Openai-Model"]; got != "gpt-5.4-actual" {
+		t.Fatalf("expected Openai-Model header, got %v", got)
+	}
+	if got := headers["X-Reasoning-Included"]; got != "true" {
+		t.Fatalf("expected X-Reasoning-Included header, got %v", got)
+	}
+	if got := headers["X-Models-Etag"]; got != `"models-v42"` {
+		t.Fatalf("expected X-Models-Etag header, got %v", got)
+	}
+	if got := headers["X-Codex-Primary-Used-Percent"]; got != "42.5" {
+		t.Fatalf("expected X-Codex-Primary-Used-Percent header, got %v", got)
+	}
+
+	// Next events are the normal SSE stream.
+	created := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected response.created, got %v", created["type"])
+	}
+	completed := mustReadWebSocketJSON(t, conn)
+	if completed["type"] != "response.completed" {
+		t.Fatalf("expected response.completed, got %v", completed["type"])
+	}
+}
+
+func TestHandleResponsesWebSocket_ForwardsOpenAIBetaHeader(t *testing.T) {
+	var gotOpenAIBeta string
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		gotOpenAIBeta = r.Header.Get("OpenAI-Beta")
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-beta\"}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-beta\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, http.Header{
+		"OpenAI-Beta": []string{"responses_websockets=2026-02-06"},
+	})
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	_ = mustReadWebSocketJSON(t, conn) // response.created
+	_ = mustReadWebSocketJSON(t, conn) // response.completed
+
+	if gotOpenAIBeta != "responses_websockets=2026-02-06" {
+		t.Fatalf("expected OpenAI-Beta header to be forwarded upstream, got %q", gotOpenAIBeta)
 	}
 }
 
@@ -806,6 +1052,18 @@ func mustReadWebSocketJSON(t *testing.T, conn *websocket.Conn) map[string]interf
 		t.Fatalf("failed to decode websocket payload %s: %v", string(data), err)
 	}
 	return payload
+}
+
+// mustReadWebSocketJSONSkipMetadata reads the next WebSocket frame, skipping
+// over any synthetic codex.response.metadata frames injected by the proxy.
+func mustReadWebSocketJSONSkipMetadata(t *testing.T, conn *websocket.Conn) map[string]interface{} {
+	t.Helper()
+	for {
+		payload := mustReadWebSocketJSON(t, conn)
+		if payload["type"] != "codex.response.metadata" {
+			return payload
+		}
+	}
 }
 
 func newResponsesWebSocketCreateRequest(input []interface{}) map[string]interface{} {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -950,8 +950,9 @@ func TestHandleResponsesWebSocket_RelaysUpstreamHeadersOnSuccess(t *testing.T) {
 		t.Fatalf("failed to write websocket request: %v", err)
 	}
 
-	// First frame: codex.response.metadata with only openai-model (the only
-	// header the Codex CLI parses from metadata frames).
+	// First frame: codex.response.metadata with openai-model in lowercase
+	// (the only header the Codex CLI parses from metadata frames via
+	// response_model() using case-insensitive comparison).
 	metadata := mustReadWebSocketJSON(t, conn)
 	if metadata["type"] != "codex.response.metadata" {
 		t.Fatalf("expected codex.response.metadata, got %v", metadata["type"])
@@ -960,8 +961,8 @@ func TestHandleResponsesWebSocket_RelaysUpstreamHeadersOnSuccess(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected headers map in metadata, got %T", metadata["headers"])
 	}
-	if got := metaHeaders["Openai-Model"]; got != "gpt-5.4-actual" {
-		t.Fatalf("expected Openai-Model header, got %v", got)
+	if got := metaHeaders["openai-model"]; got != "gpt-5.4-actual" {
+		t.Fatalf("expected openai-model header, got %v", got)
 	}
 	// X-Reasoning-Included and X-Models-Etag should NOT be in the metadata
 	// frame — the Codex CLI only reads them from HTTP upgrade headers.
@@ -970,19 +971,6 @@ func TestHandleResponsesWebSocket_RelaysUpstreamHeadersOnSuccess(t *testing.T) {
 	}
 	if _, found := metaHeaders["X-Models-Etag"]; found {
 		t.Fatalf("X-Models-Etag should not be in metadata frame")
-	}
-
-	// Second frame: codex.rate_limits with rate-limit headers.
-	rateLimits := mustReadWebSocketJSON(t, conn)
-	if rateLimits["type"] != "codex.rate_limits" {
-		t.Fatalf("expected codex.rate_limits, got %v", rateLimits["type"])
-	}
-	rlHeaders, ok := rateLimits["headers"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected headers map in rate_limits, got %T", rateLimits["headers"])
-	}
-	if got := rlHeaders["X-Codex-Primary-Used-Percent"]; got != "42.5" {
-		t.Fatalf("expected X-Codex-Primary-Used-Percent header, got %v", got)
 	}
 
 	// Remaining frames are the normal SSE stream.
@@ -1029,6 +1017,47 @@ func TestHandleResponsesWebSocket_ForwardsOpenAIBetaHeader(t *testing.T) {
 
 	if gotOpenAIBeta != "responses_websockets=2026-02-06" {
 		t.Fatalf("expected OpenAI-Beta header to be forwarded upstream, got %q", gotOpenAIBeta)
+	}
+}
+
+func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *testing.T) {
+	var gotSessionID, gotClientRequestID string
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		gotSessionID = r.Header.Get("session_id")
+		gotClientRequestID = r.Header.Get("X-Client-Request-Id")
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-sess\"}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-sess\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, http.Header{
+		"session_id":           []string{"conv-123"},
+		"X-Client-Request-Id": []string{"req-456"},
+	})
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	_ = mustReadWebSocketJSON(t, conn) // response.created
+	_ = mustReadWebSocketJSON(t, conn) // response.completed
+
+	if gotSessionID != "conv-123" {
+		t.Fatalf("expected session_id to be forwarded upstream, got %q", gotSessionID)
+	}
+	if gotClientRequestID != "req-456" {
+		t.Fatalf("expected X-Client-Request-Id to be forwarded upstream, got %q", gotClientRequestID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Improves compatibility with the [OpenAI Codex CLI](https://github.com/openai/codex) by fixing several gaps in the WebSocket and Responses API paths, identified through deep analysis of the Codex CLI Rust codebase and validated through multiple rounds of adversarial review.

### WebSocket terminal event handling
- Handle `response.failed` and `response.incomplete` as terminal SSE events, returning a sentinel error from the callback to break the scanner loop **immediately** instead of waiting for upstream EOF. Prevents double error delivery and avoids hanging up to 60 minutes on stalled upstreams.

### WebSocket model header relay
- Emit `codex.response.metadata` frames with `openai-model` (lowercase keys) on the WebSocket success path. This is the only header the Codex CLI parses from metadata frames, via `response_model()` which uses `eq_ignore_ascii_case`.
- Do NOT include `x-reasoning-included` or `x-models-etag` — the CLI only reads these from HTTP upgrade response headers in `connect_websocket()`, not from WebSocket frames.
- Do NOT synthesize `codex.rate_limits` frames from HTTP response headers — `parse_rate_limit_event` expects structured JSON fields (`rate_limits.primary.used_percent`), not HTTP header name keys. Real `codex.rate_limits` SSE events from upstream pass through verbatim.

### WebSocket compression
- Enable `permessage-deflate` compression on the WebSocket upgrader.

### Header forwarding
- Forward `OpenAI-Beta` header to upstream on both WebSocket and HTTP POST paths.
- Forward `session_id` (underscore, matching the Codex CLI's `build_conversation_headers` wire format) and `X-Client-Request-Id` on both WebSocket (base headers) and HTTP POST (extra headers) paths.
- Forward `X-OpenAI-Subagent` from WebSocket upgrade headers as a default, overridable per-turn via `client_metadata` `ws_request_header_x-openai-subagent`. Brings parity with the HTTP POST path.
- Preserve multi-valued headers using `Header.Values`/`Header.Add` instead of `Header.Get`/`Header.Set`.

## Test plan

- [x] `make test` — all existing + 8 new tests pass
- [x] `make vet` — clean
- [x] `make build` — binary builds
- [x] New tests:
  - `TestHandleResponsesWebSocket_ResponseFailedIsTerminal` — no double error frame
  - `TestHandleResponsesWebSocket_ResponseIncompleteIsTerminal` — same for incomplete
  - `TestHandleResponsesWebSocket_ResponseFailedExitsImmediatelyOnStalledUpstream` — regression test with intentionally stalled upstream (0.00s, not 60min)
  - `TestHandleResponsesWebSocket_RelaysUpstreamHeadersOnSuccess` — metadata frame with lowercase `openai-model`, no `x-reasoning-included`/`x-models-etag`
  - `TestHandleResponsesWebSocket_ForwardsOpenAIBetaHeader` — WS path forwarding
  - `TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders` — WS path `session_id` (underscore) and `X-Client-Request-Id` forwarding
  - `TestHandleResponses_ForwardsCodexClientHeaders` — HTTP path header forwarding