### PR TITLE
switch releases to goreleaser and publish Homebrew cask

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.2
           only-new-issues: true
@@ -28,9 +28,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -40,9 +40,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, build, test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/live-copilot-smoke.yaml
+++ b/.github/workflows/live-copilot-smoke.yaml
@@ -48,15 +48,15 @@ jobs:
         if: steps.gate.outputs.run != 'true'
         run: echo "${{ steps.gate.outputs.reason }}"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.gate.outputs.run == 'true'
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.gate.outputs.run == 'true'
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         if: steps.gate.outputs.run == 'true'
         with:
           node-version: 20

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,11 +12,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -24,7 +24,7 @@ jobs:
         run: make test
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -38,9 +38,9 @@ jobs:
     outputs:
       app_sha256: ${{ steps.sha256.outputs.value }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -63,16 +63,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -83,7 +83,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [macos-app, finalize-release]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Require tap publishing token
         env:
@@ -117,7 +117,7 @@ jobs:
           fi
 
       - name: Checkout Homebrew tap repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: sozercan/homebrew-repo
           token: ${{ secrets.HOMEBREW_REPO_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
@@ -21,26 +23,20 @@ jobs:
       - name: Test
         run: make test
 
-      - name: Build binaries
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          for GOOS in linux darwin; do
-            for GOARCH in amd64 arm64; do
-              OUTPUT="vekil-${GOOS}-${GOARCH}"
-              echo "Building ${OUTPUT}..."
-              CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags="-s -w" -o ${OUTPUT} .
-            done
-          done
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
         with:
-          generate_release_notes: true
-          files: vekil-*
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   macos-app:
     runs-on: macos-26
     needs: release
+    outputs:
+      app_sha256: ${{ steps.sha256.outputs.value }}
     steps:
       - uses: actions/checkout@v6
 
@@ -51,13 +47,17 @@ jobs:
       - name: Build macOS menubar app
         run: VERSION=${GITHUB_REF#refs/tags/} GOARCH=arm64 make build-app
 
-      - name: Zip app bundle
-        run: zip -r "vekil-macos-arm64.zip" "Vekil.app"
+      - name: Archive app bundle
+        run: ditto -c -k --sequesterRsrc --keepParent "Vekil.app" "vekil-macos-arm64.zip"
 
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: "vekil-macos-arm64.zip"
+      - name: Upload app bundle to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF#refs/tags/}" "vekil-macos-arm64.zip" --clobber
+
+      - name: Calculate macOS app SHA256
+        id: sha256
+        run: echo "value=$(shasum -a 256 vekil-macos-arm64.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
   publish:
     runs-on: ubuntu-latest
@@ -91,3 +91,48 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}
             ghcr.io/${{ github.repository }}:latest
+
+  finalize-release:
+    runs-on: ubuntu-latest
+    needs: [macos-app, publish]
+    steps:
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${GITHUB_REF#refs/tags/}" --draft=false
+
+  homebrew-cask:
+    runs-on: ubuntu-latest
+    needs: [macos-app, finalize-release]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Require tap publishing token
+        env:
+          HOMEBREW_REPO_TOKEN: ${{ secrets.HOMEBREW_REPO_TOKEN }}
+        run: |
+          if [ -z "$HOMEBREW_REPO_TOKEN" ]; then
+            echo "HOMEBREW_REPO_TOKEN is required to publish the Homebrew cask" >&2
+            exit 1
+          fi
+
+      - name: Checkout Homebrew tap repo
+        uses: actions/checkout@v6
+        with:
+          repository: sozercan/homebrew-repo
+          token: ${{ secrets.HOMEBREW_REPO_TOKEN }}
+          path: homebrew-repo
+
+      - name: Update Homebrew cask
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          ./scripts/publish-homebrew-cask.sh "$VERSION" "${{ needs.macos-app.outputs.app_sha256 }}" homebrew-repo
+
+      - name: Commit and push Homebrew cask
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          git -C homebrew-repo config user.name "github-actions[bot]"
+          git -C homebrew-repo config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C homebrew-repo add Casks/vekil.rb
+          git -C homebrew-repo diff --cached --quiet || git -C homebrew-repo commit -m "Update vekil to ${TAG}"
+          git -C homebrew-repo push origin main

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+version: 2
+
+project_name: vekil
+
+builds:
+  - id: vekil
+    main: .
+    binary: vekil
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -s -w
+
+archives:
+  - id: binaries
+    ids:
+      - vekil
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    formats:
+      - binary
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: sozercan
+    name: vekil
+  draft: true
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ On Apple Silicon Macs, you can also use the native menubar app.
 brew install --cask sozercan/repo/vekil
 ```
 
-If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.
+macOS will add quarantine-style attributes to the app. Clear them with `xattr -cr /Applications/Vekil.app`.
 
 Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/vekil:latest
 ```
 
-On Apple Silicon Macs, you can also use the native menubar app instead of keeping a terminal open:
+On Apple Silicon Macs, you can also use the native menubar app.
 
 ```bash
-brew tap sozercan/repo
-brew install --cask vekil
+brew tap sozercan/repo && brew install --cask vekil
 ```
+
+If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.
 
 Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/vekil:latest
 ```
 
-On Apple Silicon Macs, you can also use the native menubar app instead of keeping a terminal open. Download `vekil-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest), unzip it, and open `Vekil.app`. See [macOS Menubar App](docs/menubar.md).
+On Apple Silicon Macs, you can also use the native menubar app instead of keeping a terminal open:
+
+```bash
+brew tap sozercan/repo
+brew install --cask vekil
+```
+
+Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
 
 On first run, authenticate with GitHub's device code flow. Tokens are cached in `~/.config/vekil/`.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ On Apple Silicon Macs, you can also use the native menubar app.
 brew install --cask sozercan/repo/vekil
 ```
 
-macOS will add quarantine-style attributes to the app. Clear them with `xattr -cr /Applications/Vekil.app`.
+> **Note:** The app is not signed.
+> Clear extended attributes, including quarantine, with:
+> ```bash
+> xattr -cr /Applications/Vekil.app
+> ```
 
 Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run -p 1337:1337 \
 On Apple Silicon Macs, you can also use the native menubar app.
 
 ```bash
-brew tap sozercan/repo && brew install --cask vekil
+brew install --cask sozercan/repo/vekil
 ```
 
 If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,6 +35,18 @@ make lint
 
 GitHub Actions in `.github/workflows/ci.yaml` runs lint, tests, build, vet, and e2e validation before merge.
 
+## Release
+
+Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) now use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases.
+
+The same release workflow also:
+
+- builds `vekil-macos-arm64.zip` on a macOS runner and uploads it to the tagged release
+- updates the `vekil` cask in `sozercan/homebrew-repo`
+- pushes the multi-arch container image to GHCR
+
+To publish the Homebrew cask, configure the repository secret `HOMEBREW_REPO_TOKEN` with push access to `sozercan/homebrew-repo`.
+
 ## Manual Live Smoke Workflow
 
 The repository also includes a manual `Live Copilot Smoke` workflow in [`.github/workflows/live-copilot-smoke.yaml`](../.github/workflows/live-copilot-smoke.yaml).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ On Apple Silicon Macs, you can use the native menubar app:
 brew install --cask sozercan/repo/vekil
 ```
 
-If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.
+macOS will add quarantine-style attributes to the app. Clear them with `xattr -cr /Applications/Vekil.app`.
 
 GitHub Releases also includes a `vekil-macos-arm64.zip` menubar app bundle if you prefer a manual download.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,11 @@ On Apple Silicon Macs, you can use the native menubar app:
 brew install --cask sozercan/repo/vekil
 ```
 
-macOS will add quarantine-style attributes to the app. Clear them with `xattr -cr /Applications/Vekil.app`.
+> **Note:** The app is not signed.
+> Clear extended attributes, including quarantine, with:
+> ```bash
+> xattr -cr /Applications/Vekil.app
+> ```
 
 GitHub Releases also includes a `vekil-macos-arm64.zip` menubar app bundle if you prefer a manual download.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,12 +6,13 @@ Download the latest binary for your platform from [GitHub Releases](https://gith
 
 Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. After downloading, make the binary executable if needed and run it locally.
 
-On Apple Silicon Macs, you can install the native menubar app from the Homebrew tap:
+On Apple Silicon Macs, you can use the native menubar app:
 
 ```bash
-brew tap sozercan/repo
-brew install --cask vekil
+brew tap sozercan/repo && brew install --cask vekil
 ```
+
+If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.
 
 GitHub Releases also includes a `vekil-macos-arm64.zip` menubar app bundle if you prefer a manual download.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64
 On Apple Silicon Macs, you can use the native menubar app:
 
 ```bash
-brew tap sozercan/repo && brew install --cask vekil
+brew install --cask sozercan/repo/vekil
 ```
 
 If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,14 @@ Download the latest binary for your platform from [GitHub Releases](https://gith
 
 Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. After downloading, make the binary executable if needed and run it locally.
 
-On Apple Silicon Macs, GitHub Releases also includes a `vekil-macos-arm64.zip` menubar app bundle if you prefer a native app instead of the CLI binary.
+On Apple Silicon Macs, you can install the native menubar app from the Homebrew tap:
+
+```bash
+brew tap sozercan/repo
+brew install --cask vekil
+```
+
+GitHub Releases also includes a `vekil-macos-arm64.zip` menubar app bundle if you prefer a manual download.
 
 ## Build From Source
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -7,7 +7,7 @@ The repo includes a native macOS menubar app for running the proxy without keepi
 Install the menubar app from Homebrew:
 
 ```bash
-brew tap sozercan/repo && brew install --cask vekil
+brew install --cask sozercan/repo/vekil
 ```
 
 If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -10,7 +10,11 @@ Install the menubar app from Homebrew:
 brew install --cask sozercan/repo/vekil
 ```
 
-macOS will add quarantine-style attributes to the app. Clear them with `xattr -cr /Applications/Vekil.app`.
+> **Note:** The app is not signed.
+> Clear extended attributes, including quarantine, with:
+> ```bash
+> xattr -cr /Applications/Vekil.app
+> ```
 
 Or download `vekil-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest), unzip it, and open `Vekil.app`.
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -7,9 +7,10 @@ The repo includes a native macOS menubar app for running the proxy without keepi
 Install the menubar app from Homebrew:
 
 ```bash
-brew tap sozercan/repo
-brew install --cask vekil
+brew tap sozercan/repo && brew install --cask vekil
 ```
+
+If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.
 
 Or download `vekil-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest), unzip it, and open `Vekil.app`.
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -10,7 +10,7 @@ Install the menubar app from Homebrew:
 brew install --cask sozercan/repo/vekil
 ```
 
-If macOS adds quarantine-style attributes, clear them with `xattr -cr /Applications/Vekil.app`.
+macOS will add quarantine-style attributes to the app. Clear them with `xattr -cr /Applications/Vekil.app`.
 
 Or download `vekil-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest), unzip it, and open `Vekil.app`.
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -4,7 +4,14 @@ The repo includes a native macOS menubar app for running the proxy without keepi
 
 ## Download And Run
 
-Download `vekil-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest), unzip it, and open `Vekil.app`.
+Install the menubar app from Homebrew:
+
+```bash
+brew tap sozercan/repo
+brew install --cask vekil
+```
+
+Or download `vekil-macos-arm64.zip` from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest), unzip it, and open `Vekil.app`.
 
 The published app bundle is currently available for Apple Silicon (`arm64`). On Intel Macs, build the app from source instead.
 

--- a/scripts/publish-homebrew-cask.sh
+++ b/scripts/publish-homebrew-cask.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <version> <sha256> <tap-dir>" >&2
+  exit 1
+fi
+
+version="$1"
+sha256="$2"
+tap_dir="$3"
+cask_path="${tap_dir}/Casks/vekil.rb"
+
+mkdir -p "$(dirname "$cask_path")"
+
+cat >"$cask_path" <<EOF
+cask "vekil" do
+  version "$version"
+  sha256 "$sha256"
+
+  url "https://github.com/sozercan/vekil/releases/download/v#{version}/vekil-macos-arm64.zip"
+  name "Vekil"
+  desc "Proxy Anthropic, Gemini, and OpenAI clients through GitHub Copilot"
+  homepage "https://github.com/sozercan/vekil"
+
+  depends_on arch: :arm64
+
+  app "Vekil.app"
+
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Vekil.app"], sudo: false
+  end
+
+  zap trash: [
+    "~/.config/vekil",
+    "~/Library/LaunchAgents/com.vekil.menubar.plist",
+  ]
+end
+EOF


### PR DESCRIPTION
## What changed

This switches tagged releases from the hand-written GitHub Actions build steps to GoReleaser for the CLI artifacts and release metadata.

It also adds a dedicated macOS app publishing path that:
- builds and uploads `vekil-macos-arm64.zip`
- publishes the release in a way that works with GitHub release immutability
- updates the `vekil` cask in `sozercan/homebrew-repo`

## Why it changed

The previous flow created a published release first and then tried to upload the macOS asset afterward. GitHub now rejects that pattern when release immutability is enabled, which is what caused the `v0.8.0` macOS asset upload to fail.

The new flow creates the release as a draft, uploads all assets while it is still mutable, then publishes it and updates the tap.

## Impact

- CLI release assets are now produced by GoReleaser with checksums.
- The macOS menubar app can be installed from Homebrew via `sozercan/repo`.
- Tagged releases are compatible with GitHub's immutable release model.
- Release documentation now reflects the Homebrew cask install path and the required `HOMEBREW_REPO_TOKEN` secret.

## Validation

- `goreleaser check`
- `make test`
- `VERSION=v0.8.0 GOARCH=arm64 make build-app`
- generated cask Ruby syntax check
- workflow and GoReleaser YAML parse checks
