### PR TITLE
Use short git SHA for dev version instead of 0.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY := copilot-proxy
 LDFLAGS := -s -w
 APP_NAME := Copilot Proxy.app
 APP_BUNDLE_ID := com.copilot-proxy.menubar
-VERSION ?= 0.0.0
+VERSION ?= dev-$(shell git rev-parse --short HEAD)
 APP_VERSION := $(patsubst v%,%,$(VERSION))
 
 .PHONY: build build-app test vet lint clean docker-build


### PR DESCRIPTION
## Summary
- Replace the default `VERSION ?= 0.0.0` in the Makefile with `VERSION ?= dev-$(shell git rev-parse --short HEAD)`
- Dev builds now show a meaningful version like `dev-8dc758f` in the menubar app and app bundle plist, instead of the placeholder `0.0.0`
- Release builds that explicitly set `VERSION` (e.g. `VERSION=v1.2.3`) are unaffected

## Test plan
- [ ] Run `make -n build-app` and verify the `-X main.buildVersion=dev-<sha>` flag is present
- [ ] Run `make build-app VERSION=v1.2.3` and verify it still uses `1.2.3`