### PR TITLE
Add menubar providers-config support

### DIFF
--- a/cmd/menubar/config.go
+++ b/cmd/menubar/config.go
@@ -13,7 +13,11 @@ import (
 
 const menubarConfigFilename = "menubar.json"
 
-var userConfigDir = os.UserConfigDir
+var (
+	userConfigDir          = os.UserConfigDir
+	errMenubarConfigLoad   = errors.New("menubar config load failed")
+	errProvidersConfigLoad = errors.New("providers config load failed")
+)
 
 type menubarConfig struct {
 	ProvidersConfigPath string `json:"providers_config_path,omitempty"`
@@ -84,13 +88,17 @@ func saveMenubarConfig(cfg menubarConfig) error {
 func loadProvidersConfigForMenubar() (menubarConfig, proxy.ProvidersConfig, error) {
 	cfg, err := loadMenubarConfig()
 	if err != nil {
-		return menubarConfig{}, proxy.ProvidersConfig{}, err
+		return menubarConfig{}, proxy.ProvidersConfig{}, fmt.Errorf("%w: %w", errMenubarConfigLoad, err)
 	}
 
 	providersCfg, err := proxy.LoadProvidersConfigFile(cfg.ProvidersConfigPath)
 	if err != nil {
-		return cfg, proxy.ProvidersConfig{}, err
+		return cfg, proxy.ProvidersConfig{}, fmt.Errorf("%w: %w", errProvidersConfigLoad, err)
 	}
 
 	return cfg, providersCfg, nil
+}
+
+func isMenubarConfigLoadError(err error) bool {
+	return errors.Is(err, errMenubarConfigLoad)
 }

--- a/cmd/menubar/config.go
+++ b/cmd/menubar/config.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sozercan/vekil/proxy"
+)
+
+const menubarConfigFilename = "menubar.json"
+
+var userConfigDir = os.UserConfigDir
+
+type menubarConfig struct {
+	ProvidersConfigPath string `json:"providers_config_path,omitempty"`
+}
+
+func menubarConfigPath() (string, error) {
+	dir, err := userConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "vekil", menubarConfigFilename), nil
+}
+
+func loadMenubarConfig() (menubarConfig, error) {
+	path, err := menubarConfigPath()
+	if err != nil {
+		return menubarConfig{}, err
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return menubarConfig{}, nil
+		}
+		return menubarConfig{}, fmt.Errorf("read menubar config %q: %w", path, err)
+	}
+
+	var cfg menubarConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return menubarConfig{}, fmt.Errorf("decode menubar config %q: %w", path, err)
+	}
+
+	cfg.ProvidersConfigPath = strings.TrimSpace(cfg.ProvidersConfigPath)
+	return cfg, nil
+}
+
+func saveMenubarConfig(cfg menubarConfig) error {
+	path, err := menubarConfigPath()
+	if err != nil {
+		return err
+	}
+
+	cfg.ProvidersConfigPath = strings.TrimSpace(cfg.ProvidersConfigPath)
+	if cfg.ProvidersConfigPath == "" {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove menubar config %q: %w", path, err)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create menubar config dir: %w", err)
+	}
+
+	body, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode menubar config: %w", err)
+	}
+
+	body = append(body, '\n')
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return fmt.Errorf("write menubar config %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func loadProvidersConfigForMenubar() (menubarConfig, proxy.ProvidersConfig, error) {
+	cfg, err := loadMenubarConfig()
+	if err != nil {
+		return menubarConfig{}, proxy.ProvidersConfig{}, err
+	}
+
+	providersCfg, err := proxy.LoadProvidersConfigFile(cfg.ProvidersConfigPath)
+	if err != nil {
+		return cfg, proxy.ProvidersConfig{}, err
+	}
+
+	return cfg, providersCfg, nil
+}

--- a/cmd/menubar/config_test.go
+++ b/cmd/menubar/config_test.go
@@ -66,6 +66,116 @@ func TestSaveMenubarConfigClearsFile(t *testing.T) {
 	}
 }
 
+func TestLoadProvidersConfigForMenubar(t *testing.T) {
+	t.Run("missing menubar file uses default config", func(t *testing.T) {
+		stubUserConfigDir(t)
+
+		cfg, providersCfg, err := loadProvidersConfigForMenubar()
+		if err != nil {
+			t.Fatalf("loadProvidersConfigForMenubar() error = %v", err)
+		}
+		if cfg.ProvidersConfigPath != "" {
+			t.Fatalf("loadProvidersConfigForMenubar() ProvidersConfigPath = %q, want empty", cfg.ProvidersConfigPath)
+		}
+		if len(providersCfg.Providers) != 0 {
+			t.Fatalf("loadProvidersConfigForMenubar() Providers = %v, want empty", providersCfg.Providers)
+		}
+	})
+
+	t.Run("invalid menubar config is wrapped", func(t *testing.T) {
+		configDir := stubUserConfigDir(t)
+		configPath := filepath.Join(configDir, "vekil", menubarConfigFilename)
+		if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		if err := os.WriteFile(configPath, []byte("{"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		_, _, err := loadProvidersConfigForMenubar()
+		if !errors.Is(err, errMenubarConfigLoad) {
+			t.Fatalf("loadProvidersConfigForMenubar() error = %v, want wrapped menubar config error", err)
+		}
+	})
+
+	t.Run("invalid providers path is wrapped", func(t *testing.T) {
+		stubUserConfigDir(t)
+
+		if err := saveMenubarConfig(menubarConfig{ProvidersConfigPath: "/tmp/missing-providers.json"}); err != nil {
+			t.Fatalf("saveMenubarConfig() error = %v", err)
+		}
+
+		cfg, _, err := loadProvidersConfigForMenubar()
+		if !errors.Is(err, errProvidersConfigLoad) {
+			t.Fatalf("loadProvidersConfigForMenubar() error = %v, want wrapped providers config error", err)
+		}
+		if cfg.ProvidersConfigPath != "/tmp/missing-providers.json" {
+			t.Fatalf("loadProvidersConfigForMenubar() ProvidersConfigPath = %q, want missing path", cfg.ProvidersConfigPath)
+		}
+	})
+
+	t.Run("valid providers config loads successfully", func(t *testing.T) {
+		stubUserConfigDir(t)
+
+		providersPath := filepath.Join(t.TempDir(), "providers.json")
+		body := []byte(`{"providers":[{"id":"azure","type":"azure-openai"}]}`)
+		if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := saveMenubarConfig(menubarConfig{ProvidersConfigPath: providersPath}); err != nil {
+			t.Fatalf("saveMenubarConfig() error = %v", err)
+		}
+
+		cfg, providersCfg, err := loadProvidersConfigForMenubar()
+		if err != nil {
+			t.Fatalf("loadProvidersConfigForMenubar() error = %v", err)
+		}
+		if cfg.ProvidersConfigPath != providersPath {
+			t.Fatalf("loadProvidersConfigForMenubar() ProvidersConfigPath = %q, want %q", cfg.ProvidersConfigPath, providersPath)
+		}
+		if len(providersCfg.Providers) != 1 || providersCfg.Providers[0].ID != "azure" {
+			t.Fatalf("loadProvidersConfigForMenubar() Providers = %v, want azure provider", providersCfg.Providers)
+		}
+	})
+}
+
+func TestProvidersConfigErrorPresentation(t *testing.T) {
+	menubarErr := errors.Join(errMenubarConfigLoad, errors.New("decode menubar config"))
+	providersErr := errors.Join(errProvidersConfigLoad, errors.New("decode providers config"))
+
+	if got := providersConfigStatusTitle(menubarErr); got != "⚠ Config unavailable" {
+		t.Fatalf("providersConfigStatusTitle(menubarErr) = %q, want %q", got, "⚠ Config unavailable")
+	}
+	if got := providersConfigStatusTitle(providersErr); got != "⚠ Invalid providers config" {
+		t.Fatalf("providersConfigStatusTitle(providersErr) = %q, want %q", got, "⚠ Invalid providers config")
+	}
+
+	if title, message := providersConfigUnavailableDialog(menubarErr); title != "Menubar Config Unavailable" || message != "Could not load the saved menubar config." {
+		t.Fatalf("providersConfigUnavailableDialog(menubarErr) = (%q, %q)", title, message)
+	}
+	if title, message := providersConfigStartDialog(providersErr); title != "Invalid Providers Config" || message != "Could not load the selected providers config." {
+		t.Fatalf("providersConfigStartDialog(providersErr) = (%q, %q)", title, message)
+	}
+
+	prevCfg := menubarCfg
+	prevErr := providersConfigErr
+	t.Cleanup(func() {
+		menubarCfg = prevCfg
+		providersConfigErr = prevErr
+	})
+
+	menubarCfg = menubarConfig{ProvidersConfigPath: "/tmp/providers.json"}
+	providersConfigErr = menubarErr
+	if got := providersMenuTitle(); got != "Providers: Config unavailable" {
+		t.Fatalf("providersMenuTitle() with menubar error = %q, want %q", got, "Providers: Config unavailable")
+	}
+
+	providersConfigErr = providersErr
+	if got := providersMenuTitle(); got != "Providers: Invalid (providers.json)" {
+		t.Fatalf("providersMenuTitle() with providers error = %q, want %q", got, "Providers: Invalid (providers.json)")
+	}
+}
+
 func TestProvidersRequireGitHubAuth(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/menubar/config_test.go
+++ b/cmd/menubar/config_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sozercan/vekil/proxy"
+)
+
+func TestLoadMenubarConfigMissingFile(t *testing.T) {
+	configDir := stubUserConfigDir(t)
+
+	cfg, err := loadMenubarConfig()
+	if err != nil {
+		t.Fatalf("loadMenubarConfig() error = %v", err)
+	}
+	if cfg.ProvidersConfigPath != "" {
+		t.Fatalf("loadMenubarConfig() ProvidersConfigPath = %q, want empty", cfg.ProvidersConfigPath)
+	}
+
+	if _, err := os.Stat(filepath.Join(configDir, "vekil", menubarConfigFilename)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected config file to be absent, stat error = %v", err)
+	}
+}
+
+func TestSaveMenubarConfigRoundTrip(t *testing.T) {
+	configDir := stubUserConfigDir(t)
+	wantPath := "/tmp/providers.json"
+
+	if err := saveMenubarConfig(menubarConfig{ProvidersConfigPath: "  " + wantPath + "  "}); err != nil {
+		t.Fatalf("saveMenubarConfig() error = %v", err)
+	}
+
+	cfg, err := loadMenubarConfig()
+	if err != nil {
+		t.Fatalf("loadMenubarConfig() error = %v", err)
+	}
+	if cfg.ProvidersConfigPath != wantPath {
+		t.Fatalf("loadMenubarConfig() ProvidersConfigPath = %q, want %q", cfg.ProvidersConfigPath, wantPath)
+	}
+
+	body, err := os.ReadFile(filepath.Join(configDir, "vekil", menubarConfigFilename))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if len(body) == 0 || body[len(body)-1] != '\n' {
+		t.Fatalf("saved config should end with newline, got %q", string(body))
+	}
+}
+
+func TestSaveMenubarConfigClearsFile(t *testing.T) {
+	configDir := stubUserConfigDir(t)
+	configPath := filepath.Join(configDir, "vekil", menubarConfigFilename)
+
+	if err := saveMenubarConfig(menubarConfig{ProvidersConfigPath: "/tmp/providers.json"}); err != nil {
+		t.Fatalf("saveMenubarConfig(set) error = %v", err)
+	}
+	if err := saveMenubarConfig(menubarConfig{}); err != nil {
+		t.Fatalf("saveMenubarConfig(clear) error = %v", err)
+	}
+
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected config file to be removed, stat error = %v", err)
+	}
+}
+
+func TestProvidersRequireGitHubAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  proxy.ProvidersConfig
+		err  error
+		want bool
+	}{
+		{
+			name: "default config uses copilot",
+			want: true,
+		},
+		{
+			name: "provider only config skips auth",
+			cfg: proxy.ProvidersConfig{
+				Providers: []proxy.ProviderConfig{
+					{ID: "azure", Type: "azure-openai"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "invalid config does not trigger auth refresh",
+			cfg: proxy.ProvidersConfig{
+				Providers: []proxy.ProviderConfig{
+					{ID: "azure", Type: "azure-openai"},
+				},
+			},
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := providersRequireGitHubAuth(tt.cfg, tt.err); got != tt.want {
+				t.Fatalf("providersRequireGitHubAuth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func stubUserConfigDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	prev := userConfigDir
+	userConfigDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	t.Cleanup(func() {
+		userConfigDir = prev
+	})
+
+	return tmpDir
+}

--- a/cmd/menubar/dialog_common.go
+++ b/cmd/menubar/dialog_common.go
@@ -1,0 +1,5 @@
+package main
+
+import "errors"
+
+var errDialogCanceled = errors.New("dialog canceled")

--- a/cmd/menubar/dialog_darwin.go
+++ b/cmd/menubar/dialog_darwin.go
@@ -34,6 +34,21 @@ func showErrorDialog(title, message string) {
 	_ = exec.Command("osascript", "-e", script).Run()
 }
 
+func chooseProvidersConfigPath() (string, error) {
+	script := `POSIX path of (choose file with prompt "Choose a providers config JSON file")`
+	out, err := exec.Command("osascript", "-e", script).Output()
+	if err != nil {
+		return "", errDialogCanceled
+	}
+
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", errDialogCanceled
+	}
+
+	return path, nil
+}
+
 // copyToClipboard copies the given text to the macOS clipboard using pbcopy.
 func copyToClipboard(text string) {
 	cmd := exec.Command("pbcopy")

--- a/cmd/menubar/dialog_darwin.go
+++ b/cmd/menubar/dialog_darwin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -36,9 +37,16 @@ func showErrorDialog(title, message string) {
 
 func chooseProvidersConfigPath() (string, error) {
 	script := `POSIX path of (choose file with prompt "Choose a providers config JSON file")`
-	out, err := exec.Command("osascript", "-e", script).Output()
+	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
 	if err != nil {
-		return "", errDialogCanceled
+		if isOsascriptCancel(err, out) {
+			return "", errDialogCanceled
+		}
+		message := strings.TrimSpace(string(out))
+		if message == "" {
+			return "", fmt.Errorf("run osascript file chooser: %w", err)
+		}
+		return "", fmt.Errorf("run osascript file chooser: %w: %s", err, message)
 	}
 
 	path := strings.TrimSpace(string(out))
@@ -47,6 +55,14 @@ func chooseProvidersConfigPath() (string, error) {
 	}
 
 	return path, nil
+}
+
+func isOsascriptCancel(err error, output []byte) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return exitErr.ExitCode() == 1 && strings.Contains(string(output), "(-128)")
 }
 
 // copyToClipboard copies the given text to the macOS clipboard using pbcopy.

--- a/cmd/menubar/dialog_linux.go
+++ b/cmd/menubar/dialog_linux.go
@@ -107,6 +107,47 @@ func showErrorDialog(title, message string) {
 	_ = notify(title, message)
 }
 
+func chooseProvidersConfigPath() (string, error) {
+	if zenity, err := execLookPath("zenity"); err == nil {
+		output, runErr := execCommand(zenity,
+			"--file-selection",
+			"--title=Choose Providers Config",
+			"--file-filter=JSON files | *.json",
+			"--file-filter=All files | *",
+		).CombinedOutput()
+		if runErr == nil {
+			path := strings.TrimSpace(string(output))
+			if path == "" {
+				return "", errDialogCanceled
+			}
+			return path, nil
+		}
+		if isDialogCancel(runErr, output) {
+			return "", errDialogCanceled
+		}
+	}
+
+	if kdialog, err := execLookPath("kdialog"); err == nil {
+		output, runErr := execCommand(kdialog,
+			"--getopenfilename",
+			"",
+			"*.json|JSON files",
+		).CombinedOutput()
+		if runErr == nil {
+			path := strings.TrimSpace(string(output))
+			if path == "" {
+				return "", errDialogCanceled
+			}
+			return path, nil
+		}
+		if isDialogCancel(runErr, output) {
+			return "", errDialogCanceled
+		}
+	}
+
+	return "", errors.New("file selection is unavailable; install zenity or kdialog")
+}
+
 // copyToClipboard copies the given text to the clipboard, trying Wayland and
 // X11 tools in order.
 func copyToClipboard(text string) {

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"fyne.io/systray"
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
+	"github.com/sozercan/vekil/proxy"
 	"github.com/sozercan/vekil/server"
 )
 
@@ -19,13 +22,20 @@ var (
 	authenticator *auth.Authenticator
 
 	// Menu items kept at package level so helpers can update them.
-	mStatus *systray.MenuItem
-	mToggle *systray.MenuItem
-	mAuth   *systray.MenuItem
+	mStatus          *systray.MenuItem
+	mToggle          *systray.MenuItem
+	mAuth            *systray.MenuItem
+	mProvidersStatus *systray.MenuItem
+	mProvidersChoose *systray.MenuItem
+	mProvidersClear  *systray.MenuItem
 
 	// signInMu guards signInCancel to prevent concurrent sign-in flows.
 	signInMu     sync.Mutex
 	signInCancel context.CancelFunc
+
+	menubarCfg         menubarConfig
+	providersCfg       proxy.ProvidersConfig
+	providersConfigErr error
 )
 
 func main() {
@@ -35,6 +45,12 @@ func main() {
 		log.Fatal("failed to initialize authenticator", logger.Err(err))
 	}
 	authenticator.DisableAutoDeviceFlow = true
+
+	menubarCfg, providersCfg, providersConfigErr = loadProvidersConfigForMenubar()
+	if providersConfigErr != nil {
+		log.Error("failed to load providers config", logger.Err(providersConfigErr), logger.F("path", menubarCfg.ProvidersConfigPath))
+	}
+
 	systray.Run(onReady, onExit)
 }
 
@@ -46,6 +62,12 @@ func onReady() {
 	mStatus.Disable()
 	mVersion := systray.AddMenuItem(versionMenuTitle(), "Current app version")
 	mVersion.Disable()
+	systray.AddSeparator()
+
+	mProvidersStatus = systray.AddMenuItem("Providers: Copilot default", "")
+	mProvidersStatus.Disable()
+	mProvidersChoose = systray.AddMenuItem("Choose Providers Config…", "Select a providers JSON file")
+	mProvidersClear = systray.AddMenuItem("Use Default Copilot Routing", "Clear custom providers config")
 	systray.AddSeparator()
 
 	mToggle = systray.AddMenuItem("Start Vekil", "Start or stop Vekil")
@@ -74,11 +96,9 @@ func onReady() {
 
 	mQuit := systray.AddMenuItem("Quit", "Quit the application")
 
-	// Set initial UI state based on whether we already have credentials.
-	if authenticator.IsSignedIn() {
-		setSignedInUI()
-	} else {
-		setSignedOutUI()
+	refreshSessionUI()
+	if providersConfigErr != nil {
+		showErrorDialog("Providers Config Unavailable", fmt.Sprintf("Could not load the saved providers config.\n\n%v", providersConfigErr))
 	}
 
 	var mCheckUpdatesClicked <-chan struct{}
@@ -95,6 +115,10 @@ func onReady() {
 				} else {
 					startProxy()
 				}
+			case <-mProvidersChoose.ClickedCh:
+				selectProvidersConfig()
+			case <-mProvidersClear.ClickedCh:
+				clearProvidersConfig()
 			case <-mLaunch.ClickedCh:
 				if mLaunch.Checked() {
 					if err := removeLaunchAgent(); err != nil {
@@ -132,15 +156,28 @@ func onReady() {
 }
 
 func startProxy() {
-	if _, err := authenticator.GetToken(context.Background()); err != nil {
-		log.Error("auth failed", logger.Err(err))
-		// Token refresh failed — force re-authentication.
-		_ = authenticator.SignOut()
-		go signIn()
+	if providersConfigErr != nil {
+		showErrorDialog("Invalid Providers Config", fmt.Sprintf("Could not load the selected providers config.\n\n%v", providersConfigErr))
 		return
 	}
 
-	nextSrv, err := server.New(authenticator, log, "0.0.0.0", "1337")
+	if providersRequireGitHubAuth(providersCfg, providersConfigErr) {
+		if _, err := authenticator.GetToken(context.Background()); err != nil {
+			log.Error("auth failed", logger.Err(err))
+			// Token refresh failed — force re-authentication.
+			_ = authenticator.SignOut()
+			go signIn()
+			return
+		}
+	}
+
+	nextSrv, err := server.New(
+		authenticator,
+		log,
+		"0.0.0.0",
+		"1337",
+		server.WithProxyOptions(proxy.WithProvidersConfig(providersCfg)),
+	)
 	if err != nil {
 		log.Error("server init failed", logger.Err(err))
 		showErrorDialog("Vekil Start Failed", fmt.Sprintf("Could not initialize Vekil.\n\n%v", err))
@@ -199,7 +236,7 @@ func signIn() {
 	if err != nil {
 		log.Error("device code request failed", logger.Err(err))
 		showErrorDialog("Sign In Failed", fmt.Sprintf("Could not start sign-in: %v", err))
-		setSignedOutUI()
+		refreshSessionUI()
 		mAuth.Enable()
 		return
 	}
@@ -215,7 +252,7 @@ func signIn() {
 
 	if button == "Cancel" {
 		cancel()
-		setSignedOutUI()
+		refreshSessionUI()
 		mAuth.Enable()
 		return
 	}
@@ -229,12 +266,12 @@ func signIn() {
 			// Only show error dialog if we weren't cancelled.
 			showErrorDialog("Sign In Failed", fmt.Sprintf("Authorization failed: %v", err))
 		}
-		setSignedOutUI()
+		refreshSessionUI()
 		mAuth.Enable()
 		return
 	}
 
-	setSignedInUI()
+	refreshSessionUI()
 	showNotification("Vekil", "Successfully signed in to GitHub.")
 	log.Info("sign-in complete")
 }
@@ -256,8 +293,60 @@ func signOut() {
 		log.Error("sign-out error", logger.Err(err))
 	}
 
-	setSignedOutUI()
+	refreshSessionUI()
 	log.Info("signed out")
+}
+
+func selectProvidersConfig() {
+	path, err := chooseProvidersConfigPath()
+	if err != nil {
+		if errors.Is(err, errDialogCanceled) {
+			return
+		}
+		log.Error("providers config selection failed", logger.Err(err))
+		showErrorDialog("Providers Config", fmt.Sprintf("Could not open the providers config picker.\n\n%v", err))
+		return
+	}
+
+	if err := applyProvidersConfigPath(path); err != nil {
+		log.Error("failed to apply providers config", logger.Err(err), logger.F("path", path))
+		showErrorDialog("Providers Config", fmt.Sprintf("Could not use %s.\n\n%v", filepath.Base(path), err))
+	}
+}
+
+func clearProvidersConfig() {
+	if err := applyProvidersConfigPath(""); err != nil {
+		log.Error("failed to clear providers config", logger.Err(err))
+		showErrorDialog("Providers Config", fmt.Sprintf("Could not clear the saved providers config.\n\n%v", err))
+	}
+}
+
+func applyProvidersConfigPath(path string) error {
+	nextCfg := menubarConfig{ProvidersConfigPath: path}
+	loadedProvidersCfg, err := proxy.LoadProvidersConfigFile(path)
+	if err != nil {
+		return err
+	}
+	if err := saveMenubarConfig(nextCfg); err != nil {
+		return err
+	}
+
+	menubarCfg = nextCfg
+	providersCfg = loadedProvidersCfg
+	providersConfigErr = nil
+
+	wasRunning := srv != nil && srv.IsRunning()
+	if wasRunning {
+		stopProxy()
+	}
+
+	refreshSessionUI()
+
+	if wasRunning {
+		startProxy()
+	}
+
+	return nil
 }
 
 // setSignedInUI updates the menu to reflect an authenticated state.
@@ -276,6 +365,67 @@ func setSignedOutUI() {
 	mToggle.Disable()
 	systray.SetIcon(iconOff)
 	systray.SetTooltip("Vekil - Stopped")
+}
+
+func refreshSessionUI() {
+	refreshProvidersMenu()
+
+	switch {
+	case providersConfigErr != nil:
+		mStatus.SetTitle("⚠ Invalid providers config")
+		mAuth.SetTitle(authMenuTitle())
+		mAuth.Enable()
+		mToggle.Disable()
+		systray.SetIcon(iconOff)
+		systray.SetTooltip("Vekil - Stopped")
+	case !providersRequireGitHubAuth(providersCfg, providersConfigErr):
+		mStatus.SetTitle("● Provider-only mode")
+		mAuth.SetTitle(authMenuTitle())
+		mAuth.Enable()
+		mToggle.Enable()
+		if srv == nil || !srv.IsRunning() {
+			mToggle.SetTitle("Start Vekil")
+			systray.SetIcon(iconOff)
+			systray.SetTooltip("Vekil - Stopped")
+		}
+	case authenticator.IsSignedIn():
+		setSignedInUI()
+	default:
+		setSignedOutUI()
+	}
+}
+
+func refreshProvidersMenu() {
+	mProvidersStatus.SetTitle(providersMenuTitle())
+	if menubarCfg.ProvidersConfigPath == "" {
+		mProvidersClear.Disable()
+		return
+	}
+	mProvidersClear.Enable()
+}
+
+func providersMenuTitle() string {
+	switch {
+	case providersConfigErr != nil && menubarCfg.ProvidersConfigPath != "":
+		return fmt.Sprintf("Providers: Invalid (%s)", filepath.Base(menubarCfg.ProvidersConfigPath))
+	case providersConfigErr != nil:
+		return "Providers: Invalid"
+	case menubarCfg.ProvidersConfigPath == "":
+		return "Providers: Copilot default"
+	default:
+		return fmt.Sprintf("Providers: %s", filepath.Base(menubarCfg.ProvidersConfigPath))
+	}
+}
+
+func authMenuTitle() string {
+	if authenticator != nil && authenticator.IsSignedIn() {
+		return "Sign Out"
+	}
+	return "Sign In"
+}
+
+func providersRequireGitHubAuth(cfg proxy.ProvidersConfig, err error) bool {
+	return err == nil && cfg.UsesCopilot()
 }
 
 func onExit() {

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	menubarCfg, providersCfg, providersConfigErr = loadProvidersConfigForMenubar()
 	if providersConfigErr != nil {
-		log.Error("failed to load providers config", logger.Err(providersConfigErr), logger.F("path", menubarCfg.ProvidersConfigPath))
+		logProvidersConfigLoadError(providersConfigErr)
 	}
 
 	systray.Run(onReady, onExit)
@@ -98,7 +98,8 @@ func onReady() {
 
 	refreshSessionUI()
 	if providersConfigErr != nil {
-		showErrorDialog("Providers Config Unavailable", fmt.Sprintf("Could not load the saved providers config.\n\n%v", providersConfigErr))
+		title, message := providersConfigUnavailableDialog(providersConfigErr)
+		showErrorDialog(title, fmt.Sprintf("%s\n\n%v", message, providersConfigErr))
 	}
 
 	var mCheckUpdatesClicked <-chan struct{}
@@ -157,7 +158,8 @@ func onReady() {
 
 func startProxy() {
 	if providersConfigErr != nil {
-		showErrorDialog("Invalid Providers Config", fmt.Sprintf("Could not load the selected providers config.\n\n%v", providersConfigErr))
+		title, message := providersConfigStartDialog(providersConfigErr)
+		showErrorDialog(title, fmt.Sprintf("%s\n\n%v", message, providersConfigErr))
 		return
 	}
 
@@ -372,7 +374,7 @@ func refreshSessionUI() {
 
 	switch {
 	case providersConfigErr != nil:
-		mStatus.SetTitle("⚠ Invalid providers config")
+		mStatus.SetTitle(providersConfigStatusTitle(providersConfigErr))
 		mAuth.SetTitle(authMenuTitle())
 		mAuth.Enable()
 		mToggle.Disable()
@@ -406,6 +408,8 @@ func refreshProvidersMenu() {
 
 func providersMenuTitle() string {
 	switch {
+	case isMenubarConfigLoadError(providersConfigErr):
+		return "Providers: Config unavailable"
 	case providersConfigErr != nil && menubarCfg.ProvidersConfigPath != "":
 		return fmt.Sprintf("Providers: Invalid (%s)", filepath.Base(menubarCfg.ProvidersConfigPath))
 	case providersConfigErr != nil:
@@ -422,6 +426,35 @@ func authMenuTitle() string {
 		return "Sign Out"
 	}
 	return "Sign In"
+}
+
+func logProvidersConfigLoadError(err error) {
+	if isMenubarConfigLoadError(err) {
+		log.Error("failed to load menubar config", logger.Err(err))
+		return
+	}
+	log.Error("failed to load providers config", logger.Err(err), logger.F("path", menubarCfg.ProvidersConfigPath))
+}
+
+func providersConfigUnavailableDialog(err error) (string, string) {
+	if isMenubarConfigLoadError(err) {
+		return "Menubar Config Unavailable", "Could not load the saved menubar config."
+	}
+	return "Providers Config Unavailable", "Could not load the saved providers config."
+}
+
+func providersConfigStartDialog(err error) (string, string) {
+	if isMenubarConfigLoadError(err) {
+		return "Menubar Config Unavailable", "Could not load the saved menubar config."
+	}
+	return "Invalid Providers Config", "Could not load the selected providers config."
+}
+
+func providersConfigStatusTitle(err error) string {
+	if isMenubarConfigLoadError(err) {
+		return "⚠ Config unavailable"
+	}
+	return "⚠ Invalid providers config"
 }
 
 func providersRequireGitHubAuth(cfg proxy.ProvidersConfig, err error) bool {

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -43,9 +43,18 @@ open "Vekil.app"
 - start/stop toggle from the menubar
 - status icon: white robot when running, gray when stopped
 - current app version shown in the menu
+- choose and persist a `providers-config` JSON file from the menu
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
 - `Check for Updates…` in packaged macOS app builds
+
+## Providers Config
+
+Use `Choose Providers Config…` from the menubar menu to select the same JSON file you would pass to the CLI with `--providers-config`.
+
+- The app saves the selected path in its menubar config so it is reused on the next launch and when started at login.
+- `Use Default Copilot Routing` clears the saved path and returns to the zero-config Copilot-only behavior.
+- If the selected config does not include a Copilot provider, the app no longer requires GitHub sign-in before starting the proxy.
 
 ## Release Assets
 


### PR DESCRIPTION
## Summary

This adds `providers-config` support to the macOS/Linux tray app so the menubar flow can launch the proxy with the same provider routing configuration that the CLI already supports.

## What Changed

- added persisted menubar config storage for the selected providers config path
- added tray actions to choose or clear a providers config file
- passed the loaded providers config into `server.New(...)` when starting from the tray app
- updated tray UI/auth gating so provider-only configs can start without requiring GitHub sign-in
- added focused tests for the menubar config helpers
- documented the new tray behavior in `docs/menubar.md`

## Why

The proxy already supported `--providers-config`, but the menubar app always started with hardcoded defaults and had no way to supply provider routing. That meant Azure-backed models could work from the CLI but not from the macOS app.

## Impact

Users can now run provider-routed models from the menubar app, and launch-at-login reuses the saved providers config path on the next start.

## Validation

- `go test ./cmd/menubar -count=1`
- `go test ./... -count=1`

## Notes

`providers.json` was intentionally left uncommitted and is not part of this PR.
