### PR TITLE
reintroduce Sparkle updater support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,20 +44,45 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Require Sparkle keys
+        env:
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PUBLIC_ED_KEY" ] || [ -z "$SPARKLE_PRIVATE_ED_KEY" ]; then
+            echo "SPARKLE_PUBLIC_ED_KEY and SPARKLE_PRIVATE_ED_KEY are required to publish Sparkle updates" >&2
+            exit 1
+          fi
+
       - name: Build macOS menubar app
+        env:
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
         run: VERSION=${GITHUB_REF#refs/tags/} GOARCH=arm64 make build-app
 
       - name: Archive app bundle
-        run: ditto -c -k --sequesterRsrc --keepParent "Vekil.app" "vekil-macos-arm64.zip"
+        run: |
+          mkdir -p dist/macos-release
+          ditto -c -k --sequesterRsrc --keepParent "Vekil.app" dist/macos-release/"vekil-macos-arm64.zip"
 
-      - name: Upload app bundle to release
+      - name: Generate Sparkle appcast
+        env:
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | .build/sparkle/unpacked/bin/generate_appcast \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/" \
+            --full-release-notes-url "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}" \
+            --maximum-deltas 0 \
+            dist/macos-release
+
+      - name: Upload macOS updater assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" "vekil-macos-arm64.zip" --clobber
+        run: gh release upload "${GITHUB_REF#refs/tags/}" dist/macos-release/vekil-macos-arm64.zip dist/macos-release/appcast.xml --clobber
 
       - name: Calculate macOS app SHA256
         id: sha256
-        run: echo "value=$(shasum -a 256 vekil-macos-arm64.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(shasum -a 256 dist/macos-release/vekil-macos-arm64.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
   publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vekil
 Vekil.app/
+.build/
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,37 @@ APP_NAME := Vekil.app
 APP_BUNDLE_ID := com.vekil.menubar
 VERSION ?= dev-$(shell git rev-parse --short HEAD)
 APP_VERSION := $(patsubst v%,%,$(VERSION))
+SPARKLE_VERSION := 2.9.0
+SPARKLE_BUILD_DIR := .build/sparkle
+SPARKLE_ARCHIVE := $(SPARKLE_BUILD_DIR)/Sparkle-$(SPARKLE_VERSION).tar.xz
+SPARKLE_UNPACK_DIR := $(SPARKLE_BUILD_DIR)/unpacked
+SPARKLE_FRAMEWORK := $(SPARKLE_UNPACK_DIR)/Sparkle.framework
+SPARKLE_DOWNLOAD_URL := https://github.com/sparkle-project/Sparkle/releases/download/$(SPARKLE_VERSION)/Sparkle-$(SPARKLE_VERSION).tar.xz
+SPARKLE_FEED_URL ?= https://github.com/sozercan/vekil/releases/latest/download/appcast.xml
+SPARKLE_PUBLIC_ED_KEY ?=
 
 .PHONY: build build-app test vet lint clean docker-build
 
 build:
 	go build -ldflags="$(LDFLAGS)" -o $(BINARY) .
 
-build-app:
+$(SPARKLE_ARCHIVE):
+	@mkdir -p "$(SPARKLE_BUILD_DIR)"
+	curl -fL "$(SPARKLE_DOWNLOAD_URL)" -o "$(SPARKLE_ARCHIVE)"
+
+$(SPARKLE_FRAMEWORK): $(SPARKLE_ARCHIVE)
+	@rm -rf "$(SPARKLE_UNPACK_DIR)"
+	@mkdir -p "$(SPARKLE_UNPACK_DIR)"
+	tar -xf "$(SPARKLE_ARCHIVE)" -C "$(SPARKLE_UNPACK_DIR)"
+
+build-app: $(SPARKLE_FRAMEWORK)
 	@rm -rf "$(APP_NAME)"
 	@mkdir -p "$(APP_NAME)/Contents/MacOS"
 	@mkdir -p "$(APP_NAME)/Contents/Resources"
-	go build -ldflags="$(LDFLAGS) -X main.buildVersion=$(APP_VERSION)" -o "$(APP_NAME)/Contents/MacOS/vekil-menubar" ./cmd/menubar/
+	@mkdir -p "$(APP_NAME)/Contents/Frameworks"
+	CGO_ENABLED=1 CGO_LDFLAGS="-F$(abspath $(SPARKLE_UNPACK_DIR))" \
+		go build -tags sparkle -ldflags="$(LDFLAGS) -X main.buildVersion=$(APP_VERSION)" -o "$(APP_NAME)/Contents/MacOS/vekil-menubar" ./cmd/menubar/
+	ditto "$(SPARKLE_FRAMEWORK)" "$(APP_NAME)/Contents/Frameworks/Sparkle.framework"
 	@printf '<?xml version="1.0" encoding="UTF-8"?>\n\
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n\
 <plist version="1.0">\n\
@@ -31,10 +51,24 @@ build-app:
 	<string>$(APP_VERSION)</string>\n\
 	<key>CFBundleShortVersionString</key>\n\
 	<string>$(APP_VERSION)</string>\n\
+	<key>LSMinimumSystemVersion</key>\n\
+	<string>10.13</string>\n\
 	<key>LSUIElement</key>\n\
+	<true/>\n\
+	<key>SUEnableInstallerLauncherService</key>\n\
+	<true/>\n\
+	<key>SUFeedURL</key>\n\
+	<string>$(SPARKLE_FEED_URL)</string>\n\
+	<key>SUPublicEDKey</key>\n\
+	<string>$(SPARKLE_PUBLIC_ED_KEY)</string>\n\
+	<key>SURequireSignedFeed</key>\n\
+	<true/>\n\
+	<key>SUVerifyUpdateBeforeExtraction</key>\n\
 	<true/>\n\
 </dict>\n\
 </plist>' > "$(APP_NAME)/Contents/Info.plist"
+	codesign --force --deep --sign - --timestamp=none "$(APP_NAME)"
+	codesign --verify --deep --strict "$(APP_NAME)"
 
 test:
 	go test ./... -count=1
@@ -46,7 +80,7 @@ lint: vet
 
 clean:
 	rm -f $(BINARY)
-	rm -rf "$(APP_NAME)"
+	rm -rf "$(APP_NAME)" .build
 
 docker-build:
 	docker build -t $(BINARY) .

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -61,6 +61,17 @@ func onReady() {
 
 	mAuth = systray.AddMenuItem("Sign In", "Sign in or out of GitHub")
 	systray.AddSeparator()
+
+	var mCheckUpdates *systray.MenuItem
+	if updaterSupported() {
+		mCheckUpdates = systray.AddMenuItem("Check for Updates…", "Check for Vekil updates")
+		if err := startUpdater(); err != nil {
+			log.Error("failed to start updater", logger.Err(err))
+			mCheckUpdates.Disable()
+		}
+		systray.AddSeparator()
+	}
+
 	mQuit := systray.AddMenuItem("Quit", "Quit the application")
 
 	// Set initial UI state based on whether we already have credentials.
@@ -68,6 +79,11 @@ func onReady() {
 		setSignedInUI()
 	} else {
 		setSignedOutUI()
+	}
+
+	var mCheckUpdatesClicked <-chan struct{}
+	if mCheckUpdates != nil {
+		mCheckUpdatesClicked = mCheckUpdates.ClickedCh
 	}
 
 	go func() {
@@ -98,6 +114,11 @@ func onReady() {
 					signOut()
 				} else {
 					go signIn()
+				}
+			case <-mCheckUpdatesClicked:
+				if err := checkForUpdates(); err != nil {
+					log.Error("failed to check for updates", logger.Err(err))
+					showErrorDialog("Update Check Failed", err.Error())
 				}
 			case <-mQuit.ClickedCh:
 				if srv != nil && srv.IsRunning() {

--- a/cmd/menubar/updater_bridge.h
+++ b/cmd/menubar/updater_bridge.h
@@ -1,0 +1,7 @@
+#ifndef VEKIL_UPDATER_BRIDGE_H
+#define VEKIL_UPDATER_BRIDGE_H
+
+char *vekil_updater_start(void);
+char *vekil_updater_check(void);
+
+#endif

--- a/cmd/menubar/updater_bridge_darwin.m
+++ b/cmd/menubar/updater_bridge_darwin.m
@@ -1,0 +1,91 @@
+//go:build darwin && cgo && sparkle
+
+#import "updater_bridge.h"
+
+#import <Cocoa/Cocoa.h>
+#import <dispatch/dispatch.h>
+#include <string.h>
+
+@interface SPUUpdater : NSObject
+
+- (BOOL)startUpdater:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+@end
+
+@interface SPUStandardUpdaterController : NSObject
+
+@property (nonatomic, readonly) SPUUpdater *updater;
+
+- (instancetype)initWithStartingUpdater:(BOOL)startUpdater
+                        updaterDelegate:(id _Nullable)updaterDelegate
+                      userDriverDelegate:(id _Nullable)userDriverDelegate;
+- (IBAction)checkForUpdates:(id _Nullable)sender;
+
+@end
+
+static SPUStandardUpdaterController *vekilUpdaterController = nil;
+static BOOL vekilUpdaterStarted = NO;
+
+static char *copy_error_message(NSString *message)
+{
+    NSString *fallbackMessage = message ?: @"Sparkle returned an unknown error";
+    const char *utf8 = fallbackMessage.UTF8String;
+    if (utf8 == NULL) {
+        return strdup("Sparkle returned an unknown error");
+    }
+    return strdup(utf8);
+}
+
+static void run_on_main_queue_sync(dispatch_block_t block)
+{
+    if ([NSThread isMainThread]) {
+        block();
+        return;
+    }
+
+    dispatch_sync(dispatch_get_main_queue(), block);
+}
+
+char *vekil_updater_start(void)
+{
+    __block char *errorMessage = NULL;
+
+    run_on_main_queue_sync(^{
+        if (vekilUpdaterController == nil) {
+            vekilUpdaterController =
+                [[SPUStandardUpdaterController alloc] initWithStartingUpdater:NO
+                                                              updaterDelegate:nil
+                                                            userDriverDelegate:nil];
+        }
+
+        if (vekilUpdaterStarted) {
+            return;
+        }
+
+        NSError *error = nil;
+        if (![vekilUpdaterController.updater startUpdater:&error]) {
+            errorMessage = copy_error_message(error.localizedDescription);
+            return;
+        }
+
+        vekilUpdaterStarted = YES;
+    });
+
+    return errorMessage;
+}
+
+char *vekil_updater_check(void)
+{
+    __block char *errorMessage = NULL;
+
+    run_on_main_queue_sync(^{
+        if (vekilUpdaterController == nil || !vekilUpdaterStarted) {
+            errorMessage = copy_error_message(@"The updater is not available yet.");
+            return;
+        }
+
+        [vekilUpdaterController checkForUpdates:nil];
+    });
+
+    return errorMessage;
+}

--- a/cmd/menubar/updater_darwin.go
+++ b/cmd/menubar/updater_darwin.go
@@ -1,0 +1,37 @@
+//go:build darwin && cgo && sparkle
+
+package main
+
+/*
+#cgo darwin CFLAGS: -fobjc-arc
+#cgo darwin LDFLAGS: -framework Cocoa -framework Sparkle
+#include <stdlib.h>
+#include "updater_bridge.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+func updaterSupported() bool {
+	return true
+}
+
+func startUpdater() error {
+	return updaterCall(C.vekil_updater_start())
+}
+
+func checkForUpdates() error {
+	return updaterCall(C.vekil_updater_check())
+}
+
+func updaterCall(message *C.char) error {
+	if message == nil {
+		return nil
+	}
+
+	defer C.free(unsafe.Pointer(message))
+	return errors.New(C.GoString(message))
+}

--- a/cmd/menubar/updater_disabled.go
+++ b/cmd/menubar/updater_disabled.go
@@ -4,7 +4,7 @@ package main
 
 import "errors"
 
-var errUpdaterDisabled = errors.New("Sparkle updater is not available in this build")
+var errUpdaterDisabled = errors.New("sparkle updater is not available in this build")
 
 func updaterSupported() bool {
 	return false

--- a/cmd/menubar/updater_disabled.go
+++ b/cmd/menubar/updater_disabled.go
@@ -1,0 +1,19 @@
+//go:build !darwin || !cgo || !sparkle
+
+package main
+
+import "errors"
+
+var errUpdaterDisabled = errors.New("Sparkle updater is not available in this build")
+
+func updaterSupported() bool {
+	return false
+}
+
+func startUpdater() error {
+	return errUpdaterDisabled
+}
+
+func checkForUpdates() error {
+	return errUpdaterDisabled
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,8 @@ make build-app
 make docker-build
 ```
 
+`go test ./...` and ordinary Go builds do not require Sparkle. The updater code is only compiled for the packaged macOS app build via `make build-app`, which downloads Sparkle 2.9.0 into `.build/sparkle/`, passes the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.
+
 ## Test
 
 ```bash
@@ -42,10 +44,13 @@ Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.ya
 The same release workflow also:
 
 - builds `vekil-macos-arm64.zip` on a macOS runner and uploads it to the tagged release
+- generates and uploads `appcast.xml` for Sparkle update checks
 - updates the `vekil` cask in `sozercan/homebrew-repo`
 - pushes the multi-arch container image to GHCR
 
 To publish the Homebrew cask, configure the repository secret `HOMEBREW_REPO_TOKEN` with push access to `sozercan/homebrew-repo`.
+
+To publish Sparkle updates, configure both `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_PRIVATE_ED_KEY` in the repository secrets.
 
 ## Manual Live Smoke Workflow
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -1,6 +1,6 @@
 # macOS Menubar App
 
-The repo includes a native macOS menubar app for running the proxy without keeping a terminal open.
+The repo includes a native macOS menubar app for running the proxy without keeping a terminal open. Published app bundles also include Sparkle-based update checks.
 
 ## Download And Run
 
@@ -10,7 +10,7 @@ Install the menubar app from Homebrew:
 brew install --cask sozercan/repo/vekil
 ```
 
-> **Note:** The app is not signed.
+> **Note:** The app is not Developer ID signed.
 > Clear extended attributes, including quarantine, with:
 > ```bash
 > xattr -cr /Applications/Vekil.app
@@ -27,6 +27,17 @@ make build-app
 open "Vekil.app"
 ```
 
+`make build-app` downloads Sparkle 2.9.0 into `.build/sparkle/`, builds the menubar app with the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.
+
+If `SPARKLE_PUBLIC_ED_KEY` is not set, the app still builds, but `Check for Updates…` is disabled because Sparkle cannot start without a public EdDSA key.
+
+To build a locally update-enabled app:
+
+```bash
+SPARKLE_PUBLIC_ED_KEY=your_public_key make build-app
+open "Vekil.app"
+```
+
 ## Features
 
 - start/stop toggle from the menubar
@@ -34,3 +45,13 @@ open "Vekil.app"
 - current app version shown in the menu
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
+- `Check for Updates…` in packaged macOS app builds
+
+## Release Assets
+
+The release workflow publishes two macOS updater assets:
+
+- `vekil-macos-arm64.zip`
+- `appcast.xml`
+
+It signs the appcast with `SPARKLE_PRIVATE_ED_KEY`, so repository releases need both `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_PRIVATE_ED_KEY` secrets configured.


### PR DESCRIPTION
## What changed

This reintroduces Sparkle support for the macOS menubar app now that releases are published from the public `sozercan/vekil` repository.

The PR:

- restores the Sparkle-backed updater bridge in `cmd/menubar/`
- adds a `Check for Updates…` menu item to the menubar app when Sparkle is available
- updates `make build-app` to download and embed `Sparkle.framework`, include Sparkle plist keys, and ad-hoc sign the app bundle
- updates the release workflow to require Sparkle keys, generate `appcast.xml`, and upload both `vekil-macos-arm64.zip` and `appcast.xml`
- documents the local build flow and release secret requirements

## Why

Sparkle had been reverted when the repository was private. Now that the project is public, GitHub Releases can safely host the updater feed and assets again, so the menubar app can regain built-in update checks.

## Impact

Users of the packaged macOS app can check for updates from the menu again, and release tags can publish the Sparkle appcast needed for future in-app updates.

This also makes the required release-time setup explicit:

- `SPARKLE_PUBLIC_ED_KEY`
- `SPARKLE_PRIVATE_ED_KEY`

## Validation

- `make test`
- `make vet`
- `VERSION=v0.0.0 SPARKLE_PUBLIC_ED_KEY=test make build-app`

## Notes

The local smoke build used a placeholder public key to verify the Sparkle-enabled app path compiles and packages cleanly. The release workflow still requires real Sparkle signing keys in GitHub secrets before the next tagged release.
