### PR TITLE
fix: use *string for ContentBlock.Text to preserve empty text in JSON

### DIFF
--- a/models/anthropic.go
+++ b/models/anthropic.go
@@ -36,7 +36,7 @@ type AnthropicMessage struct {
 // (text, image, tool_use, tool_result, thinking).
 type ContentBlock struct {
 	Type      string                `json:"type"`
-	Text      string                `json:"text,omitempty"`
+	Text      *string               `json:"text,omitempty"`
 	Source    *AnthropicImageSource `json:"source,omitempty"`
 	ID        string                `json:"id,omitempty"`
 	Name      string                `json:"name,omitempty"`

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -389,8 +389,8 @@ func TestHandleAnthropicMessages(t *testing.T) {
 	if len(anthropicResp.Content) == 0 {
 		t.Fatal("expected content blocks, got none")
 	}
-	if anthropicResp.Content[0].Text != "Hello from the backend!" {
-		t.Errorf("expected text 'Hello from the backend!', got %q", anthropicResp.Content[0].Text)
+	if derefString(anthropicResp.Content[0].Text) != "Hello from the backend!" {
+		t.Errorf("expected text 'Hello from the backend!', got %q", derefString(anthropicResp.Content[0].Text))
 	}
 	if anthropicResp.Usage.InputTokens != 10 {
 		t.Errorf("expected input_tokens 10, got %d", anthropicResp.Usage.InputTokens)
@@ -460,7 +460,7 @@ func TestHandleAnthropicMessages_ImageBlocksForwarded(t *testing.T) {
 	if err := json.Unmarshal(body, &anthropicResp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	if len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Type != "text" || anthropicResp.Content[0].Text != "I can see the screenshot." {
+	if len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Type != "text" || derefString(anthropicResp.Content[0].Text) != "I can see the screenshot." {
 		t.Fatalf("unexpected content: %+v", anthropicResp.Content)
 	}
 }
@@ -3094,7 +3094,7 @@ func TestHandleAnthropicMessages_ParallelToolCalls(t *testing.T) {
 	if len(anthropicResp.Content) != 3 {
 		t.Fatalf("expected 3 content blocks (1 text + 2 tool_use), got %d", len(anthropicResp.Content))
 	}
-	if anthropicResp.Content[0].Type != "text" || anthropicResp.Content[0].Text != "I'll delegate both tasks" {
+	if anthropicResp.Content[0].Type != "text" || derefString(anthropicResp.Content[0].Text) != "I'll delegate both tasks" {
 		t.Errorf("content[0] = %+v, want text", anthropicResp.Content[0])
 	}
 	if anthropicResp.Content[1].Type != "tool_use" || anthropicResp.Content[1].ID != "call_1" || anthropicResp.Content[1].Name != "delegate_task" {

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -214,7 +214,7 @@ func (s *anthropicStreamState) emitText(text string) bool {
 			Index: intVal(s.textBlockIndex),
 			ContentBlock: &models.ContentBlock{
 				Type: "text",
-				Text: "",
+				Text: stringPtr(""),
 			},
 		}) {
 			return false

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -143,7 +143,7 @@ func parseSystemMessage(raw json.RawMessage) (*models.OpenAIMessage, error) {
 	for _, b := range blocks {
 		switch b.Type {
 		case "text":
-			sb.WriteString(b.Text)
+			sb.WriteString(derefString(b.Text))
 		default:
 			return nil, fmt.Errorf("unsupported system content block type %q", b.Type)
 		}
@@ -177,7 +177,7 @@ func translateMessage(msg models.AnthropicMessage) ([]models.OpenAIMessage, erro
 	for _, block := range blocks {
 		switch block.Type {
 		case "text":
-			appendTextContentPart(&textParts, &multimodalParts, block.Text)
+			appendTextContentPart(&textParts, &multimodalParts, derefString(block.Text))
 
 		case "image":
 			part, err := translateAnthropicImageBlock(block)
@@ -321,7 +321,7 @@ func extractToolResultContent(raw json.RawMessage) (string, error) {
 	var sb strings.Builder
 	for _, b := range blocks {
 		if b.Type == "text" {
-			sb.WriteString(b.Text)
+			sb.WriteString(derefString(b.Text))
 		}
 	}
 	return sb.String(), nil
@@ -387,7 +387,7 @@ func TranslateOpenAIToAnthropic(resp *models.OpenAIResponse, model string) *mode
 			if err := json.Unmarshal(msg.Content, &text); err == nil && strings.TrimSpace(text) != "" {
 				content = append(content, models.ContentBlock{
 					Type: "text",
-					Text: text,
+					Text: stringPtr(text),
 				})
 			}
 		}

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -559,8 +559,8 @@ func TestTranslateOpenAIToAnthropic(t *testing.T) {
 		if got.Content[0].Type != "text" {
 			t.Errorf("content type = %q, want %q", got.Content[0].Type, "text")
 		}
-		if got.Content[0].Text != "Hello there" {
-			t.Errorf("content text = %q, want %q", got.Content[0].Text, "Hello there")
+		if derefString(got.Content[0].Text) != "Hello there" {
+			t.Errorf("content text = %q, want %q", derefString(got.Content[0].Text), "Hello there")
 		}
 		if got.StopReason == nil || *got.StopReason != "end_turn" {
 			t.Errorf("stop_reason = %v, want %q", got.StopReason, "end_turn")
@@ -647,7 +647,7 @@ func TestTranslateOpenAIToAnthropic(t *testing.T) {
 		if len(got.Content) != 3 {
 			t.Fatalf("expected 3 content blocks, got %d", len(got.Content))
 		}
-		if got.Content[0].Type != "text" || got.Content[0].Text != "I'll delegate both tasks" {
+		if got.Content[0].Type != "text" || derefString(got.Content[0].Text) != "I'll delegate both tasks" {
 			t.Errorf("first block = %+v, want text", got.Content[0])
 		}
 		if got.Content[1].Type != "tool_use" || got.Content[1].ID != "call_1" || got.Content[1].Name != "delegate_task" {
@@ -690,7 +690,7 @@ func TestTranslateOpenAIToAnthropic(t *testing.T) {
 		if len(got.Content) != 2 {
 			t.Fatalf("expected 2 content blocks, got %d", len(got.Content))
 		}
-		if got.Content[0].Type != "text" || got.Content[0].Text != "Let me check" {
+		if got.Content[0].Type != "text" || derefString(got.Content[0].Text) != "Let me check" {
 			t.Errorf("first block = %+v, want text 'Let me check'", got.Content[0])
 		}
 		if got.Content[1].Type != "tool_use" || got.Content[1].Name != "search" {


### PR DESCRIPTION
## Summary

- Fix `content_block_start` streaming events for text blocks dropping the required `"text":""` field due to Go's `omitempty` on a plain `string`
- Change `ContentBlock.Text` from `string` to `*string` so `omitempty` correctly distinguishes nil (omit for tool_use blocks) from `""` (emit for text blocks)
- Uses existing `stringPtr()` / `derefString()` helpers from `proxy/gemini.go`

## Problem

The Anthropic streaming spec requires `content_block_start` events for text blocks to include `"text":""` in the response. With a plain `string` field and `json:",omitempty"`, Go's JSON encoder treats `""` as a zero value and drops it entirely. Strict SDK clients like `@ai-sdk/anthropic` (used by [opencode](https://github.com/anomalyco/opencode)) fail with a type validation error because the required field is missing.

## Fix

`*string` with `omitempty` gives correct behavior for both cases:
- `nil` → field omitted (correct for `tool_use` blocks that don't have `text`)  
- `stringPtr("")` → serializes as `"text":""` (correct for `text` blocks)