### PR TITLE
surface websocket upstream stream failures

### DIFF
--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -21,9 +21,9 @@ import (
 const responsesWebSocketRequestHeaderPrefix = "ws_request_header_"
 
 // errStreamFailedUpstream is a sentinel error indicating the upstream stream
-// ended with response.failed or response.incomplete. The error event has already
-// been forwarded to the WebSocket client, so no additional error frame should
-// be sent.
+// ended with response.failed or response.incomplete after forwarding the
+// upstream failure event. This path also emits the standard websocket error
+// payload so clients can surface the upstream error details.
 var errStreamFailedUpstream = errors.New("upstream stream ended with response.failed or response.incomplete")
 
 var responsesWebSocketUpgrader = websocket.Upgrader{

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -54,9 +54,21 @@ type responsesWebSocketJSONField struct {
 type responsesWebSocketStreamEvent struct {
 	Type     string `json:"type"`
 	Response struct {
-		ID string `json:"id"`
+		ID                string                                    `json:"id"`
+		Error             responsesWebSocketStreamError             `json:"error"`
+		IncompleteDetails responsesWebSocketStreamIncompleteDetails `json:"incomplete_details"`
 	} `json:"response,omitempty"`
 	Item json.RawMessage `json:"item,omitempty"`
+}
+
+type responsesWebSocketStreamError struct {
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type responsesWebSocketStreamIncompleteDetails struct {
+	Reason string `json:"reason"`
 }
 
 type responsesWebSocketSession struct {
@@ -607,9 +619,11 @@ func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader, heade
 				responseID = event.Response.ID
 			}
 		case "response.failed", "response.incomplete":
+			s.sendUpstreamStreamFailure(event, headers)
 			// Return the sentinel immediately to break out of the SSE
-			// scanner loop. The event has already been forwarded to the
-			// client above, so no additional error frame is needed.
+			// scanner loop. The failure event has already been forwarded to
+			// the client above, and we also emit a standard error payload so
+			// websocket clients can surface the upstream error details.
 			return errStreamFailedUpstream
 		}
 
@@ -635,6 +649,14 @@ func (s *responsesWebSocketSession) writeJSON(payload interface{}) error {
 		return err
 	}
 	return s.conn.WriteMessage(websocket.TextMessage, encoded)
+}
+
+func (s *responsesWebSocketSession) sendUpstreamStreamFailure(event responsesWebSocketStreamEvent, headers http.Header) {
+	status, message, code := responsesWebSocketStreamFailureDetails(event)
+	if status == 0 || strings.TrimSpace(message) == "" {
+		return
+	}
+	s.sendWrappedError(status, message, code, headers)
 }
 
 func (s *responsesWebSocketSession) sendWrappedError(status int, message, code string, headers http.Header) {
@@ -715,6 +737,52 @@ func extractResponsesWebSocketError(status int, body []byte) (string, string) {
 	}
 
 	return http.StatusText(status), ""
+}
+
+func responsesWebSocketStreamFailureDetails(event responsesWebSocketStreamEvent) (int, string, string) {
+	switch event.Type {
+	case "response.failed":
+		errType := strings.TrimSpace(event.Response.Error.Type)
+		code := strings.TrimSpace(event.Response.Error.Code)
+		message := strings.TrimSpace(event.Response.Error.Message)
+		if message == "" {
+			if code != "" {
+				message = code
+			} else {
+				message = "upstream response.failed"
+			}
+		}
+		return responsesWebSocketErrorStatus(errType), message, code
+	case "response.incomplete":
+		reason := strings.TrimSpace(event.Response.IncompleteDetails.Reason)
+		if reason == "" {
+			return http.StatusConflict, "upstream response.incomplete", "response_incomplete"
+		}
+		return http.StatusConflict, "upstream response.incomplete: " + reason, reason
+	default:
+		return 0, "", ""
+	}
+}
+
+func responsesWebSocketErrorStatus(errType string) int {
+	switch strings.TrimSpace(errType) {
+	case "invalid_request_error":
+		return http.StatusBadRequest
+	case "authentication_error":
+		return http.StatusUnauthorized
+	case "permission_error":
+		return http.StatusForbidden
+	case "not_found_error":
+		return http.StatusNotFound
+	case "conflict_error":
+		return http.StatusConflict
+	case "rate_limit_error":
+		return http.StatusTooManyRequests
+	case "server_error":
+		return http.StatusInternalServerError
+	default:
+		return http.StatusBadGateway
+	}
 }
 
 func flattenResponsesWebSocketHeaders(headers http.Header) map[string]interface{} {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -818,6 +818,23 @@ func TestHandleResponsesWebSocket_ResponseFailedKeepsSessionOpen(t *testing.T) {
 	if failed["type"] != "response.failed" {
 		t.Fatalf("expected response.failed, got %v", failed["type"])
 	}
+	errFrame := mustReadWebSocketJSON(t, conn)
+	if errFrame["type"] != "error" {
+		t.Fatalf("expected error frame after response.failed, got %v", errFrame["type"])
+	}
+	if statusCode, _ := errFrame["status_code"].(float64); statusCode != float64(http.StatusInternalServerError) {
+		t.Fatalf("expected error status %d, got %v", http.StatusInternalServerError, errFrame["status_code"])
+	}
+	errPayload, ok := errFrame["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %T", errFrame["error"])
+	}
+	if errPayload["code"] != "context_length_exceeded" {
+		t.Fatalf("expected error code context_length_exceeded, got %v", errPayload["code"])
+	}
+	if errPayload["message"] != "context too long" {
+		t.Fatalf("expected error message context too long, got %v", errPayload["message"])
+	}
 
 	retry := newResponsesWebSocketCreateRequest([]interface{}{
 		map[string]interface{}{
@@ -885,6 +902,23 @@ func TestHandleResponsesWebSocket_ResponseIncompleteKeepsSessionOpen(t *testing.
 	incomplete := mustReadWebSocketJSON(t, conn)
 	if incomplete["type"] != "response.incomplete" {
 		t.Fatalf("expected response.incomplete, got %v", incomplete["type"])
+	}
+	errFrame := mustReadWebSocketJSON(t, conn)
+	if errFrame["type"] != "error" {
+		t.Fatalf("expected error frame after response.incomplete, got %v", errFrame["type"])
+	}
+	if statusCode, _ := errFrame["status_code"].(float64); statusCode != float64(http.StatusConflict) {
+		t.Fatalf("expected error status %d, got %v", http.StatusConflict, errFrame["status_code"])
+	}
+	errPayload, ok := errFrame["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %T", errFrame["error"])
+	}
+	if errPayload["code"] != "max_output_tokens" {
+		t.Fatalf("expected error code max_output_tokens, got %v", errPayload["code"])
+	}
+	if errPayload["message"] != "upstream response.incomplete: max_output_tokens" {
+		t.Fatalf("expected incomplete error message, got %v", errPayload["message"])
 	}
 
 	next := newResponsesWebSocketCreateRequest([]interface{}{
@@ -971,6 +1005,17 @@ func TestHandleResponsesWebSocket_ResponseFailedOnStalledUpstreamKeepsSessionOpe
 	failed := mustReadWebSocketJSON(t, conn)
 	if failed["type"] != "response.failed" {
 		t.Fatalf("expected response.failed, got %v", failed["type"])
+	}
+	errFrame := mustReadWebSocketJSON(t, conn)
+	if errFrame["type"] != "error" {
+		t.Fatalf("expected error frame after response.failed, got %v", errFrame["type"])
+	}
+	errPayload, ok := errFrame["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %T", errFrame["error"])
+	}
+	if errPayload["message"] != "context too long" {
+		t.Fatalf("expected error message context too long, got %v", errPayload["message"])
 	}
 
 	next := newResponsesWebSocketCreateRequest([]interface{}{


### PR DESCRIPTION
## What changed

The proxy websocket bridge for `GET /v1/responses` now emits a normal `error` frame when the upstream stream ends with `response.failed` or `response.incomplete`, while still forwarding the original upstream event.

The websocket tests now cover failed, incomplete, and stalled-upstream cases so the extra error payload stays exercised.

## Why

Codex-style websocket clients were only seeing the generic disconnect path after an upstream `response.failed` event, which hid the actual upstream message and code.

## Impact

Clients now get actionable upstream failure details such as the error message, code, and mapped status code instead of only the generic `stream disconnected before completion` surface.

## Root cause

The proxy forwarded the upstream stream failure event but did not emit a standard websocket `error` payload that existing clients already know how to surface.

## Validation

- `go test ./proxy -count=1`
- `go test ./... -count=1`
