### PR TITLE
add Windows release binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,7 @@ The macOS menubar app has its own workflow in [`.github/workflows/macos-app.yaml
 
 ## Release
 
-Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) now use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases.
+Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) now use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 
 The same release workflow also:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@
 
 Download the latest binary for your platform from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest).
 
-Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. After downloading, make the binary executable if needed and run it locally.
+Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`. Windows release assets are published as `.exe` binaries. After downloading, make the binary executable if needed and run it locally.
 
 On Apple Silicon Macs, you can use the native menubar app:
 


### PR DESCRIPTION
## What changed
- add `windows` to the GoReleaser build matrix so tagged releases publish `windows/amd64` and `windows/arm64` CLI binaries
- update release docs to list the new published platforms and note that Windows assets are `.exe` binaries

## Why
The release workflow already publishes CLI binaries through GoReleaser, but the target matrix only included Linux and macOS. That left Windows users without official release artifacts even though the project cross-builds cleanly for both supported Windows architectures.

## Impact
Windows users can download official `amd64` and `arm64` binaries from GitHub Releases without building from source. The existing release workflow and macOS app packaging flow stay unchanged.

## Validation
- `go test ./... -count=1`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/vekil-windows-amd64.exe .`
- `GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -o /tmp/vekil-windows-arm64.exe .`
- `git diff --check -- .goreleaser.yaml docs/getting-started.md docs/development.md`
