### PR TITLE
add macOS app smoke workflow

### DIFF
--- a/.github/workflows/macos-app.yaml
+++ b/.github/workflows/macos-app.yaml
@@ -1,0 +1,29 @@
+name: macOS App
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-app-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build and smoke test macOS menubar app
+        run: scripts/macos-app-smoke.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SPARKLE_DOWNLOAD_URL := https://github.com/sparkle-project/Sparkle/releases/down
 SPARKLE_FEED_URL ?= https://github.com/sozercan/vekil/releases/latest/download/appcast.xml
 SPARKLE_PUBLIC_ED_KEY ?=
 
-.PHONY: build build-app test vet lint clean docker-build
+.PHONY: build build-app test-app test vet lint clean docker-build
 
 build:
 	go build -ldflags="$(LDFLAGS)" -o $(BINARY) .
@@ -71,6 +71,18 @@ build-app: $(SPARKLE_FRAMEWORK)
 </plist>' > "$(APP_NAME)/Contents/Info.plist"
 	codesign --force --deep --sign - --timestamp=none "$(APP_NAME)"
 	codesign --verify --deep --strict "$(APP_NAME)"
+
+test-app: build-app
+	test -x "$(APP_NAME)/Contents/MacOS/vekil-menubar"
+	test -f "$(APP_NAME)/Contents/Info.plist"
+	test -d "$(APP_NAME)/Contents/Frameworks/Sparkle.framework"
+	plutil -lint "$(APP_NAME)/Contents/Info.plist"
+	/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$(APP_NAME)/Contents/Info.plist" | grep -Fxq 'vekil-menubar'
+	/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$(APP_NAME)/Contents/Info.plist" | grep -Fxq '$(APP_BUNDLE_ID)'
+	/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$(APP_NAME)/Contents/Info.plist" | grep -Fxq '$(APP_VERSION)'
+	/usr/libexec/PlistBuddy -c 'Print :LSUIElement' "$(APP_NAME)/Contents/Info.plist" | grep -Fxq 'true'
+	/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$(APP_NAME)/Contents/Info.plist" | grep -Fxq '$(SPARKLE_FEED_URL)'
+	otool -L "$(APP_NAME)/Contents/MacOS/vekil-menubar" | grep -Fq '@rpath/Sparkle.framework/Versions/B/Sparkle'
 
 test:
 	go test ./... -count=1

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,8 @@ make docker-build
 
 ```bash
 go test ./... -count=1
+make test-app          # macOS only; builds and verifies Vekil.app
+scripts/macos-app-smoke.sh  # macOS only; build + launch smoke for Vekil.app
 go test ./proxy/ -run TestHandle -v
 go test ./proxy/ -run TestMapStopReason/stop -v
 ```
@@ -35,7 +37,9 @@ make lint
 
 ## CI
 
-GitHub Actions in `.github/workflows/ci.yaml` runs lint, tests, build, vet, and e2e validation before merge.
+GitHub Actions in [`.github/workflows/ci.yaml`](../.github/workflows/ci.yaml) runs lint, tests, build, vet, and e2e validation before merge.
+
+The macOS menubar app has its own workflow in [`.github/workflows/macos-app.yaml`](../.github/workflows/macos-app.yaml). It runs `scripts/macos-app-smoke.sh` on a macOS runner, which builds `Vekil.app`, validates the bundle contents, launches the app through Launch Services, verifies it stays up, and then quits it cleanly.
 
 ## Release
 

--- a/scripts/macos-app-smoke.sh
+++ b/scripts/macos-app-smoke.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+APP_PATH="${APP_PATH:-${REPO_ROOT}/Vekil.app}"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.vekil.menubar}"
+APP_EXECUTABLE="${APP_EXECUTABLE:-${APP_PATH}/Contents/MacOS/vekil-menubar}"
+
+app_pid=""
+
+cleanup() {
+  osascript -e "tell application id \"${APP_BUNDLE_ID}\" to quit" >/dev/null 2>&1 || true
+
+  if [[ -f "${APP_EXECUTABLE}" ]]; then
+    pkill -f "${APP_EXECUTABLE}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+wait_for_pid() {
+  local attempt pid
+
+  for attempt in $(seq 1 20); do
+    pid="$(lsappinfo info -only pid -app "${APP_BUNDLE_ID}" 2>/dev/null | awk -F= '/"pid"=/{print $2}')"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      printf '%s\n' "${pid}"
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_exit() {
+  local pid="$1"
+  local attempt
+
+  for attempt in $(seq 1 20); do
+    if ! ps -p "${pid}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+main() {
+  require_cmd make
+  require_cmd open
+  require_cmd osascript
+  require_cmd lsappinfo
+  require_cmd pgrep
+  require_cmd pkill
+
+  cd "${REPO_ROOT}"
+
+  log "Building and validating Vekil.app"
+  make test-app
+
+  log "Ensuring no stale app instance is running"
+  cleanup
+  sleep 2
+
+  log "Launching ${APP_PATH}"
+  open "${APP_PATH}"
+
+  app_pid="$(wait_for_pid)" || die "app did not appear in Launch Services after launch"
+  log "App started with pid ${app_pid}"
+
+  if ! ps -p "${app_pid}" -o command= | grep -Fq "${APP_EXECUTABLE}"; then
+    ps -p "${app_pid}" -o pid=,ppid=,etime=,command=
+    die "launched process did not match ${APP_EXECUTABLE}"
+  fi
+
+  sleep 3
+  ps -p "${app_pid}" >/dev/null 2>&1 || die "app exited shortly after launch"
+
+  log "Quitting ${APP_BUNDLE_ID}"
+  osascript -e "tell application id \"${APP_BUNDLE_ID}\" to quit" >/dev/null 2>&1 || die "failed to quit app via AppleScript"
+  wait_for_exit "${app_pid}" || die "app did not exit cleanly after quit"
+
+  log "macOS app smoke test passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add dedicated GitHub Actions coverage for the macOS menubar app.

This introduces a standalone `macOS App` workflow that runs on a macOS runner and executes a reusable smoke script. The smoke script builds `Vekil.app`, validates the bundle contents with `make test-app`, launches the app through Launch Services, verifies the menubar process stays up, and then quits it cleanly.

## Why

The existing Go tests covered the pure-Go menubar helpers, but CI did not exercise the packaged macOS app path itself. That left the Sparkle-linked bundle build and startup lifecycle mostly unverified until release time.

## Impact

PRs and pushes now get a dedicated macOS app signal without mixing this check into the live Copilot smoke workflow.

## Validation

- `make test`
- `scripts/macos-app-smoke.sh`
