### PR TITLE
clarify multi-provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vekil
 
-High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs, forwarding all requests to GitHub Copilot's backend (`api.githubcopilot.com`). This lets you use tools that speak the Anthropic, Gemini, or OpenAI protocol with your GitHub Copilot subscription.
+High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs. By default it forwards requests to GitHub Copilot's backend (`api.githubcopilot.com`), and it can also route selected models to configured providers such as Azure OpenAI behind the same proxy endpoint. This lets you use tools that speak the Anthropic, Gemini, or OpenAI protocol with your GitHub Copilot subscription, while still exposing additional provider-backed models when configured.
 
 ## What It Supports
 
@@ -38,7 +38,9 @@ brew install --cask sozercan/repo/vekil
 
 Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
 
-On first run, authenticate with GitHub's device code flow. Tokens are cached in `~/.config/vekil/`.
+If your setup includes a Copilot provider, first run starts GitHub's device code flow. Tokens are cached in `~/.config/vekil/`.
+
+For multi-provider setup and non-Copilot-only deployments, see [Configuration](docs/configuration.md).
 
 ## Docs
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,10 +57,12 @@ kubectl apply -f k8s/vekil.yaml
 
 ## First Run
 
-On first run, the proxy starts GitHub's device code flow:
+If your setup includes a Copilot provider, the proxy starts GitHub's device code flow on first run:
 
 1. Visit the URL shown in the terminal.
 2. Enter the one-time code.
 3. Authorize the application.
 
 Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry.
+
+If your provider config does not include Copilot, startup skips GitHub authentication. See [configuration.md](configuration.md) for multi-provider setup details.


### PR DESCRIPTION
## What changed
- clarifies that Vekil defaults to GitHub Copilot but can also route configured models to other providers such as Azure OpenAI
- updates the README first-run wording so GitHub device auth is described as conditional on having a Copilot provider configured
- adds a direct pointer to the configuration docs for multi-provider and non-Copilot-only setups
- updates getting started with the same conditional-auth clarification

## Why
The top-level docs still read as if every deployment forwards all traffic to Copilot and always requires GitHub device authentication on first run. That was no longer true after multi-provider routing landed.

## Impact
Users configuring Azure OpenAI or other non-Copilot-only setups should now get the right expectations from the landing docs without having to infer behavior from deeper configuration pages.

## Validation
- `git diff --check`
