### PR TITLE
fix macOS menubar Sparkle rpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ APP_NAME := Vekil.app
 APP_BUNDLE_ID := com.vekil.menubar
 VERSION ?= dev-$(shell git rev-parse --short HEAD)
 APP_VERSION := $(patsubst v%,%,$(VERSION))
+APP_CGO_LDFLAGS = -F$(abspath $(SPARKLE_UNPACK_DIR)) -Wl,-rpath,@executable_path/../Frameworks
 SPARKLE_VERSION := 2.9.0
 SPARKLE_BUILD_DIR := .build/sparkle
 SPARKLE_ARCHIVE := $(SPARKLE_BUILD_DIR)/Sparkle-$(SPARKLE_VERSION).tar.xz
@@ -32,8 +33,9 @@ build-app: $(SPARKLE_FRAMEWORK)
 	@mkdir -p "$(APP_NAME)/Contents/MacOS"
 	@mkdir -p "$(APP_NAME)/Contents/Resources"
 	@mkdir -p "$(APP_NAME)/Contents/Frameworks"
-	CGO_ENABLED=1 CGO_LDFLAGS="-F$(abspath $(SPARKLE_UNPACK_DIR))" \
+	CGO_ENABLED=1 CGO_LDFLAGS="$(APP_CGO_LDFLAGS)" \
 		go build -tags sparkle -ldflags="$(LDFLAGS) -X main.buildVersion=$(APP_VERSION)" -o "$(APP_NAME)/Contents/MacOS/vekil-menubar" ./cmd/menubar/
+	otool -l "$(APP_NAME)/Contents/MacOS/vekil-menubar" | grep -q '@executable_path/../Frameworks'
 	ditto "$(SPARKLE_FRAMEWORK)" "$(APP_NAME)/Contents/Frameworks/Sparkle.framework"
 	@printf '<?xml version="1.0" encoding="UTF-8"?>\n\
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n\


### PR DESCRIPTION
## Summary
Fix the macOS menubar app build so the packaged executable can load the bundled Sparkle framework at launch.

## Root Cause
The `vekil-menubar` binary linked against `@rpath/Sparkle.framework/Versions/B/Sparkle`, but the app build did not embed an `LC_RPATH` entry for `@executable_path/../Frameworks`.

In the published `v0.8.2` app bundle this caused launch to fail immediately with:

```text
dyld: Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
Reason: no LC_RPATH\x27s found
```

## What Changed
- add a dedicated `APP_CGO_LDFLAGS` variable for the app build
- link the menubar binary with `-Wl,-rpath,@executable_path/../Frameworks`
- make `build-app` fail fast if the built executable is missing that rpath

## Impact
Packaged macOS menubar builds can now start with the bundled Sparkle framework present instead of crashing during dynamic loader startup.

## Validation
- `make build-app`
- verified `otool -l Vekil.app/Contents/MacOS/vekil-menubar` contains `LC_RPATH @executable_path/../Frameworks`
- verified the rebuilt app no longer exits with the Sparkle `dyld` load failure
- `make test`
