### PR TITLE
add multi-provider model routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Documentation update rules:
 - **Gemini is a translation layer**: Gemini endpoints are implemented like Anthropic, not as zero-copy passthrough. Keep Gemini-specific protocol logic in `proxy/gemini*.go`.
 - **Responses compatibility is proxy-owned**: `/v1/responses/compact` and `/v1/memories/trace_summarize` are compatibility shims implemented on top of the upstream `/responses` API. Preserve this behavior for Codex-style clients.
 - **OpenAI passthrough is near-zero-copy, not literal zero-copy**: chat completions may inject `parallel_tool_calls` and force streaming; `/v1/responses` may rewrite proxy-owned compaction items before forwarding.
+- **Provider endpoint support is explicit**: `models[].endpoints` is an allowlist. Do not advertise `/chat/completions` or other routes for a provider/model unless that upstream capability has been verified. The Azure `gpt-5.4-pro` example configuration is `/responses`-only.
+- **Proxy websocket bridging is not upstream realtime**: `GET /v1/responses` remains a proxy-owned websocket transport over upstream HTTP `/responses`. Do not describe it as native Azure websocket or `/realtime` support.
 - **Minimal dependencies**: Keep third-party deps minimal. Current non-stdlib dependencies used in production code are `systray`, `uuid`, and `klauspost/compress`.
 - **Distroless container**: Single static binary, CGO_ENABLED=0.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible 
 - Gemini Generate Content and Count Tokens APIs
 - OpenAI Chat Completions API
 - OpenAI Responses API, including Codex websocket bridging
+- Multi-provider model routing, including Azure OpenAI deployments behind the same `/v1` endpoint
 - Proxy-owned Codex compatibility endpoints for compaction and memory summarization
 - Streaming, tool use, parallel tool calls, compressed request bodies, and OAuth token caching
 

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -140,7 +140,12 @@ func startProxy() {
 		return
 	}
 
-	nextSrv := server.New(authenticator, log, "0.0.0.0", "1337")
+	nextSrv, err := server.New(authenticator, log, "0.0.0.0", "1337")
+	if err != nil {
+		log.Error("server init failed", logger.Err(err))
+		showErrorDialog("Vekil Start Failed", fmt.Sprintf("Could not initialize Vekil.\n\n%v", err))
+		return
+	}
 	if err := nextSrv.Start(); err != nil {
 		log.Error("server start failed", logger.Err(err))
 		showErrorDialog("Vekil Start Failed", fmt.Sprintf("Could not start Vekil on port 1337.\n\n%v", err))

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,4 @@ This folder is intentionally split into small, single-purpose files so humans an
 - Prefer linking to one focused file instead of expanding the root `README.md`.
 - When behavior changes, update the smallest relevant doc instead of adding more material to the root README.
 - Keep each doc narrowly scoped and avoid duplicating long explanations across files.
+- When documenting provider features, distinguish proxy-owned websocket bridging from upstream-native websocket or realtime APIs.

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,11 +20,18 @@ Model normalization:
 
 ### `GET /v1/models`
 
-The live model list is fetched dynamically from the upstream Copilot API. The proxy preserves the upstream OpenAI-style `data` payload and also adds a Codex-compatible top-level `models` array.
+The proxy builds a merged model catalog across the configured providers. It preserves the OpenAI-style `data` payload and also adds a Codex-compatible top-level `models` array.
 
 ```bash
 curl http://localhost:1337/v1/models
 ```
+
+When multiple providers are configured:
+
+- public model IDs stay unprefixed, for example `gpt-5.4`
+- each public ID must be owned by exactly one provider
+- startup fails if providers collide on the same model ID
+- Azure OpenAI deployments can be exposed under a different public ID while the proxy rewrites the upstream `model` field
 
 Example IDs in recent upstream responses have included:
 
@@ -100,9 +107,17 @@ Validation failures (`400 INVALID_ARGUMENT`) include path/body model mismatches,
 
 Near zero-copy passthrough for requests without tools. When tools are present, the proxy injects `parallel_tool_calls: true`, forces upstream streaming for reliable parallel tool calls, and aggregates the result back to non-streaming JSON.
 
+When provider routing is configured, the request is routed by the public `model` ID. If the selected provider uses a different upstream model or deployment name, the proxy rewrites the outgoing `model` field before forwarding.
+
+The proxy also enforces the model's configured `supported_endpoints` before forwarding. If a model is exposed as `/responses`-only, `POST /v1/chat/completions` fails fast with `400` instead of probing an unsupported upstream route. The Azure `gpt-5.4-pro` example configuration is set up this way.
+
 ## `POST /v1/responses` and `GET /v1/responses` (OpenAI)
 
 `POST /v1/responses` is a near zero-copy passthrough for the OpenAI Responses API. Proxy-owned synthetic compaction items are expanded back into normal context before forwarding so resumed Codex sessions continue through the standard `/v1/responses` path.
+
+Like chat completions, Responses requests are routed by the public `model` ID. Fallback retries for unsupported `/responses` models stay within the selected provider; the proxy does not silently switch providers.
+
+For responses-only Azure deployments such as the `gpt-5.4-pro` example configuration, this is the canonical inference path.
 
 Streaming Responses requests are passed through directly with upstream headers preserved.
 
@@ -120,6 +135,8 @@ Websocket bridge behavior:
 - optional turn-state delta replay can be enabled with `--responses-ws-turn-state-delta`
 - if upstream rejects delta replay, the proxy automatically falls back to full replay
 
+This websocket bridge is a proxy transport adaptation layered over upstream HTTP `/responses`. It is not the same feature as provider-native websocket or realtime APIs such as Azure `/realtime`.
+
 See [configuration.md](configuration.md) for tuning flags.
 
 ## `POST /v1/responses/compact`
@@ -132,6 +149,7 @@ Compatibility shim for environments expecting `/responses/compact`. The proxy re
 Requests to this endpoint are accepted up to `64 MiB` so large session histories can be compacted without tripping the default request-body limit.
 
 If the requested model does not support the upstream Responses API, the proxy retries against a compatible fallback model discovered from `/models`.
+That fallback stays within the selected provider; the proxy does not silently switch providers.
 
 ## `POST /v1/memories/trace_summarize`
 
@@ -145,4 +163,4 @@ Returns `{"status":"ok"}`.
 
 ## `GET /readyz`
 
-Validates that the proxy can obtain a Copilot token and successfully probe upstream `/models`. On success it returns `{"status":"ready"}`. On failure it returns `503` with `{"status":"not_ready","error":"..."}`.
+Validates that the proxy can authenticate to and successfully probe the configured upstream providers. On success it returns `{"status":"ready"}`. On failure it returns `503` with `{"status":"not_ready","error":"..."}`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,10 +16,9 @@
 │                       Translate ◄──   .com           │
 │                       OAI→Gemini                     │
 │                                                     │
-│  /v1/chat/completions ─────────► /chat/completions  │
-│                   (passthrough; forced-stream       │
-│                    + aggregate when tools present)  │
-│  /v1/responses ────────────────► /responses         │
+│  /v1/chat/completions ─────────► Provider router ─► │
+│  /v1/responses ────────────────► (Copilot / Azure  │
+│                   HTTP /responses)                 │
 │                   (passthrough + proxy compaction   │
 │                    expansion when needed)           │
 │  /v1/responses/compact ────────► /responses         │
@@ -36,7 +35,7 @@
 |---------|---------------|
 | `main` | CLI flags, HTTP server setup, graceful shutdown |
 | `auth/` | GitHub OAuth device code flow, Copilot token exchange, disk caching, auto-refresh |
-| `proxy/` | HTTP handlers, Anthropic/OpenAI and Gemini/OpenAI translation, SSE streaming, retry logic |
+| `proxy/` | HTTP handlers, provider routing, Anthropic/OpenAI and Gemini/OpenAI translation, SSE streaming, retry logic |
 | `models/` | Request and response type definitions only |
 | `logger/` | Structured JSON logging |
 | `server/` | Reusable HTTP server lifecycle |
@@ -45,7 +44,11 @@
 ## Key Decisions
 
 - Pure `net/http` with Go `ServeMux` routing; no web framework.
+- Public model IDs are a single namespace across providers. The proxy validates ownership during startup and fails fast on collisions.
+- Provider endpoint support is explicit. `models[].endpoints` is an allowlist, so do not expose `/chat/completions` or other routes for a provider/model until that upstream capability is verified.
 - Gemini is a translation path like Anthropic, not a passthrough path.
 - OpenAI Chat Completions is near-zero-copy except where forced streaming is needed for tool reliability.
 - OpenAI Responses compatibility is partly proxy-owned, especially for Codex compaction and websocket bridging.
+- The Codex websocket bridge is transport adaptation over upstream HTTP `/responses`, not a claim that the selected provider has native websocket or realtime support.
+- Azure OpenAI support is implemented as an OpenAI-compatible provider behind the existing proxy surface; Azure deployment names are internal to provider config.
 - Production dependencies stay minimal.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@
 | `--port` | `PORT` | `1337` | Listen port |
 | `--host` | `HOST` | `0.0.0.0` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
+| `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON provider configuration for multi-provider model routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 | `--copilot-editor-version` | `COPILOT_EDITOR_VERSION` | `vscode/1.95.0` | Upstream `editor-version` header |
@@ -20,9 +21,62 @@ For CI or other non-interactive environments, the proxy also accepts a GitHub to
 
 If one of these is set, it overrides any cached login state and is exchanged for a short-lived Copilot token at startup.
 
+If your provider config does not include a Copilot provider, startup skips the GitHub auth check.
+
+## Multi-Provider Routing
+
+Use `--providers-config` to expose non-Copilot models such as Azure OpenAI deployments behind the same proxy endpoint.
+
+Example:
+
+```json
+{
+  "providers": [
+    {
+      "id": "copilot",
+      "type": "copilot",
+      "default": true,
+      "exclude_models": ["gpt-5.4-pro"]
+    },
+    {
+      "id": "azure-openai",
+      "type": "azure-openai",
+      "base_url": "https://myresource.cognitiveservices.azure.com/openai",
+      "api_key_env": "AZURE_OPENAI_API_KEY",
+      "api_version": "2025-04-01-preview",
+      "models": [
+        {
+          "public_id": "gpt-5.4-pro",
+          "deployment": "gpt-5.4-pro",
+          "endpoints": ["/responses"],
+          "name": "GPT-5.4 Pro"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Routing rules:
+
+- Clients keep using plain model IDs such as `gpt-5.4-pro`.
+- Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
+- Public model IDs are global across all providers. Startup fails if two providers expose the same ID.
+- `exclude_models` lets one provider give ownership of a public ID to another provider.
+- When `api_version` is set for Azure OpenAI, the proxy appends `api-version=...` to upstream requests.
+- `models[].endpoints` is an allowlist, not a guess. Keep it limited to the routes you have validated for that deployment.
+- The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
+
+Use the JSON example above as a starting point for your local providers config file.
+
 ## WebSocket Session Tuning
 
 These settings affect the Codex-style `GET /v1/responses` websocket bridge.
+
+Important:
+
+- This websocket bridge is proxy-owned and still forwards upstream over HTTP `/responses`.
+- It is separate from Azure OpenAI's native `/realtime` websocket and WebRTC APIs.
 
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ Example:
     {
       "id": "azure-openai",
       "type": "azure-openai",
-      "base_url": "https://myresource.cognitiveservices.azure.com/openai",
+      "base_url": "https://myresource.cognitiveservices.azure.com/openai/v1",
       "api_key_env": "AZURE_OPENAI_API_KEY",
       "api_version": "2025-04-01-preview",
       "models": [
@@ -61,9 +61,11 @@ Routing rules:
 
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
 - Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
+- Azure `base_url` must include the OpenAI-compatible `/openai/v1` prefix because the proxy appends routes like `/chat/completions`, `/responses`, and `/models` directly.
 - Public model IDs are global across all providers. Startup fails if two providers expose the same ID.
 - `exclude_models` lets one provider give ownership of a public ID to another provider.
 - When `api_version` is set for Azure OpenAI, the proxy appends `api-version=...` to upstream requests.
+- Only one Copilot provider is supported in a config today.
 - `models[].endpoints` is an allowlist, not a guess. Keep it limited to the routes you have validated for that deployment.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ func runServe() {
 	port := flag.String("port", getEnv("PORT", "1337"), "Listen port")
 	host := flag.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
 	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	providersConfigPath := flag.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON provider configuration")
 	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
 	streamingUpstreamTimeout := flag.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
 	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
@@ -138,14 +139,21 @@ func runServe() {
 		log.Fatal("failed to initialize authenticator", logger.Err(err))
 	}
 
-	log.Info("authenticating with GitHub Copilot...")
-	ctx := context.Background()
-	if _, err := authenticator.GetToken(ctx); err != nil {
-		log.Fatal("authentication failed", logger.Err(err))
+	providersCfg, err := proxy.LoadProvidersConfigFile(*providersConfigPath)
+	if err != nil {
+		log.Fatal("failed to load providers config", logger.Err(err))
 	}
-	log.Info("authenticated successfully")
 
-	srv := server.New(
+	if providersCfg.UsesCopilot() {
+		log.Info("authenticating with GitHub Copilot...")
+		ctx := context.Background()
+		if _, err := authenticator.GetToken(ctx); err != nil {
+			log.Fatal("authentication failed", logger.Err(err))
+		}
+		log.Info("authenticated successfully")
+	}
+
+	srv, err := server.New(
 		authenticator,
 		log,
 		*host,
@@ -164,7 +172,11 @@ func runServe() {
 			AutoCompactMaxBytes: *responsesWSCompactMaxBytes,
 			AutoCompactKeepTail: *responsesWSCompactKeepTail,
 		}),
+		server.WithProxyOptions(proxy.WithProvidersConfig(providersCfg)),
 	)
+	if err != nil {
+		log.Fatal("failed to initialize server", logger.Err(err))
+	}
 
 	if err := srv.Start(); err != nil {
 		log.Fatal("server start error", logger.Err(err))

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -131,20 +131,22 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "anthropic"), logger.Err(err))
-		writeAnthropicError(w, http.StatusInternalServerError, "api_error", "authentication failed")
-		return
-	}
-
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
-	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
+	resp, err := h.postChatCompletions(upstreamCtx, oaiBody)
 	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "anthropic"), logger.Err(err))
-		writeAnthropicError(w, upstreamStatusCode(err, http.StatusBadGateway), "api_error", "upstream request failed")
+		if statusCode == http.StatusBadRequest {
+			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
+			return
+		}
+		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
 		return
 	}
 
@@ -179,13 +181,6 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 // HandleOpenAIChatCompletions handles POST /v1/chat/completions by forwarding the
 // request to Copilot with only auth headers injected (near zero-copy passthrough).
 func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *http.Request) {
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "openai"), logger.Err(err))
-		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
-		return
-	}
-
 	bodyBytes, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -199,10 +194,19 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
-	resp, err := h.postChatCompletions(upstreamCtx, token, bodyBytes)
+	resp, err := h.postChatCompletions(upstreamCtx, bodyBytes)
 	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "openai"), logger.Err(err))
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
+		if statusCode == http.StatusBadRequest {
+			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+			return
+		}
+		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
 

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -81,13 +81,6 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 		oaiReq.StreamOptions = &models.StreamOptions{IncludeUsage: true}
 	}
 
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "gemini"), logger.Err(err))
-		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", "authentication failed")
-		return
-	}
-
 	oaiBody, err := json.Marshal(oaiReq)
 	if err != nil {
 		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", "failed to marshal request")
@@ -97,7 +90,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(stream || forceStream)
 	defer upstreamCancel()
 
-	resp, err := h.postChatCompletions(upstreamCtx, token, oaiBody)
+	resp, err := h.postChatCompletions(upstreamCtx, oaiBody)
 	if err != nil {
 		h.writeGeminiUpstreamFailure(w, err)
 		return
@@ -177,14 +170,7 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "gemini_count_tokens"), logger.Err(err))
-		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", "authentication failed")
-		return
-	}
-
-	oaiResp, err := h.runGeminiCountTokensProbe(token, oaiReq)
+	oaiResp, err := h.runGeminiCountTokensProbe(oaiReq)
 	if err != nil {
 		h.writeGeminiProtocolError(w, err)
 		return
@@ -243,7 +229,7 @@ func geminiContentHasInlineMedia(content *models.GeminiContent) bool {
 	return false
 }
 
-func (h *ProxyHandler) runGeminiCountTokensProbe(token string, baseReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
+func (h *ProxyHandler) runGeminiCountTokensProbe(baseReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
 	probeReq, err := cloneOpenAIRequest(baseReq)
 	if err != nil {
 		return nil, &geminiProtocolError{
@@ -263,16 +249,16 @@ func (h *ProxyHandler) runGeminiCountTokensProbe(token string, baseReq *models.O
 	probeReq.MaxCompletionTokens = &one
 	probeReq.MaxTokens = nil
 
-	oaiResp, fallback, err := h.executeGeminiCountTokensProbe(token, probeReq)
+	oaiResp, fallback, err := h.executeGeminiCountTokensProbe(probeReq)
 	if fallback {
 		probeReq.MaxCompletionTokens = nil
 		probeReq.MaxTokens = &one
-		return h.executeGeminiCountTokensProbeFinal(token, probeReq)
+		return h.executeGeminiCountTokensProbeFinal(probeReq)
 	}
 	return oaiResp, err
 }
 
-func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
+func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
@@ -285,7 +271,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *mod
 		}
 	}
 
-	resp, err := h.postChatCompletions(upstreamCtx, token, body)
+	resp, err := h.postChatCompletions(upstreamCtx, body)
 	if err != nil {
 		return nil, false, mapGeminiTransportError(err)
 	}
@@ -298,7 +284,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(token string, probeReq *mod
 	return h.decodeGeminiProbeResponse(resp)
 }
 
-func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(token string, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
+func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
@@ -311,7 +297,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(token string, probeReq
 		}
 	}
 
-	resp, err := h.postChatCompletions(upstreamCtx, token, body)
+	resp, err := h.postChatCompletions(upstreamCtx, body)
 	if err != nil {
 		return nil, mapGeminiTransportError(err)
 	}
@@ -365,6 +351,14 @@ func mapGeminiTransportError(err error) error {
 		return &geminiProtocolError{
 			statusCode: upstreamErr.statusCode,
 			status:     mapGeminiUpstreamStatus(upstreamErr.statusCode),
+			message:    fmt.Sprintf("upstream request failed: %v", err),
+		}
+	}
+	var providerErr *providerRequestError
+	if errors.As(err, &providerErr) {
+		return &geminiProtocolError{
+			statusCode: providerErr.statusCode,
+			status:     mapGeminiUpstreamStatus(providerErr.statusCode),
 			message:    fmt.Sprintf("upstream request failed: %v", err),
 		}
 	}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -185,6 +185,8 @@ type ProxyHandler struct {
 	client                   *http.Client
 	copilotURL               string
 	copilotHeaders           CopilotHeaderConfig
+	providersConfig          ProvidersConfig
+	providersState           *providerSetup
 	responsesWS              ResponsesWebSocketConfig
 	streamingUpstreamTimeout time.Duration
 	log                      *logger.Logger
@@ -202,6 +204,20 @@ type Option func(*ProxyHandler)
 func WithCopilotHeaderConfig(cfg CopilotHeaderConfig) Option {
 	return func(h *ProxyHandler) {
 		h.copilotHeaders = cfg.withDefaults()
+	}
+}
+
+// WithProvidersConfig enables multi-provider model routing. When unset, the
+// proxy keeps its legacy single-upstream Copilot behavior.
+func WithProvidersConfig(cfg ProvidersConfig) Option {
+	return func(h *ProxyHandler) {
+		h.providersConfig = cfg
+	}
+}
+
+func withCopilotBaseURLForTest(baseURL string) Option {
+	return func(h *ProxyHandler) {
+		h.copilotURL = strings.TrimRight(baseURL, "/")
 	}
 }
 
@@ -235,7 +251,7 @@ func WithStreamingUpstreamTimeout(timeout time.Duration) Option {
 }
 
 // NewProxyHandler creates a ProxyHandler with connection pooling and HTTP/2.
-func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) *ProxyHandler {
+func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) (*ProxyHandler, error) {
 	h := &ProxyHandler{
 		auth: a,
 		client: &http.Client{
@@ -259,7 +275,10 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 			opt(h)
 		}
 	}
-	return h
+	if err := h.initializeProviders(); err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 func (h *ProxyHandler) responsesWebSocketConfig() ResponsesWebSocketConfig {
@@ -366,7 +385,7 @@ func (h *ProxyHandler) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleReadyz validates that the proxy can obtain an auth token and reach the
-// upstream Copilot API.
+// configured upstream providers.
 func (h *ProxyHandler) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), readyzUpstreamTimeout)
 	defer cancel()
@@ -375,42 +394,39 @@ func (h *ProxyHandler) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.auth.GetTokenNonInteractive(ctx)
-	if err != nil {
-		if shouldSuppressReadyzResponse(r.Context(), err) {
+	setup := h.providerSetup()
+	for _, providerID := range setup.providerOrder {
+		provider := setup.providerByID(providerID)
+		if provider == nil {
+			continue
+		}
+		if err := h.checkProviderReady(ctx, provider); err != nil {
+			if shouldSuppressReadyzResponse(r.Context(), err) {
+				return
+			}
+			writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", err.Error())
 			return
 		}
-		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", fmt.Sprintf("failed to get token: %v", err))
-		return
-	}
-
-	if err := h.checkUpstreamReady(ctx, token); err != nil {
-		if shouldSuppressReadyzResponse(r.Context(), err) {
-			return
-		}
-		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", err.Error())
-		return
 	}
 
 	writeReadyzStatus(w, http.StatusOK, "ready", "")
 }
 
-func (h *ProxyHandler) checkUpstreamReady(ctx context.Context, token string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.copilotURL+"/models", nil)
+func (h *ProxyHandler) checkProviderReady(ctx context.Context, provider *providerRuntime) error {
+	req, err := h.newProviderProbeRequest(ctx, provider)
 	if err != nil {
-		return fmt.Errorf("failed to create upstream probe request: %w", err)
+		return err
 	}
-	h.setCopilotHeaders(req, token)
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("upstream probe failed: %w", err)
+		return fmt.Errorf("provider %q upstream probe failed: %w", provider.id, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		message := fmt.Sprintf("upstream probe returned %d", resp.StatusCode)
+		message := fmt.Sprintf("provider %q upstream probe returned %d", provider.id, resp.StatusCode)
 		if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
 			message += ": " + trimmed
 		}
@@ -418,6 +434,40 @@ func (h *ProxyHandler) checkUpstreamReady(ctx context.Context, token string) err
 	}
 
 	return nil
+}
+
+func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *providerRuntime) (*http.Request, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is required")
+	}
+
+	switch provider.kind {
+	case providerTypeCopilot:
+		token, err := h.auth.GetTokenNonInteractive(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get token for provider %q: %w", provider.id, err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.baseURL+"/models", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create upstream probe request: %w", err)
+		}
+		h.setCopilotHeaders(req, token)
+		return req, nil
+	case providerTypeAzureOpenAI:
+		fullURL, err := h.providerRequestURL(provider, "/models", "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to build provider %q probe URL: %w", provider.id, err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create upstream probe request: %w", err)
+		}
+		req.Header.Set("api-key", provider.apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	default:
+		return nil, fmt.Errorf("unsupported provider type %q", provider.kind)
+	}
 }
 
 func shouldSuppressReadyzResponse(parent context.Context, err error) bool {
@@ -447,10 +497,9 @@ func writeReadyzStatus(w http.ResponseWriter, statusCode int, status string, err
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-// HandleModels handles GET /v1/models by proxying to the upstream Copilot API.
-// Responses are cached for modelsCacheTTL to avoid repeated upstream calls.
-// The response includes both the standard OpenAI "data" field and a Codex-compatible
-// "models" field so that both OpenAI SDK clients and Codex CLI can parse it.
+// HandleModels handles GET /v1/models by building a merged model catalog across
+// the configured providers. Responses are cached for modelsCacheTTL to avoid
+// repeated upstream calls.
 func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 	cacheKey := r.URL.RawQuery
 	now := time.Now()
@@ -469,46 +518,30 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "models"), logger.Err(err))
-		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
-		return
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), modelsUpstreamTimeout)
 	defer cancel()
 
-	upstreamURL := h.copilotURL + "/models"
-	if cacheKey != "" {
-		upstreamURL += "?" + cacheKey
+	conditionalETag := ""
+	if hasCachedEntry {
+		conditionalETag = cachedEntry.etag
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
-	if err != nil {
-		writeOpenAIError(w, http.StatusInternalServerError, "failed to create request", "server_error")
-		return
-	}
-	h.setCopilotHeaders(req, token)
-	if hasCachedEntry && cachedEntry.etag != "" {
-		req.Header.Set("If-None-Match", cachedEntry.etag)
-	}
-
-	resp, err := h.client.Do(req)
+	entry, notModified, err := h.buildMergedModelsEntry(ctx, cacheKey, conditionalETag)
 	if err != nil {
 		h.log.Error("upstream request failed", logger.F("endpoint", "models"), logger.Err(err))
-		writeOpenAIError(w, http.StatusBadGateway, "upstream request failed", "server_error")
+		if hasCachedEntry {
+			writeCachedModelsResponse(w, cachedEntry)
+			return
+		}
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
+		if statusCode == http.StatusInternalServerError {
+			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+			return
+		}
+		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadGateway, "failed to read upstream response", "server_error")
-		return
-	}
-
-	if resp.StatusCode == http.StatusNotModified && hasCachedEntry {
+	if notModified && hasCachedEntry {
 		cachedEntry.expiry = time.Now().Add(modelsCacheTTL)
 		h.models.mu.Lock()
 		if h.models.entries == nil {
@@ -521,19 +554,8 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Transform the response to include a Codex-compatible "models" field.
-	if resp.StatusCode == http.StatusOK {
-		body = transformModelsResponse(body)
-	}
-
 	// Cache successful responses
-	if resp.StatusCode == http.StatusOK {
-		entry := cachedModelsResponse{
-			body:       body,
-			statusCode: resp.StatusCode,
-			expiry:     time.Now().Add(modelsCacheTTL),
-			etag:       resp.Header.Get("ETag"),
-		}
+	if entry.statusCode == http.StatusOK {
 		h.models.mu.Lock()
 		if h.models.entries == nil {
 			h.models.entries = make(map[string]cachedModelsResponse)
@@ -542,16 +564,77 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 		h.models.mu.Unlock()
 	}
 
-	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
-		w.Header().Set("Content-Type", contentType)
-	} else {
-		w.Header().Set("Content-Type", "application/json")
-	}
-	if etag := resp.Header.Get("ETag"); etag != "" {
+	w.Header().Set("Content-Type", "application/json")
+	if etag := entry.etag; etag != "" {
 		w.Header().Set("ETag", etag)
 	}
-	w.WriteHeader(resp.StatusCode)
-	_, _ = w.Write(body)
+	w.WriteHeader(entry.statusCode)
+	_, _ = w.Write(entry.body)
+}
+
+func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifNoneMatch string) (cachedModelsResponse, bool, error) {
+	setup := h.providerSetup()
+	rawEntries := make([]json.RawMessage, 0)
+	owners := make(map[string]string)
+	mergedETag := ""
+	sawDynamicProvider := false
+	allDynamicProvidersUnchanged := true
+
+	for _, providerID := range setup.providerOrder {
+		provider := setup.providerByID(providerID)
+		if provider == nil {
+			continue
+		}
+
+		result, err := h.fetchProviderModels(ctx, provider, rawQuery, ifNoneMatch)
+		if err != nil {
+			return cachedModelsResponse{}, false, err
+		}
+
+		if provider.kind == providerTypeCopilot {
+			sawDynamicProvider = true
+			if result.notModified {
+				continue
+			}
+			allDynamicProvidersUnchanged = false
+			if result.etag != "" {
+				mergedETag = result.etag
+			}
+		}
+
+		for _, model := range result.models {
+			if existingProvider, exists := owners[model.publicID]; exists {
+				if existingProvider == model.providerID {
+					continue
+				}
+				return cachedModelsResponse{}, false, fmt.Errorf("model %q is exposed by both provider %q and provider %q", model.publicID, existingProvider, model.providerID)
+			}
+			owners[model.publicID] = model.providerID
+			rawEntries = append(rawEntries, model.raw)
+		}
+	}
+
+	if sawDynamicProvider && allDynamicProvidersUnchanged {
+		return cachedModelsResponse{etag: ifNoneMatch}, true, nil
+	}
+
+	body, err := json.Marshal(struct {
+		Object string            `json:"object"`
+		Data   []json.RawMessage `json:"data"`
+	}{
+		Object: "list",
+		Data:   rawEntries,
+	})
+	if err != nil {
+		return cachedModelsResponse{}, false, err
+	}
+
+	return cachedModelsResponse{
+		body:       transformModelsResponse(body),
+		statusCode: http.StatusOK,
+		expiry:     time.Now().Add(modelsCacheTTL),
+		etag:       mergedETag,
+	}, false, nil
 }
 
 // transformModelsResponse adds a Codex-compatible "models" field to the

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -576,6 +576,7 @@ func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifN
 	setup := h.providerSetup()
 	rawEntries := make([]json.RawMessage, 0)
 	owners := make(map[string]string)
+	refreshedDynamicModels := make(map[string][]providerModel)
 	mergedETag := ""
 	sawDynamicProvider := false
 	allDynamicProvidersUnchanged := true
@@ -597,6 +598,9 @@ func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifN
 				continue
 			}
 			allDynamicProvidersUnchanged = false
+			if len(setup.providers) > 1 {
+				refreshedDynamicModels[provider.id] = result.models
+			}
 			if result.etag != "" {
 				mergedETag = result.etag
 			}
@@ -627,6 +631,12 @@ func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifN
 	})
 	if err != nil {
 		return cachedModelsResponse{}, false, err
+	}
+
+	for providerID, models := range refreshedDynamicModels {
+		if err := setup.replaceProviderModels(providerID, models); err != nil {
+			return cachedModelsResponse{}, false, err
+		}
 	}
 
 	return cachedModelsResponse{

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2191,7 +2191,6 @@ func TestPostJSONEndpointWithHeaders_ProxyHeadersTakePrecedence(t *testing.T) {
 
 	resp, err := handler.postJSONEndpointWithHeaders(
 		context.Background(),
-		"test-token",
 		"/responses",
 		[]byte(`{"input":"hello"}`),
 		http.Header{
@@ -2231,6 +2230,267 @@ func TestHandleOpenAIChatCompletionsUpstreamError(t *testing.T) {
 	resp := w.Result()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleOpenAIChatCompletions_RoutesConfiguredAzureModel(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/openai/v1/chat/completions" {
+			t.Fatalf("expected Azure path /openai/v1/chat/completions, got %s", got)
+		}
+		if got := r.URL.Query().Get("api-version"); got != "preview" {
+			t.Fatalf("expected api-version=preview, got %q", got)
+		}
+		if got := r.Header.Get("api-key"); got != "azure-test-key" {
+			t.Fatalf("expected api-key header, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("expected no Copilot Authorization header, got %q", got)
+		}
+
+		var upstreamReq models.OpenAIRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "gpt-5-4-prod" {
+			t.Fatalf("expected Azure deployment model gpt-5-4-prod, got %q", upstreamReq.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(models.OpenAIResponse{
+			ID:     "chatcmpl-1",
+			Object: "chat.completion",
+			Choices: []models.OpenAIChoice{{
+				Index: 0,
+				Message: models.OpenAIMessage{
+					Role:    "assistant",
+					Content: json.RawMessage(`"Hi"`),
+				},
+			}},
+		})
+	}))
+	defer azureServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:         "azure",
+				Type:       "azure-openai",
+				Default:    true,
+				BaseURL:    azureServer.URL + "/openai/v1",
+				APIKeyEnv:  "TEST_AZURE_API_KEY",
+				APIVersion: "preview",
+				Models: []ProviderModelConfig{{
+					PublicID:   "gpt-5.4",
+					Deployment: "gpt-5-4-prod",
+					Endpoints:  []string{"/chat/completions", "/responses"},
+					Name:       "GPT-5.4",
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model": "gpt-5.4",
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var oaiResp models.OpenAIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&oaiResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(oaiResp.Choices) != 1 || string(oaiResp.Choices[0].Message.Content) != `"Hi"` {
+		t.Fatalf("unexpected response body: %+v", oaiResp)
+	}
+}
+
+func TestHandleOpenAIChatCompletions_RejectsConfiguredAzureModelWithoutChatSupport(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:        "azure",
+				Type:      "azure-openai",
+				Default:   true,
+				BaseURL:   "https://example.openai.azure.com/openai",
+				APIKeyEnv: "TEST_AZURE_API_KEY",
+				Models: []ProviderModelConfig{{
+					PublicID:   "gpt-5.4-pro",
+					Deployment: "gpt-5.4-pro",
+					Endpoints:  []string{"/responses"},
+					Name:       "GPT-5.4 Pro",
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model": "gpt-5.4-pro",
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+
+	var errResp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if !strings.Contains(errResp.Error.Message, `does not support /chat/completions`) {
+		t.Fatalf("expected unsupported endpoint message, got %q", errResp.Error.Message)
+	}
+}
+
+func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	copilotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/models" {
+			t.Fatalf("expected /models lookup, got %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT-5.4"}]}`))
+	}))
+	defer copilotServer.Close()
+
+	_, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		withCopilotBaseURLForTest(copilotServer.URL),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:      "copilot",
+					Type:    "copilot",
+					Default: true,
+				},
+				{
+					ID:        "azure",
+					Type:      "azure-openai",
+					BaseURL:   "https://example.openai.azure.com/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4",
+						Deployment: "gpt-5-4-prod",
+					}},
+				},
+			},
+		}),
+	)
+	if err == nil {
+		t.Fatal("expected provider model collision error")
+	}
+	if !strings.Contains(err.Error(), "gpt-5.4") {
+		t.Fatalf("expected model id in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "copilot") || !strings.Contains(err.Error(), "azure") {
+		t.Fatalf("expected both provider ids in error, got %v", err)
+	}
+}
+
+func TestNewProxyHandler_AllowsDuplicateModelIDsWithinSameProvider(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	copilotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/models" {
+			t.Fatalf("expected /models lookup, got %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[
+			{"id":"gpt-4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/chat/completions"],"name":"GPT-4"},
+			{"id":"gpt-4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT-4"},
+			{"id":"gpt-4o","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT-4o"}
+		]}`))
+	}))
+	defer copilotServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		withCopilotBaseURLForTest(copilotServer.URL),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:      "copilot",
+					Type:    "copilot",
+					Default: true,
+				},
+				{
+					ID:        "azure",
+					Type:      "azure-openai",
+					BaseURL:   "https://example.openai.azure.com/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4-pro",
+						Deployment: "gpt-5-4-pro",
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("expected duplicate IDs within one provider to be deduped, got %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+
+	seen := make(map[string]int)
+	for _, model := range result.Data {
+		seen[model.ID]++
+	}
+	if seen["gpt-4"] != 1 {
+		t.Fatalf("expected deduped gpt-4 entry once, got %+v", seen)
 	}
 }
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2422,6 +2422,32 @@ func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
 	}
 }
 
+func TestNewProxyHandler_RejectsMultipleCopilotProviders(t *testing.T) {
+	_, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:      "copilot",
+					Type:    "copilot",
+					Default: true,
+				},
+				{
+					ID:   "copilot-secondary",
+					Type: "copilot",
+				},
+			},
+		}),
+	)
+	if err == nil {
+		t.Fatal("expected multiple copilot providers to be rejected")
+	}
+	if !strings.Contains(err.Error(), "multiple copilot providers configured") {
+		t.Fatalf("expected multiple copilot providers error, got %v", err)
+	}
+}
+
 func TestNewProxyHandler_AllowsDuplicateModelIDsWithinSameProvider(t *testing.T) {
 	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
@@ -2478,7 +2504,8 @@ func TestNewProxyHandler_AllowsDuplicateModelIDsWithinSameProvider(t *testing.T)
 
 	var result struct {
 		Data []struct {
-			ID string `json:"id"`
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -2486,11 +2513,241 @@ func TestNewProxyHandler_AllowsDuplicateModelIDsWithinSameProvider(t *testing.T)
 	}
 
 	seen := make(map[string]int)
+	var gpt4Endpoints []string
 	for _, model := range result.Data {
 		seen[model.ID]++
+		if model.ID == "gpt-4" {
+			gpt4Endpoints = model.SupportedEndpoints
+		}
 	}
 	if seen["gpt-4"] != 1 {
 		t.Fatalf("expected deduped gpt-4 entry once, got %+v", seen)
+	}
+	if !supportsEndpoint(gpt4Endpoints, "/chat/completions") || !supportsEndpoint(gpt4Endpoints, "/responses") {
+		t.Fatalf("expected merged gpt-4 endpoints, got %+v", gpt4Endpoints)
+	}
+}
+
+func TestHandleResponses_AllowsMergedDuplicateDynamicProviderEndpoints(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	var responsesCalls int32
+	copilotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[
+				{"id":"gpt-4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/chat/completions"],"name":"GPT-4"},
+				{"id":"gpt-4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT-4"}
+			]}`))
+		case "/responses":
+			atomic.AddInt32(&responsesCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-copilot","object":"response","status":"completed"}`))
+		default:
+			t.Fatalf("unexpected Copilot path %q", r.URL.Path)
+		}
+	}))
+	defer copilotServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		withCopilotBaseURLForTest(copilotServer.URL),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:      "copilot",
+					Type:    "copilot",
+					Default: true,
+				},
+				{
+					ID:        "azure",
+					Type:      "azure-openai",
+					BaseURL:   "https://example.openai.azure.com/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4-pro",
+						Deployment: "gpt-5-4-pro",
+						Endpoints:  []string{"/responses"},
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"Hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var responseBody struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		t.Fatalf("decode responses body: %v", err)
+	}
+	if responseBody.ID != "resp-copilot" {
+		t.Fatalf("expected Copilot response, got %+v", responseBody)
+	}
+	if got := atomic.LoadInt32(&responsesCalls); got != 1 {
+		t.Fatalf("expected one Copilot responses request, got %d", got)
+	}
+}
+
+func TestHandleModels_RefreshesDynamicProviderOwnershipForRouting(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	var modelsCalls int32
+	var copilotResponses int32
+	var azureResponses int32
+
+	copilotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models":
+			call := atomic.AddInt32(&modelsCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			switch call {
+			case 1:
+				_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT-4"}]}`))
+			default:
+				_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-new","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT New"}]}`))
+			}
+		case "/responses":
+			atomic.AddInt32(&copilotResponses, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-copilot","object":"response","status":"completed"}`))
+		default:
+			t.Fatalf("unexpected Copilot path %q", r.URL.Path)
+		}
+	}))
+	defer copilotServer.Close()
+
+	azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openai/v1/responses" {
+			t.Fatalf("unexpected Azure path %q", r.URL.Path)
+		}
+		atomic.AddInt32(&azureResponses, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-azure","object":"response","status":"completed"}`))
+	}))
+	defer azureServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		withCopilotBaseURLForTest(copilotServer.URL),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:   "copilot",
+					Type: "copilot",
+				},
+				{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   azureServer.URL + "/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4-pro",
+						Deployment: "gpt-5-4-pro",
+						Endpoints:  []string{"/responses"},
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	modelsReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	modelsW := httptest.NewRecorder()
+	handler.HandleModels(modelsW, modelsReq)
+
+	modelsResp := modelsW.Result()
+	if modelsResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(modelsResp.Body)
+		t.Fatalf("expected models refresh 200, got %d: %s", modelsResp.StatusCode, body)
+	}
+
+	var modelsBody struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(modelsResp.Body).Decode(&modelsBody); err != nil {
+		t.Fatalf("decode refreshed models response: %v", err)
+	}
+	if len(modelsBody.Data) == 0 || modelsBody.Data[0].ID != "gpt-new" {
+		t.Fatalf("expected refreshed models to include gpt-new, got %+v", modelsBody.Data)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-new","input":"Hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var responseBody struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		t.Fatalf("decode responses body: %v", err)
+	}
+	if responseBody.ID != "resp-copilot" {
+		t.Fatalf("expected Copilot routing after refresh, got %+v", responseBody)
+	}
+	if got := atomic.LoadInt32(&copilotResponses); got != 1 {
+		t.Fatalf("expected one Copilot responses request, got %d", got)
+	}
+	if got := atomic.LoadInt32(&azureResponses); got != 0 {
+		t.Fatalf("expected no Azure responses requests, got %d", got)
+	}
+}
+
+func TestNewProviderJSONRequest_OmitsBodyForGetNilPayload(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	req, err := handler.newProviderJSONRequest(
+		context.Background(),
+		&providerRuntime{
+			id:      "copilot",
+			kind:    providerTypeCopilot,
+			baseURL: "http://example.test",
+		},
+		http.MethodGet,
+		"/models",
+		nil,
+		nil,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("newProviderJSONRequest returned error: %v", err)
+	}
+	if req.Body != nil && req.Body != http.NoBody {
+		t.Fatalf("expected no GET body, got %T", req.Body)
+	}
+	if req.GetBody != nil {
+		t.Fatal("expected GetBody to be nil for GET without payload")
+	}
+	if req.ContentLength != 0 {
+		t.Fatalf("expected ContentLength 0, got %d", req.ContentLength)
 	}
 }
 

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -1,0 +1,743 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type providerType string
+
+const (
+	providerTypeCopilot     providerType = "copilot"
+	providerTypeAzureOpenAI providerType = "azure-openai"
+)
+
+var defaultStaticProviderEndpoints = []string{"/chat/completions", "/responses"}
+
+// ProvidersConfig configures optional non-Copilot upstream providers.
+// When empty, the proxy keeps its legacy zero-config Copilot behavior.
+type ProvidersConfig struct {
+	Providers []ProviderConfig `json:"providers"`
+}
+
+// ProviderConfig configures one upstream provider instance.
+type ProviderConfig struct {
+	ID            string                `json:"id"`
+	Type          string                `json:"type"`
+	Default       bool                  `json:"default,omitempty"`
+	ExcludeModels []string              `json:"exclude_models,omitempty"`
+	BaseURL       string                `json:"base_url,omitempty"`
+	APIKey        string                `json:"api_key,omitempty"`
+	APIKeyEnv     string                `json:"api_key_env,omitempty"`
+	APIVersion    string                `json:"api_version,omitempty"`
+	Models        []ProviderModelConfig `json:"models,omitempty"`
+}
+
+// ProviderModelConfig maps a public model ID exposed by this proxy to the
+// upstream model or deployment name used by the provider.
+type ProviderModelConfig struct {
+	PublicID            string   `json:"public_id"`
+	Deployment          string   `json:"deployment,omitempty"`
+	Name                string   `json:"name,omitempty"`
+	Endpoints           []string `json:"endpoints,omitempty"`
+	ModelPickerEnabled  *bool    `json:"model_picker_enabled,omitempty"`
+	ModelPickerCategory string   `json:"model_picker_category,omitempty"`
+	ReasoningEffort     []string `json:"reasoning_effort,omitempty"`
+	Vision              bool     `json:"vision,omitempty"`
+	ParallelToolCalls   *bool    `json:"parallel_tool_calls,omitempty"`
+	ContextWindow       int64    `json:"context_window,omitempty"`
+}
+
+type providerRuntime struct {
+	id            string
+	kind          providerType
+	isDefault     bool
+	baseURL       string
+	apiKey        string
+	apiVersion    string
+	excludeModels map[string]struct{}
+	staticModels  map[string]providerModel
+	staticOrder   []string
+}
+
+type providerModel struct {
+	publicID           string
+	upstreamModel      string
+	providerID         string
+	supportedEndpoints []string
+	disabled           bool
+	raw                json.RawMessage
+}
+
+type providerSetup struct {
+	providers          map[string]*providerRuntime
+	providerOrder      []string
+	defaultProviderID  string
+	models             map[string]providerModel
+	hasConfiguredState bool
+}
+
+type providerModelsFetchResult struct {
+	models      []providerModel
+	etag        string
+	notModified bool
+}
+
+type providerRequestError struct {
+	statusCode int
+	err        error
+}
+
+func (e *providerRequestError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *providerRequestError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func LoadProvidersConfigFile(path string) (ProvidersConfig, error) {
+	var cfg ProvidersConfig
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return cfg, nil
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, fmt.Errorf("read providers config %q: %w", path, err)
+	}
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return cfg, fmt.Errorf("decode providers config %q: %w", path, err)
+	}
+	return cfg, nil
+}
+
+func (c ProvidersConfig) UsesCopilot() bool {
+	if len(c.Providers) == 0 {
+		return true
+	}
+	for _, provider := range c.Providers {
+		if providerType(strings.TrimSpace(provider.Type)) == providerTypeCopilot {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultProviderSetup(h *ProxyHandler) *providerSetup {
+	return &providerSetup{
+		providers: map[string]*providerRuntime{
+			"copilot": {
+				id:            "copilot",
+				kind:          providerTypeCopilot,
+				isDefault:     true,
+				baseURL:       strings.TrimRight(h.copilotURL, "/"),
+				excludeModels: map[string]struct{}{},
+				staticModels:  map[string]providerModel{},
+			},
+		},
+		providerOrder:     []string{"copilot"},
+		defaultProviderID: "copilot",
+		models:            map[string]providerModel{},
+	}
+}
+
+func (h *ProxyHandler) providerSetup() *providerSetup {
+	if h != nil && h.providersState != nil {
+		return h.providersState
+	}
+	return defaultProviderSetup(h)
+}
+
+func (ps *providerSetup) defaultProvider() *providerRuntime {
+	if ps == nil {
+		return nil
+	}
+	return ps.providers[ps.defaultProviderID]
+}
+
+func (ps *providerSetup) providerByID(id string) *providerRuntime {
+	if ps == nil {
+		return nil
+	}
+	return ps.providers[id]
+}
+
+func (ps *providerSetup) lookupModel(model string) (providerModel, bool) {
+	if ps == nil {
+		return providerModel{}, false
+	}
+	pm, ok := ps.models[strings.TrimSpace(model)]
+	return pm, ok
+}
+
+func (h *ProxyHandler) initializeProviders() error {
+	if len(h.providersConfig.Providers) == 0 {
+		return nil
+	}
+
+	setup, err := h.buildConfiguredProviderSetup(context.Background(), h.providersConfig)
+	if err != nil {
+		return err
+	}
+	h.providersState = setup
+	return nil
+}
+
+func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg ProvidersConfig) (*providerSetup, error) {
+	providers, providerOrder, defaultProviderID, err := h.buildProviders(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	setup := &providerSetup{
+		providers:          providers,
+		providerOrder:      providerOrder,
+		defaultProviderID:  defaultProviderID,
+		models:             make(map[string]providerModel),
+		hasConfiguredState: true,
+	}
+
+	needsDynamicModelValidation := false
+	for _, provider := range providers {
+		if provider.kind == providerTypeCopilot && len(providers) > 1 {
+			needsDynamicModelValidation = true
+			break
+		}
+	}
+
+	if !needsDynamicModelValidation {
+		for _, provider := range providers {
+			for publicID, model := range provider.staticModels {
+				setup.models[publicID] = model
+			}
+		}
+		return setup, nil
+	}
+
+	if len(providers) == 0 {
+		return setup, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, modelsUpstreamTimeout)
+	defer cancel()
+
+	for _, providerID := range providerOrder {
+		provider := providers[providerID]
+		if provider.kind != providerTypeCopilot {
+			for publicID, model := range provider.staticModels {
+				if existing, exists := setup.models[publicID]; exists {
+					return nil, fmt.Errorf("model %q is exposed by both provider %q and provider %q", publicID, existing.providerID, model.providerID)
+				}
+				setup.models[publicID] = model
+			}
+			continue
+		}
+
+		result, err := h.fetchProviderModels(ctx, provider, "", "")
+		if err != nil {
+			return nil, fmt.Errorf("load models for provider %q: %w", provider.id, err)
+		}
+		for _, model := range result.models {
+			if existing, exists := setup.models[model.publicID]; exists {
+				if existing.providerID == model.providerID {
+					continue
+				}
+				return nil, fmt.Errorf("model %q is exposed by both provider %q and provider %q", model.publicID, existing.providerID, model.providerID)
+			}
+			setup.models[model.publicID] = model
+		}
+	}
+
+	return setup, nil
+}
+
+func (h *ProxyHandler) buildProviders(cfg ProvidersConfig) (map[string]*providerRuntime, []string, string, error) {
+	providers := make(map[string]*providerRuntime, len(cfg.Providers))
+	providerOrder := make([]string, 0, len(cfg.Providers))
+	defaultProviderID := ""
+	copilotProviders := 0
+
+	for _, raw := range cfg.Providers {
+		provider, err := buildProviderRuntime(raw, h.copilotURL)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		if _, exists := providers[provider.id]; exists {
+			return nil, nil, "", fmt.Errorf("duplicate provider id %q", provider.id)
+		}
+		providers[provider.id] = provider
+		providerOrder = append(providerOrder, provider.id)
+		if provider.kind == providerTypeCopilot {
+			copilotProviders++
+		}
+		if provider.isDefault {
+			if defaultProviderID != "" {
+				return nil, nil, "", fmt.Errorf("multiple default providers configured: %q and %q", defaultProviderID, provider.id)
+			}
+			defaultProviderID = provider.id
+		}
+	}
+
+	if len(providers) == 0 {
+		return nil, nil, "", fmt.Errorf("providers config must include at least one provider when provided explicitly")
+	}
+
+	if defaultProviderID == "" {
+		switch {
+		case len(providers) == 1:
+			for id := range providers {
+				defaultProviderID = id
+			}
+		case copilotProviders == 1:
+			for _, provider := range providers {
+				if provider.kind == providerTypeCopilot {
+					defaultProviderID = provider.id
+					break
+				}
+			}
+		default:
+			return nil, nil, "", fmt.Errorf("multiple providers configured but no default provider selected")
+		}
+	}
+
+	if defaultProvider := providers[defaultProviderID]; defaultProvider != nil {
+		defaultProvider.isDefault = true
+	}
+
+	return providers, providerOrder, defaultProviderID, nil
+}
+
+func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*providerRuntime, error) {
+	id := strings.TrimSpace(cfg.ID)
+	if id == "" {
+		return nil, fmt.Errorf("provider id is required")
+	}
+
+	kind := providerType(strings.TrimSpace(cfg.Type))
+	switch kind {
+	case providerTypeCopilot:
+	case providerTypeAzureOpenAI:
+	default:
+		return nil, fmt.Errorf("provider %q has unsupported type %q", id, cfg.Type)
+	}
+
+	runtime := &providerRuntime{
+		id:            id,
+		kind:          kind,
+		isDefault:     cfg.Default,
+		excludeModels: make(map[string]struct{}, len(cfg.ExcludeModels)),
+		staticModels:  make(map[string]providerModel, len(cfg.Models)),
+	}
+
+	for _, excluded := range cfg.ExcludeModels {
+		excluded = strings.TrimSpace(excluded)
+		if excluded != "" {
+			runtime.excludeModels[excluded] = struct{}{}
+		}
+	}
+
+	switch kind {
+	case providerTypeCopilot:
+		runtime.baseURL = strings.TrimRight(defaultCopilotURL, "/")
+	case providerTypeAzureOpenAI:
+		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+		if baseURL == "" {
+			return nil, fmt.Errorf("provider %q must set base_url", id)
+		}
+		runtime.baseURL = baseURL
+		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
+		runtime.apiKey = strings.TrimSpace(cfg.APIKey)
+		if runtime.apiKey == "" && strings.TrimSpace(cfg.APIKeyEnv) != "" {
+			runtime.apiKey = strings.TrimSpace(os.Getenv(strings.TrimSpace(cfg.APIKeyEnv)))
+		}
+		if runtime.apiKey == "" {
+			return nil, fmt.Errorf("provider %q must set api_key or api_key_env", id)
+		}
+		if len(cfg.Models) == 0 {
+			return nil, fmt.Errorf("provider %q must configure at least one model", id)
+		}
+		for _, modelCfg := range cfg.Models {
+			model, err := buildStaticProviderModel(id, modelCfg)
+			if err != nil {
+				return nil, err
+			}
+			if _, excluded := runtime.excludeModels[model.publicID]; excluded {
+				continue
+			}
+			if _, exists := runtime.staticModels[model.publicID]; exists {
+				return nil, fmt.Errorf("provider %q configures model %q more than once", id, model.publicID)
+			}
+			runtime.staticModels[model.publicID] = model
+			runtime.staticOrder = append(runtime.staticOrder, model.publicID)
+		}
+	}
+
+	return runtime, nil
+}
+
+func buildStaticProviderModel(providerID string, cfg ProviderModelConfig) (providerModel, error) {
+	publicID := strings.TrimSpace(cfg.PublicID)
+	if publicID == "" {
+		return providerModel{}, fmt.Errorf("provider %q contains a model without public_id", providerID)
+	}
+
+	upstreamModel := strings.TrimSpace(cfg.Deployment)
+	if upstreamModel == "" {
+		upstreamModel = publicID
+	}
+
+	name := strings.TrimSpace(cfg.Name)
+	if name == "" {
+		name = publicID
+	}
+
+	endpoints := normalizeProviderEndpoints(cfg.Endpoints)
+	raw, err := synthesizeProviderModelRaw(providerID, publicID, name, endpoints, cfg)
+	if err != nil {
+		return providerModel{}, err
+	}
+
+	return providerModel{
+		publicID:           publicID,
+		upstreamModel:      upstreamModel,
+		providerID:         providerID,
+		supportedEndpoints: endpoints,
+		raw:                raw,
+	}, nil
+}
+
+func normalizeProviderEndpoints(endpoints []string) []string {
+	if len(endpoints) == 0 {
+		return append([]string(nil), defaultStaticProviderEndpoints...)
+	}
+
+	normalized := make([]string, 0, len(endpoints))
+	seen := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		endpoint = strings.TrimSpace(endpoint)
+		if endpoint == "" {
+			continue
+		}
+		if _, ok := seen[endpoint]; ok {
+			continue
+		}
+		seen[endpoint] = struct{}{}
+		normalized = append(normalized, endpoint)
+	}
+	if len(normalized) == 0 {
+		return append([]string(nil), defaultStaticProviderEndpoints...)
+	}
+	return normalized
+}
+
+func synthesizeProviderModelRaw(providerID, publicID, name string, endpoints []string, cfg ProviderModelConfig) (json.RawMessage, error) {
+	type limits struct {
+		MaxContextWindowTokens int64 `json:"max_context_window_tokens,omitempty"`
+	}
+	type supports struct {
+		ParallelToolCalls bool     `json:"parallel_tool_calls"`
+		ReasoningEffort   []string `json:"reasoning_effort,omitempty"`
+		Vision            bool     `json:"vision"`
+	}
+	type capabilities struct {
+		Limits   limits   `json:"limits,omitempty"`
+		Supports supports `json:"supports,omitempty"`
+	}
+
+	modelPickerEnabled := true
+	if cfg.ModelPickerEnabled != nil {
+		modelPickerEnabled = *cfg.ModelPickerEnabled
+	}
+
+	parallelToolCalls := false
+	if cfg.ParallelToolCalls != nil {
+		parallelToolCalls = *cfg.ParallelToolCalls
+	}
+
+	category := strings.TrimSpace(cfg.ModelPickerCategory)
+	if category == "" {
+		category = "versatile"
+	}
+
+	payload := map[string]interface{}{
+		"id":                  publicID,
+		"object":              "model",
+		"created":             0,
+		"owned_by":            providerID,
+		"name":                name,
+		"supported_endpoints": endpoints,
+		"capabilities": capabilities{
+			Limits: limits{
+				MaxContextWindowTokens: cfg.ContextWindow,
+			},
+			Supports: supports{
+				ParallelToolCalls: parallelToolCalls,
+				ReasoningEffort:   append([]string(nil), cfg.ReasoningEffort...),
+				Vision:            cfg.Vision,
+			},
+		},
+		"model_picker_enabled":  modelPickerEnabled,
+		"model_picker_category": category,
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal model %q for provider %q: %w", publicID, providerID, err)
+	}
+	return raw, nil
+}
+
+func (h *ProxyHandler) resolveProviderModel(model, endpoint string) (*providerRuntime, providerModel, bool) {
+	setup := h.providerSetup()
+	model = strings.TrimSpace(model)
+	if model != "" {
+		if providerModel, ok := setup.lookupModel(model); ok {
+			provider := setup.providerByID(providerModel.providerID)
+			if provider != nil {
+				return provider, providerModel, true
+			}
+		}
+	}
+
+	defaultProvider := setup.defaultProvider()
+	if defaultProvider == nil {
+		return nil, providerModel{}, false
+	}
+	return defaultProvider, providerModel{
+		publicID:           model,
+		upstreamModel:      model,
+		providerID:         defaultProvider.id,
+		supportedEndpoints: nil,
+	}, false
+}
+
+func providerModelSupportsEndpoint(model providerModel, endpoint string) bool {
+	if len(model.supportedEndpoints) == 0 {
+		return true
+	}
+	return supportsEndpoint(model.supportedEndpoints, endpoint)
+}
+
+func rewriteRequestModelForProvider(body []byte, upstreamModel string) ([]byte, bool, error) {
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	if upstreamModel == "" {
+		return body, false, nil
+	}
+
+	current := extractResponsesRequestModel(body)
+	if current == "" {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return body, false, nil
+		}
+		current = strings.TrimSpace(payload.Model)
+	}
+
+	if current == "" || current == upstreamModel {
+		return body, false, nil
+	}
+	return rewriteResponsesRequestModel(body, upstreamModel)
+}
+
+func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string, extraQuery string) (string, error) {
+	if provider == nil {
+		return "", fmt.Errorf("provider is required")
+	}
+
+	baseURL := strings.TrimRight(provider.baseURL, "/")
+	fullURL := baseURL + path
+	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" {
+		return appendRawQuery(fullURL, extraQuery), nil
+	}
+	return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+}
+
+func appendQuery(parts ...string) string {
+	combined := ""
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if combined == "" {
+			combined = part
+			continue
+		}
+		combined += "&" + part
+	}
+	return combined
+}
+
+func appendRawQuery(rawURL, rawQuery string) string {
+	rawQuery = strings.TrimSpace(strings.TrimPrefix(rawQuery, "?"))
+	if rawQuery == "" {
+		return rawURL
+	}
+	separator := "?"
+	if strings.Contains(rawURL, "?") {
+		separator = "&"
+	}
+	return rawURL + separator + rawQuery
+}
+
+func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *providerRuntime) error {
+	if provider == nil {
+		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
+	}
+
+	switch provider.kind {
+	case providerTypeCopilot:
+		token, err := h.auth.GetToken(req.Context())
+		if err != nil {
+			return &providerRequestError{statusCode: http.StatusInternalServerError, err: err}
+		}
+		h.setCopilotHeaders(req, token)
+	case providerTypeAzureOpenAI:
+		req.Header.Set("api-key", provider.apiKey)
+		req.Header.Set("Content-Type", "application/json")
+	default:
+		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("unsupported provider type %q", provider.kind)}
+	}
+	return nil
+}
+
+func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string) (*http.Request, error) {
+	fullURL, err := h.providerRequestURL(provider, path, extraQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if len(extraHeaders) > 0 {
+		mergeHeaderValues(req.Header, extraHeaders)
+	}
+	if err := h.applyProviderHeaders(req, provider); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *providerRuntime, rawQuery, ifNoneMatch string) (providerModelsFetchResult, error) {
+	if provider == nil {
+		return providerModelsFetchResult{}, fmt.Errorf("provider is required")
+	}
+
+	switch provider.kind {
+	case providerTypeAzureOpenAI:
+		models := make([]providerModel, 0, len(provider.staticModels))
+		for _, publicID := range provider.staticOrder {
+			model, ok := provider.staticModels[publicID]
+			if ok {
+				models = append(models, model)
+			}
+		}
+		return providerModelsFetchResult{models: models}, nil
+	case providerTypeCopilot:
+		resp, err := h.doWithRetry(func() (*http.Request, error) {
+			req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, rawQuery)
+			if err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(ifNoneMatch) != "" {
+				req.Header.Set("If-None-Match", ifNoneMatch)
+			}
+			return req, nil
+		})
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		result := providerModelsFetchResult{etag: resp.Header.Get("ETag")}
+		if resp.StatusCode == http.StatusNotModified {
+			result.notModified = true
+			return result, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			return providerModelsFetchResult{}, &providerRequestError{
+				statusCode: resp.StatusCode,
+				err:        fmt.Errorf("unexpected /models status %d: %s", resp.StatusCode, string(body)),
+			}
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+
+		models, err := decodeProviderModelsFromBody(provider.id, body, provider.excludeModels)
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+		result.models = models
+		return result, nil
+	default:
+		return providerModelsFetchResult{}, fmt.Errorf("unsupported provider type %q", provider.kind)
+	}
+}
+
+func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[string]struct{}) ([]providerModel, error) {
+	var upstream struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &upstream); err != nil {
+		return nil, err
+	}
+
+	models := make([]providerModel, 0, len(upstream.Data))
+	seen := make(map[string]struct{}, len(upstream.Data))
+	for _, raw := range upstream.Data {
+		var parsed struct {
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+			Policy             struct {
+				State string `json:"state"`
+			} `json:"policy"`
+		}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			continue
+		}
+		publicID := strings.TrimSpace(parsed.ID)
+		if publicID == "" {
+			continue
+		}
+		if _, skip := excluded[publicID]; skip {
+			continue
+		}
+		if _, duplicate := seen[publicID]; duplicate {
+			continue
+		}
+		seen[publicID] = struct{}{}
+		models = append(models, providerModel{
+			publicID:           publicID,
+			upstreamModel:      publicID,
+			providerID:         providerID,
+			supportedEndpoints: append([]string(nil), parsed.SupportedEndpoints...),
+			disabled:           strings.EqualFold(parsed.Policy.State, "disabled"),
+			raw:                raw,
+		})
+	}
+
+	return models, nil
+}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 )
 
 type providerType string
@@ -80,6 +81,7 @@ type providerSetup struct {
 	providers          map[string]*providerRuntime
 	providerOrder      []string
 	defaultProviderID  string
+	modelsMu           sync.RWMutex
 	models             map[string]providerModel
 	hasConfiguredState bool
 }
@@ -181,8 +183,37 @@ func (ps *providerSetup) lookupModel(model string) (providerModel, bool) {
 	if ps == nil {
 		return providerModel{}, false
 	}
+	ps.modelsMu.RLock()
+	defer ps.modelsMu.RUnlock()
 	pm, ok := ps.models[strings.TrimSpace(model)]
 	return pm, ok
+}
+
+func (ps *providerSetup) replaceProviderModels(providerID string, models []providerModel) error {
+	if ps == nil {
+		return nil
+	}
+
+	ps.modelsMu.Lock()
+	defer ps.modelsMu.Unlock()
+
+	next := make(map[string]providerModel, len(ps.models)+len(models))
+	for publicID, model := range ps.models {
+		if model.providerID == providerID {
+			continue
+		}
+		next[publicID] = model
+	}
+
+	for _, model := range models {
+		if existing, exists := next[model.publicID]; exists && existing.providerID != model.providerID {
+			return fmt.Errorf("model %q is exposed by both provider %q and provider %q", model.publicID, existing.providerID, model.providerID)
+		}
+		next[model.publicID] = model
+	}
+
+	ps.models = next
+	return nil
 }
 
 func (h *ProxyHandler) initializeProviders() error {
@@ -284,6 +315,9 @@ func (h *ProxyHandler) buildProviders(cfg ProvidersConfig) (map[string]*provider
 		providerOrder = append(providerOrder, provider.id)
 		if provider.kind == providerTypeCopilot {
 			copilotProviders++
+			if copilotProviders > 1 {
+				return nil, nil, "", fmt.Errorf("multiple copilot providers configured; only one copilot provider is supported")
+			}
 		}
 		if provider.isDefault {
 			if defaultProviderID != "" {
@@ -624,7 +658,12 @@ func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *pro
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bytes.NewReader(body))
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -706,7 +745,7 @@ func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[s
 	}
 
 	models := make([]providerModel, 0, len(upstream.Data))
-	seen := make(map[string]struct{}, len(upstream.Data))
+	indexByID := make(map[string]int, len(upstream.Data))
 	for _, raw := range upstream.Data {
 		var parsed struct {
 			ID                 string   `json:"id"`
@@ -725,19 +764,99 @@ func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[s
 		if _, skip := excluded[publicID]; skip {
 			continue
 		}
-		if _, duplicate := seen[publicID]; duplicate {
+
+		supportedEndpoints := normalizeDynamicProviderEndpoints(parsed.SupportedEndpoints)
+		disabled := strings.EqualFold(parsed.Policy.State, "disabled")
+		if index, duplicate := indexByID[publicID]; duplicate {
+			merged := models[index]
+			merged.supportedEndpoints = mergeDynamicProviderEndpoints(merged.supportedEndpoints, supportedEndpoints)
+			merged.disabled = merged.disabled && disabled
+			baseRaw := merged.raw
+			if merged.disabled != models[index].disabled && !merged.disabled {
+				baseRaw = raw
+			}
+			merged.raw = mergeProviderModelRaw(baseRaw, merged.supportedEndpoints)
+			models[index] = merged
 			continue
 		}
-		seen[publicID] = struct{}{}
+
+		indexByID[publicID] = len(models)
 		models = append(models, providerModel{
 			publicID:           publicID,
 			upstreamModel:      publicID,
 			providerID:         providerID,
-			supportedEndpoints: append([]string(nil), parsed.SupportedEndpoints...),
-			disabled:           strings.EqualFold(parsed.Policy.State, "disabled"),
-			raw:                raw,
+			supportedEndpoints: supportedEndpoints,
+			disabled:           disabled,
+			raw:                mergeProviderModelRaw(raw, supportedEndpoints),
 		})
 	}
 
 	return models, nil
+}
+
+func normalizeDynamicProviderEndpoints(endpoints []string) []string {
+	if len(endpoints) == 0 {
+		return nil
+	}
+
+	normalized := make([]string, 0, len(endpoints))
+	seen := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		endpoint = strings.TrimSpace(endpoint)
+		if endpoint == "" {
+			continue
+		}
+		if _, exists := seen[endpoint]; exists {
+			continue
+		}
+		seen[endpoint] = struct{}{}
+		normalized = append(normalized, endpoint)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func mergeDynamicProviderEndpoints(existing, incoming []string) []string {
+	if len(existing) == 0 || len(incoming) == 0 {
+		return nil
+	}
+
+	merged := append([]string(nil), existing...)
+	seen := make(map[string]struct{}, len(existing)+len(incoming))
+	for _, endpoint := range existing {
+		seen[endpoint] = struct{}{}
+	}
+	for _, endpoint := range incoming {
+		if _, exists := seen[endpoint]; exists {
+			continue
+		}
+		seen[endpoint] = struct{}{}
+		merged = append(merged, endpoint)
+	}
+	return merged
+}
+
+func mergeProviderModelRaw(raw json.RawMessage, supportedEndpoints []string) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+
+	if len(supportedEndpoints) == 0 {
+		delete(payload, "supported_endpoints")
+	} else if encoded, err := json.Marshal(supportedEndpoints); err == nil {
+		payload["supported_endpoints"] = encoded
+	}
+
+	merged, err := json.Marshal(payload)
+	if err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	return merged
 }

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -32,13 +32,6 @@ func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 // HandleResponses handles POST /v1/responses by forwarding the request to
 // Copilot's responses endpoint with only auth headers injected.
 func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "responses"), logger.Err(err))
-		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
-		return
-	}
-
 	bodyBytes, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -60,16 +53,34 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(isStreaming)
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithHeaders(upstreamCtx, token, bodyBytes, extraHeaders)
+	resp, err := h.postResponsesWithHeaders(upstreamCtx, bodyBytes, extraHeaders)
 	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "responses"), logger.Err(err))
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
+		if statusCode == http.StatusBadRequest {
+			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+			return
+		}
+		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
-	resp, err = h.maybeRetryCompactedResponsesRequest(upstreamCtx, token, bodyBytes, extraHeaders, resp)
+	resp, err = h.maybeRetryCompactedResponsesRequest(upstreamCtx, bodyBytes, extraHeaders, resp)
 	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "responses"), logger.Err(err))
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
+		if statusCode == http.StatusBadRequest {
+			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+			return
+		}
+		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
 
@@ -106,13 +117,6 @@ Be concise, structured, and action-oriented. Do not chat with the user. Do not a
 // that Codex expects. The returned compaction item is a proxy-owned token that
 // this proxy can later expand back into summarized context for /responses.
 func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "compact"), logger.Err(err))
-		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
-		return
-	}
-
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -135,10 +139,19 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, bodyBytes, responsesExtraHeadersFromRequest(r))
+	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, bodyBytes, responsesExtraHeadersFromRequest(r))
 	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "compact"), logger.Err(err))
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
+		if statusCode == http.StatusBadRequest {
+			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+			return
+		}
+		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -209,13 +222,6 @@ Respond with a JSON array where each element has "trace_summary" and "memory_sum
 // the traces to the upstream /responses endpoint with a summarization prompt,
 // then transforming the response into the format Codex expects.
 func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Request) {
-	token, err := h.auth.GetToken(r.Context())
-	if err != nil {
-		h.log.Error("failed to get token", logger.F("endpoint", "memory_summarize"), logger.Err(err))
-		writeOpenAIError(w, http.StatusInternalServerError, "authentication failed", "server_error")
-		return
-	}
-
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -258,10 +264,19 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, token, reqBody, responsesExtraHeadersFromRequest(r))
+	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, reqBody, responsesExtraHeadersFromRequest(r))
 	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "memory_summarize"), logger.Err(err))
-		writeOpenAIError(w, upstreamStatusCode(err, http.StatusBadGateway), "upstream request failed", "server_error")
+		if statusCode == http.StatusBadRequest {
+			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+			return
+		}
+		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -395,12 +410,12 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte) ([]byte, []string)
 	return bodyBytes, nil
 }
 
-func (h *ProxyHandler) postResponsesWithFallback(ctx context.Context, token string, bodyBytes []byte) (*http.Response, error) {
-	return h.postResponsesWithFallbackHeaders(ctx, token, bodyBytes, nil)
+func (h *ProxyHandler) postResponsesWithFallback(ctx context.Context, bodyBytes []byte) (*http.Response, error) {
+	return h.postResponsesWithFallbackHeaders(ctx, bodyBytes, nil)
 }
 
-func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, token string, bodyBytes []byte, extraHeaders http.Header) (*http.Response, error) {
-	resp, err := h.postResponsesWithHeaders(ctx, token, bodyBytes, extraHeaders)
+func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, bodyBytes []byte, extraHeaders http.Header) (*http.Response, error) {
+	resp, err := h.postResponsesWithHeaders(ctx, bodyBytes, extraHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +436,8 @@ func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, tok
 	}
 
 	requestedModel := extractResponsesRequestModel(bodyBytes)
-	fallbackModel, fallbackErr := h.pickResponsesCompatibleModel(ctx, token, requestedModel)
+	provider, _, _ := h.resolveProviderModel(requestedModel, "/responses")
+	fallbackModel, fallbackErr := h.pickResponsesCompatibleModel(ctx, provider, requestedModel)
 	if fallbackErr != nil {
 		h.log.Debug("responses fallback lookup failed", logger.Err(fallbackErr))
 		return resp, nil
@@ -444,7 +460,7 @@ func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, tok
 		logger.F("fallback_model", fallbackModel),
 	)
 
-	retryResp, retryErr := h.postResponsesWithHeaders(ctx, token, fallbackBody, extraHeaders)
+	retryResp, retryErr := h.postResponsesWithHeaders(ctx, fallbackBody, extraHeaders)
 	if retryErr != nil {
 		h.log.Debug("responses fallback request failed", logger.Err(retryErr))
 		return resp, nil
@@ -453,7 +469,7 @@ func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, tok
 	return retryResp, nil
 }
 
-func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, token string, bodyBytes []byte, extraHeaders http.Header, resp *http.Response) (*http.Response, error) {
+func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, bodyBytes []byte, extraHeaders http.Header, resp *http.Response) (*http.Response, error) {
 	if resp == nil || resp.StatusCode != http.StatusRequestEntityTooLarge {
 		return resp, nil
 	}
@@ -484,7 +500,7 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, 
 	}
 
 	prefixLen := len(input) - keepTail
-	summary, err := h.compactResponsesInput(ctx, token, model, input[:prefixLen], extraHeaders)
+	summary, err := h.compactResponsesInput(ctx, model, input[:prefixLen], extraHeaders)
 	if err != nil {
 		h.log.Debug("responses 413 compaction failed", logger.Err(err))
 		return resp, nil
@@ -530,7 +546,7 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, 
 		logger.F("compacted_bytes", rawMessagesSize(compactedInput)),
 	)
 
-	retryResp, retryErr := h.postResponsesWithHeaders(ctx, token, retryBody, extraHeaders)
+	retryResp, retryErr := h.postResponsesWithHeaders(ctx, retryBody, extraHeaders)
 	if retryErr != nil {
 		h.log.Debug("responses 413 retry request failed", logger.Err(retryErr))
 		return resp, nil
@@ -539,7 +555,7 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, 
 	return retryResp, nil
 }
 
-func (h *ProxyHandler) compactResponsesInput(ctx context.Context, token, model string, input []json.RawMessage, extraHeaders http.Header) (string, error) {
+func (h *ProxyHandler) compactResponsesInput(ctx context.Context, model string, input []json.RawMessage, extraHeaders http.Header) (string, error) {
 	model = strings.TrimSpace(model)
 	if model == "" {
 		return "", fmt.Errorf("missing model for websocket compaction")
@@ -554,7 +570,7 @@ func (h *ProxyHandler) compactResponsesInput(ctx context.Context, token, model s
 		return "", err
 	}
 
-	resp, err := h.postResponsesWithFallbackHeaders(ctx, token, bodyBytes, extraHeaders)
+	resp, err := h.postResponsesWithFallbackHeaders(ctx, bodyBytes, extraHeaders)
 	if err != nil {
 		return "", err
 	}
@@ -635,53 +651,31 @@ func rewriteResponsesRequestModel(body []byte, model string) ([]byte, bool, erro
 	return rewritten, true, nil
 }
 
-func (h *ProxyHandler) pickResponsesCompatibleModel(ctx context.Context, token, exclude string) (string, error) {
-	resp, err := h.doWithRetry(func() (*http.Request, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.copilotURL+"/models", nil)
-		if err != nil {
-			return nil, err
-		}
-		h.setCopilotHeaders(req, token)
-		return req, nil
-	})
+func (h *ProxyHandler) pickResponsesCompatibleModel(ctx context.Context, provider *providerRuntime, exclude string) (string, error) {
+	if provider == nil {
+		return "", fmt.Errorf("provider is required")
+	}
+
+	result, err := h.fetchProviderModels(ctx, provider, "", "")
 	if err != nil {
-		return "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return "", fmt.Errorf("unexpected /models status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var upstream struct {
-		Data []struct {
-			ID                 string   `json:"id"`
-			SupportedEndpoints []string `json:"supported_endpoints"`
-			Policy             struct {
-				State string `json:"state"`
-			} `json:"policy"`
-		} `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&upstream); err != nil {
 		return "", err
 	}
 
 	supported := make(map[string]struct{})
 	firstAvailable := ""
-	for _, model := range upstream.Data {
-		if model.ID == "" || model.ID == exclude {
+	for _, model := range result.models {
+		if model.publicID == "" || model.publicID == exclude {
 			continue
 		}
-		if !supportsEndpoint(model.SupportedEndpoints, "/responses") {
+		if !providerModelSupportsEndpoint(model, "/responses") {
 			continue
 		}
-		if strings.EqualFold(model.Policy.State, "disabled") {
+		if model.disabled {
 			continue
 		}
-		supported[model.ID] = struct{}{}
+		supported[model.publicID] = struct{}{}
 		if firstAvailable == "" {
-			firstAvailable = model.ID
+			firstAvailable = model.publicID
 		}
 	}
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -410,10 +410,6 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte) ([]byte, []string)
 	return bodyBytes, nil
 }
 
-func (h *ProxyHandler) postResponsesWithFallback(ctx context.Context, bodyBytes []byte) (*http.Response, error) {
-	return h.postResponsesWithFallbackHeaders(ctx, bodyBytes, nil)
-}
-
 func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, bodyBytes []byte, extraHeaders http.Header) (*http.Response, error) {
 	resp, err := h.postResponsesWithHeaders(ctx, bodyBytes, extraHeaders)
 	if err != nil {

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -279,16 +279,10 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 		})
 	}
 
-	token, err := h.auth.GetToken(s.ctx)
-	if err != nil {
-		s.sendWrappedError(http.StatusInternalServerError, fmt.Sprintf("failed to get token: %v", err), "server_error", nil)
-		return err
-	}
-
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(true)
 	defer upstreamCancel()
 
-	resp, deltaAttempted, deltaFallback, err := s.postCreateRequest(h, upstreamCtx, token, request, plan)
+	resp, deltaAttempted, deltaFallback, err := s.postCreateRequest(h, upstreamCtx, request, plan)
 	metrics.deltaAttempted = deltaAttempted
 	metrics.deltaFallback = deltaFallback
 	if err != nil {
@@ -318,7 +312,7 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 	}
 
 	s.rememberResponse(plan.resetHistory, responseID, plan.signature, plan.currentInput, outputItems)
-	metrics = s.maybeAutoCompactHistory(h, token, request, metrics)
+	metrics = s.maybeAutoCompactHistory(h, request, metrics)
 	s.logRequestMetrics(h, request, responseID, metrics)
 	return nil
 }
@@ -346,13 +340,13 @@ func (s *responsesWebSocketSession) planRequest(h *ProxyHandler, request *respon
 	return plan, nil
 }
 
-func (s *responsesWebSocketSession) postCreateRequest(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, plan responsesWebSocketRequestPlan) (*http.Response, bool, bool, error) {
-	resp, err := s.postCreateRequestSegments(h, ctx, token, request, plan.upstreamSegments(), plan.useTurnStateDelta)
+func (s *responsesWebSocketSession) postCreateRequest(h *ProxyHandler, ctx context.Context, request *responsesWebSocketCreateRequest, plan responsesWebSocketRequestPlan) (*http.Response, bool, bool, error) {
+	resp, err := s.postCreateRequestSegments(h, ctx, request, plan.upstreamSegments(), plan.useTurnStateDelta)
 	if err != nil || resp == nil {
 		return resp, plan.useTurnStateDelta, false, err
 	}
 	if !plan.useTurnStateDelta {
-		resp, err = s.maybeRetryCompactedCreateRequest(h, ctx, token, request, resp, true)
+		resp, err = s.maybeRetryCompactedCreateRequest(h, ctx, request, resp, true)
 		return resp, false, false, err
 	}
 	if resp.StatusCode == http.StatusOK {
@@ -375,21 +369,21 @@ func (s *responsesWebSocketSession) postCreateRequest(h *ProxyHandler, ctx conte
 	)
 	s.turnState = ""
 
-	resp, err = s.postCreateRequestSegments(h, ctx, token, request, plan.fullReplaySegments, false)
+	resp, err = s.postCreateRequestSegments(h, ctx, request, plan.fullReplaySegments, false)
 	if err != nil || resp == nil {
 		return resp, true, true, err
 	}
-	resp, err = s.maybeRetryCompactedCreateRequest(h, ctx, token, request, resp, true)
+	resp, err = s.maybeRetryCompactedCreateRequest(h, ctx, request, resp, true)
 	return resp, true, true, err
 }
 
-func (s *responsesWebSocketSession) postCreateRequestSegments(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, inputSegments [][]json.RawMessage, includeTurnState bool) (*http.Response, error) {
+func (s *responsesWebSocketSession) postCreateRequestSegments(h *ProxyHandler, ctx context.Context, request *responsesWebSocketCreateRequest, inputSegments [][]json.RawMessage, includeTurnState bool) (*http.Response, error) {
 	bodyBytes, err := request.upstreamBody(inputSegments...)
 	if err != nil {
 		return nil, err
 	}
 	bodyBytes = h.rewriteResponsesRequestBody(bodyBytes, "responses/websocket", true)
-	return h.postResponsesWithHeaders(ctx, token, bodyBytes, s.requestHeaders(request, includeTurnState))
+	return h.postResponsesWithHeaders(ctx, bodyBytes, s.requestHeaders(request, includeTurnState))
 }
 
 func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCreateRequest, includeTurnState bool) http.Header {
@@ -436,11 +430,11 @@ func (s *responsesWebSocketSession) rememberResponse(resetHistory bool, response
 	s.historyItems = append(s.historyItems, outputItems...)
 }
 
-func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, token string, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
+func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
 	ctx, cancel := h.newInferenceUpstreamContext(false)
 	defer cancel()
 
-	compaction, compacted, err := s.compactHistory(h, ctx, token, request, false)
+	compaction, compacted, err := s.compactHistory(h, ctx, request, false)
 	if err != nil {
 		h.log.Debug("responses websocket auto-compaction failed",
 			logger.Err(err),
@@ -469,12 +463,12 @@ func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, tok
 	return metrics
 }
 
-func (s *responsesWebSocketSession) maybeRetryCompactedCreateRequest(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, resp *http.Response, fullReplayUsed bool) (*http.Response, error) {
+func (s *responsesWebSocketSession) maybeRetryCompactedCreateRequest(h *ProxyHandler, ctx context.Context, request *responsesWebSocketCreateRequest, resp *http.Response, fullReplayUsed bool) (*http.Response, error) {
 	if resp == nil || !fullReplayUsed || resp.StatusCode != http.StatusRequestEntityTooLarge || strings.TrimSpace(request.PreviousResponseID) == "" {
 		return resp, nil
 	}
 
-	compaction, compacted, err := s.compactHistory(h, ctx, token, request, true)
+	compaction, compacted, err := s.compactHistory(h, ctx, request, true)
 	if err != nil {
 		h.log.Debug("responses websocket 413 compaction failed",
 			logger.Err(err),
@@ -499,10 +493,10 @@ func (s *responsesWebSocketSession) maybeRetryCompactedCreateRequest(h *ProxyHan
 	)
 
 	_ = resp.Body.Close()
-	return s.postCreateRequestSegments(h, ctx, token, request, [][]json.RawMessage{s.historyItems, request.Input}, false)
+	return s.postCreateRequestSegments(h, ctx, request, [][]json.RawMessage{s.historyItems, request.Input}, false)
 }
 
-func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.Context, token string, request *responsesWebSocketCreateRequest, force bool) (responsesWebSocketHistoryCompaction, bool, error) {
+func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.Context, request *responsesWebSocketCreateRequest, force bool) (responsesWebSocketHistoryCompaction, bool, error) {
 	var result responsesWebSocketHistoryCompaction
 
 	cfg := h.responsesWebSocketConfig()
@@ -532,7 +526,7 @@ func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.
 	result.fromItems = len(s.historyItems)
 	result.fromBytes = rawMessagesSize(s.historyItems)
 
-	summary, err := h.compactResponsesInput(ctx, token, request.Model, prefix, s.requestHeaders(request, false))
+	summary, err := h.compactResponsesInput(ctx, request.Model, prefix, s.requestHeaders(request, false))
 	if err != nil {
 		return result, false, err
 	}

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -305,9 +305,10 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 
 	responseID, outputItems, err := s.streamUpstreamResponse(resp.Body, resp.Header)
 	if err != nil {
-		if !errors.Is(err, errStreamFailedUpstream) {
-			s.sendWrappedError(http.StatusBadGateway, err.Error(), "server_error", nil)
+		if errors.Is(err, errStreamFailedUpstream) {
+			return nil
 		}
+		s.sendWrappedError(http.StatusBadGateway, err.Error(), "server_error", nil)
 		return err
 	}
 

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -773,11 +773,21 @@ func TestHandleResponsesWebSocket_TurnStateDeltaFallsBackToFullReplay(t *testing
 	}
 }
 
-func TestHandleResponsesWebSocket_ResponseFailedIsTerminal(t *testing.T) {
+func TestHandleResponsesWebSocket_ResponseFailedKeepsSessionOpen(t *testing.T) {
+	var upstreamRequests int
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamRequests++
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-fail\"}}\n\n")
-		_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-fail\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"context too long\"}}}\n\n")
+		switch upstreamRequests {
+		case 1:
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-fail\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-fail\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"context too long\"}}}\n\n")
+		case 2:
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-retry\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-retry\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+		default:
+			t.Fatalf("unexpected upstream request count %d", upstreamRequests)
+		}
 	})
 
 	server := startResponsesWebSocketProxyServer(t, handler)
@@ -809,22 +819,45 @@ func TestHandleResponsesWebSocket_ResponseFailedIsTerminal(t *testing.T) {
 		t.Fatalf("expected response.failed, got %v", failed["type"])
 	}
 
-	// The connection should close without a proxy-generated error frame.
-	// If the proxy sent a second error, we'd read it here.
-	if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
-		t.Fatalf("failed to set read deadline: %v", err)
+	retry := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "try again"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(retry); err != nil {
+		t.Fatalf("failed to write retry websocket request: %v", err)
 	}
-	_, _, err := conn.ReadMessage()
-	if err == nil {
-		t.Fatalf("expected connection to close after response.failed, but got another message")
+
+	retryCreated := mustReadWebSocketJSON(t, conn)
+	if retryCreated["type"] != "response.created" {
+		t.Fatalf("expected retry response.created, got %v", retryCreated["type"])
+	}
+
+	retryCompleted := mustReadWebSocketJSON(t, conn)
+	if retryCompleted["type"] != "response.completed" {
+		t.Fatalf("expected retry response.completed, got %v", retryCompleted["type"])
 	}
 }
 
-func TestHandleResponsesWebSocket_ResponseIncompleteIsTerminal(t *testing.T) {
+func TestHandleResponsesWebSocket_ResponseIncompleteKeepsSessionOpen(t *testing.T) {
+	var upstreamRequests int
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamRequests++
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-inc\"}}\n\n")
-		_, _ = fmt.Fprint(w, "event: response.incomplete\ndata: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp-inc\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n\n")
+		switch upstreamRequests {
+		case 1:
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-inc\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.incomplete\ndata: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp-inc\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n\n")
+		case 2:
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-next\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-next\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+		default:
+			t.Fatalf("unexpected upstream request count %d", upstreamRequests)
+		}
 	})
 
 	server := startResponsesWebSocketProxyServer(t, handler)
@@ -854,30 +887,60 @@ func TestHandleResponsesWebSocket_ResponseIncompleteIsTerminal(t *testing.T) {
 		t.Fatalf("expected response.incomplete, got %v", incomplete["type"])
 	}
 
-	// No proxy-generated error frame should follow.
-	if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
-		t.Fatalf("failed to set read deadline: %v", err)
+	next := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "continue"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(next); err != nil {
+		t.Fatalf("failed to write follow-up websocket request: %v", err)
 	}
-	_, _, err := conn.ReadMessage()
-	if err == nil {
-		t.Fatalf("expected connection to close after response.incomplete, but got another message")
+
+	nextCreated := mustReadWebSocketJSON(t, conn)
+	if nextCreated["type"] != "response.created" {
+		t.Fatalf("expected follow-up response.created, got %v", nextCreated["type"])
+	}
+
+	nextCompleted := mustReadWebSocketJSON(t, conn)
+	if nextCompleted["type"] != "response.completed" {
+		t.Fatalf("expected follow-up response.completed, got %v", nextCompleted["type"])
 	}
 }
 
-func TestHandleResponsesWebSocket_ResponseFailedExitsImmediatelyOnStalledUpstream(t *testing.T) {
+func TestHandleResponsesWebSocket_ResponseFailedOnStalledUpstreamKeepsSessionOpen(t *testing.T) {
 	// Regression test: if upstream emits response.failed and then stalls
 	// (keeps the body open), the proxy should exit the SSE loop immediately
-	// rather than blocking until EOF or the 60-minute timeout.
+	// rather than blocking until EOF or the 60-minute timeout, and the
+	// websocket session should remain usable for the next turn.
 	stallReleased := make(chan struct{})
+	var mu sync.Mutex
+	upstreamRequests := 0
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		upstreamRequests++
+		requestNumber := upstreamRequests
+		mu.Unlock()
+
 		w.Header().Set("Content-Type", "text/event-stream")
-		flusher, _ := w.(http.Flusher)
-		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-stall\"}}\n\n")
-		flusher.Flush()
-		_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-stall\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"context too long\"}}}\n\n")
-		flusher.Flush()
-		// Stall: keep the body open until the test signals release.
-		<-stallReleased
+		switch requestNumber {
+		case 1:
+			flusher, _ := w.(http.Flusher)
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-stall\"}}\n\n")
+			flusher.Flush()
+			_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-stall\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"context too long\"}}}\n\n")
+			flusher.Flush()
+			// Stall: keep the body open until the test signals release.
+			<-stallReleased
+		case 2:
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-after-stall\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-after-stall\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+		default:
+			t.Fatalf("unexpected upstream request count %d", requestNumber)
+		}
 	})
 
 	server := startResponsesWebSocketProxyServer(t, handler)
@@ -910,15 +973,27 @@ func TestHandleResponsesWebSocket_ResponseFailedExitsImmediatelyOnStalledUpstrea
 		t.Fatalf("expected response.failed, got %v", failed["type"])
 	}
 
-	// The connection should close promptly without waiting for upstream EOF.
-	// Use a tight deadline: if the proxy blocked on the stalled body, this
-	// would time out at 2 seconds (mustReadWebSocketJSON's deadline).
-	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
-		t.Fatalf("failed to set read deadline: %v", err)
+	next := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "after failure"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(next); err != nil {
+		t.Fatalf("failed to write follow-up websocket request: %v", err)
 	}
-	_, _, err := conn.ReadMessage()
-	if err == nil {
-		t.Fatalf("expected connection to close after response.failed on stalled upstream, but got another message")
+
+	nextCreated := mustReadWebSocketJSON(t, conn)
+	if nextCreated["type"] != "response.created" {
+		t.Fatalf("expected follow-up response.created, got %v", nextCreated["type"])
+	}
+
+	nextCompleted := mustReadWebSocketJSON(t, conn)
+	if nextCompleted["type"] != "response.completed" {
+		t.Fatalf("expected follow-up response.completed, got %v", nextCompleted["type"])
 	}
 }
 
@@ -1032,7 +1107,7 @@ func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *test
 
 	server := startResponsesWebSocketProxyServer(t, handler)
 	conn := mustDialResponsesWebSocket(t, server, http.Header{
-		"session_id":           []string{"conv-123"},
+		"session_id":          []string{"conv-123"},
 		"X-Client-Request-Id": []string{"req-456"},
 	})
 	defer func() { _ = conn.Close() }()

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -33,13 +34,78 @@ func upstreamStatusCode(err error, fallback int) int {
 }
 
 func extractRequestModel(body []byte) string {
-	var payload struct {
-		Model string `json:"model"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	tok, err := dec.Token()
+	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(payload.Model)
+
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return ""
+	}
+
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+
+		key, ok := keyToken.(string)
+		if !ok {
+			return ""
+		}
+
+		if key == "model" {
+			var model string
+			if err := dec.Decode(&model); err != nil {
+				return ""
+			}
+			return strings.TrimSpace(model)
+		}
+
+		if err := skipJSONValue(dec); err != nil {
+			return ""
+		}
+	}
+
+	return ""
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		for dec.More() {
+			if _, err := dec.Token(); err != nil {
+				return err
+			}
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err = dec.Token()
+		return err
+	case '[':
+		for dec.More() {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err = dec.Token()
+		return err
+	default:
+		return nil
+	}
 }
 
 func mergeHeaderValues(dst, src http.Header) {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -94,10 +94,6 @@ func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*h
 	return h.postJSONEndpoint(ctx, "/chat/completions", body)
 }
 
-func (h *ProxyHandler) postResponses(ctx context.Context, body []byte) (*http.Response, error) {
-	return h.postJSONEndpoint(ctx, "/responses", body)
-}
-
 func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
 	return h.postJSONEndpointWithHeaders(ctx, "/responses", body, extraHeaders)
 }

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 func (h *ProxyHandler) newInferenceUpstreamContext(streaming bool) (context.Context, context.CancelFunc) {
@@ -23,11 +25,21 @@ func upstreamStatusCode(err error, fallback int) int {
 	if errors.As(err, &upstreamErr) {
 		return upstreamErr.statusCode
 	}
+	var providerErr *providerRequestError
+	if errors.As(err, &providerErr) {
+		return providerErr.statusCode
+	}
 	return fallback
 }
 
-func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, token, path string, body []byte) (*http.Response, error) {
-	return h.postJSONEndpointWithHeaders(ctx, token, path, body, nil)
+func extractRequestModel(body []byte) string {
+	var payload struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Model)
 }
 
 func mergeHeaderValues(dst, src http.Header) {
@@ -39,30 +51,55 @@ func mergeHeaderValues(dst, src http.Header) {
 	}
 }
 
-func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, token, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
+func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, []byte, error) {
+	model := extractRequestModel(body)
+	provider, owner, known := h.resolveProviderModel(model, endpoint)
+	if provider == nil {
+		return nil, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
+	}
+	if known && !providerModelSupportsEndpoint(owner, endpoint) {
+		return nil, nil, &providerRequestError{
+			statusCode: http.StatusBadRequest,
+			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
+		}
+	}
+
+	rewrittenBody, _, err := rewriteRequestModelForProvider(body, owner.upstreamModel)
+	if err != nil {
+		return nil, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+	}
+	return provider, rewrittenBody, nil
+}
+
+func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body []byte) (*http.Response, error) {
+	return h.postJSONEndpointWithHeaders(ctx, path, body, nil)
+}
+
+func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
+	provider, rewrittenBody, err := h.resolveProviderRequest(body, path)
+	if err != nil {
+		return nil, err
+	}
+
 	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.copilotURL+path, bytes.NewReader(body))
+		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "")
 		if err != nil {
 			return nil, err
 		}
-		if len(extraHeaders) > 0 {
-			mergeHeaderValues(req.Header, extraHeaders)
-		}
-		h.setCopilotHeaders(req, token)
 		return req, nil
 	})
 }
 
-func (h *ProxyHandler) postChatCompletions(ctx context.Context, token string, body []byte) (*http.Response, error) {
-	return h.postJSONEndpoint(ctx, token, "/chat/completions", body)
+func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*http.Response, error) {
+	return h.postJSONEndpoint(ctx, "/chat/completions", body)
 }
 
-func (h *ProxyHandler) postResponses(ctx context.Context, token string, body []byte) (*http.Response, error) {
-	return h.postJSONEndpoint(ctx, token, "/responses", body)
+func (h *ProxyHandler) postResponses(ctx context.Context, body []byte) (*http.Response, error) {
+	return h.postJSONEndpoint(ctx, "/responses", body)
 }
 
-func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, token string, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	return h.postJSONEndpointWithHeaders(ctx, token, "/responses", body, extraHeaders)
+func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
+	return h.postJSONEndpointWithHeaders(ctx, "/responses", body, extraHeaders)
 }
 
 func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {

--- a/proxy/upstream_http_test.go
+++ b/proxy/upstream_http_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import "testing"
+
+func TestExtractRequestModel(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "top level model",
+			body: `{"model":"gpt-4.1","input":"hello"}`,
+			want: "gpt-4.1",
+		},
+		{
+			name: "nested content before model",
+			body: `{"input":{"messages":[{"role":"user","content":"hi"}],"metadata":{"nested":[1,2,3]}},"model":"  gpt-4o-mini  "}`,
+			want: "gpt-4o-mini",
+		},
+		{
+			name: "nested model key is ignored",
+			body: `{"input":{"model":"wrong"},"metadata":{"flags":["a","b"]}}`,
+			want: "",
+		},
+		{
+			name: "non string model is ignored",
+			body: `{"model":123,"input":"hello"}`,
+			want: "",
+		},
+		{
+			name: "non object payload is ignored",
+			body: `["gpt-4.1"]`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractRequestModel([]byte(tt.body)); got != tt.want {
+				t.Fatalf("extractRequestModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/live-cli-smoke.sh
+++ b/scripts/live-cli-smoke.sh
@@ -100,7 +100,7 @@ assert_exact_output() {
 }
 
 read_normalized_output() {
-  awk 'NF { line = $0 } END { gsub(/\r/, "", line); printf "%s", line }' "$1"
+  awk 'NF { gsub(/\r/, "", $0); printf "%s", $0 }' "$1"
 }
 
 start_proxy() {

--- a/server/server.go
+++ b/server/server.go
@@ -53,7 +53,7 @@ func WithStreamingUpstreamTimeout(timeout time.Duration) Option {
 }
 
 // New creates a Server with routes and timeouts configured.
-func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string, opts ...Option) *Server {
+func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string, opts ...Option) (*Server, error) {
 	cfg := options{}
 	for _, opt := range opts {
 		if opt != nil {
@@ -61,7 +61,10 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		}
 	}
 
-	handler := proxy.NewProxyHandler(authenticator, log, cfg.proxyOptions...)
+	handler, err := proxy.NewProxyHandler(authenticator, log, cfg.proxyOptions...)
+	if err != nil {
+		return nil, err
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
@@ -87,7 +90,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 			IdleTimeout:  120 * time.Second,
 		},
 		log: log,
-	}
+	}, nil
 }
 
 // Start begins listening in a goroutine. It returns an error if the listener

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,7 +28,10 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 		t.Fatalf("expected TCP address, got %T", listener.Addr())
 	}
 
-	srv := New(auth.NewTestAuthenticator("test-token"), logger.New(logger.ParseLevel("error")), "127.0.0.1", strconv.Itoa(addr.Port))
+	srv, err := New(auth.NewTestAuthenticator("test-token"), logger.New(logger.ParseLevel("error")), "127.0.0.1", strconv.Itoa(addr.Port))
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
 	err = srv.Start()
 	if err == nil {
 		t.Fatal("expected Start to fail when port is already in use")
@@ -42,12 +45,15 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 }
 
 func TestNew_ConfiguresExtendedWriteTimeout(t *testing.T) {
-	srv := New(
+	srv, err := New(
 		auth.NewTestAuthenticator("test-token"),
 		logger.New(logger.ParseLevel("error")),
 		"127.0.0.1",
 		"0",
 	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
 
 	if got, want := srv.httpServer.WriteTimeout, 65*time.Minute; got != want {
 		t.Fatalf("WriteTimeout = %v, want %v", got, want)
@@ -73,13 +79,16 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := New(
+			srv, err := New(
 				auth.NewTestAuthenticator("test-token"),
 				logger.New(logger.ParseLevel("error")),
 				"127.0.0.1",
 				"0",
 				tc.opts...,
 			)
+			if err != nil {
+				t.Fatalf("failed to initialize server: %v", err)
+			}
 
 			if got, want := srv.httpServer.WriteTimeout, customTimeout+5*time.Minute; got != want {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)


### PR DESCRIPTION
## Summary
- add provider config loading and provider-aware model routing across upstreams
- merge provider model catalogs into `/v1/models` and enforce per-model endpoint support
- rewrite requests to provider deployment IDs, add provider-specific readiness probes, and surface invalid provider config during server init
- update docs and examples so Azure setup does not rely on a checked-in sample config

## Validation
- make test
- make build