### PR TITLE
translate transient /responses stream failures before commit

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -119,7 +119,7 @@ Like chat completions, Responses requests are routed by the public `model` ID. F
 
 For responses-only Azure deployments such as the `gpt-5.4-pro` example configuration, this is the canonical inference path.
 
-Streaming Responses requests are passed through directly with upstream headers preserved.
+Streaming Responses requests preserve upstream headers and are otherwise passed through directly. One narrow exception exists for `POST /v1/responses` with `stream: true`: if the first semantic SSE event is an immediate transient `response.failed` admission error such as `too_many_requests`, `model_overloaded`, `bad_gateway`, or `gateway_timeout`, the proxy translates that pre-commit failure into a normal HTTP error before flushing `200 OK`. All other streaming failures stay passthrough SSE.
 
 `GET /v1/responses` upgrades to a websocket bridge for Codex-style clients. The proxy:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,6 +134,7 @@ Websocket bridge behavior:
 - long sessions are auto-compacted into one proxy-owned checkpoint plus a recent tail
 - optional turn-state delta replay can be enabled with `--responses-ws-turn-state-delta`
 - if upstream rejects delta replay, the proxy automatically falls back to full replay
+- if the first streamed upstream event is a transient `response.failed` admission error, the bridge sends a wrapped websocket error frame instead of relaying the raw `response.failed` event
 
 This websocket bridge is a proxy transport adaptation layered over upstream HTTP `/responses`. It is not the same feature as provider-native websocket or realtime APIs such as Azure `/realtime`.
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -824,8 +824,16 @@ func writeAnthropicError(w http.ResponseWriter, status int, errType, message str
 	})
 }
 
-func writeOpenAIError(w http.ResponseWriter, status int, message, errType string) {
+func writeOpenAIErrorWithRetryAfter(w http.ResponseWriter, status int, message, errType, retryAfter string, upstreamHeaders http.Header) {
 	w.Header().Set("Content-Type", "application/json")
+	if retryAfter != "" {
+		w.Header().Set("Retry-After", retryAfter)
+	}
+	for _, name := range []string{"X-Request-Id", "X-Azure-Request-Id", "Openai-Request-Id"} {
+		for _, value := range headerValuesCI(upstreamHeaders, name) {
+			w.Header().Add(name, value)
+		}
+	}
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"error": map[string]interface{}{
@@ -835,6 +843,10 @@ func writeOpenAIError(w http.ResponseWriter, status int, message, errType string
 			"code":    nil,
 		},
 	})
+}
+
+func writeOpenAIError(w http.ResponseWriter, status int, message, errType string) {
+	writeOpenAIErrorWithRetryAfter(w, status, message, errType, "", nil)
 }
 
 // readBody reads the request body up to maxRequestBodySize. If the body exceeds

--- a/proxy/responses_failure_translate.go
+++ b/proxy/responses_failure_translate.go
@@ -526,9 +526,7 @@ func nextResponsesSSEMessage(buf []byte, allowBOM bool) (responsesSSEMessage, in
 		if colon := bytes.IndexByte(line, ':'); colon >= 0 {
 			field = line[:colon]
 			value = string(line[colon+1:])
-			if strings.HasPrefix(value, " ") {
-				value = value[1:]
-			}
+			value = strings.TrimPrefix(value, " ")
 		}
 
 		switch string(field) {

--- a/proxy/responses_failure_translate.go
+++ b/proxy/responses_failure_translate.go
@@ -520,7 +520,6 @@ func nextResponsesSSEMessage(buf []byte, allowBOM bool) (responsesSSEMessage, in
 			continue
 		}
 
-		msg.semantic = true
 		field := line
 		value := ""
 		if colon := bytes.IndexByte(line, ':'); colon >= 0 {
@@ -532,8 +531,10 @@ func nextResponsesSSEMessage(buf []byte, allowBOM bool) (responsesSSEMessage, in
 		switch string(field) {
 		case "event":
 			msg.event = value
+			msg.semantic = true
 		case "data":
 			dataLines = append(dataLines, value)
+			msg.semantic = true
 		}
 	}
 }

--- a/proxy/responses_failure_translate.go
+++ b/proxy/responses_failure_translate.go
@@ -1,0 +1,610 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sozercan/vekil/logger"
+)
+
+const (
+	responsesPrecommitPeekTimeout   = 750 * time.Millisecond
+	responsesPrecommitMaxPeekBytes  = 64 * 1024
+	responsesPeekReadChunkSize      = 4 * 1024
+	responsesFailureTapMaxBuffer    = 64 * 1024
+	responsesFailureLogMessageLimit = 256
+)
+
+type responsesPeekDecision int
+
+const (
+	responsesPeekDecisionPassthrough responsesPeekDecision = iota
+	responsesPeekDecisionTranslate
+)
+
+type peekResult struct {
+	decision         responsesPeekDecision
+	status           int
+	errType          string
+	message          string
+	retryAfter       string
+	retryAfterSource string
+	failure          *responsesWebSocketStreamEvent
+	bufferedBytes    int
+	peekDuration     time.Duration
+}
+
+type responsesPeekChunk struct {
+	data []byte
+	err  error
+}
+
+type responsesSSEMessage struct {
+	event    string
+	data     string
+	semantic bool
+}
+
+type responsesSSEParser struct {
+	pending  []byte
+	allowBOM bool
+}
+
+func peekAndForwardResponses(h *ProxyHandler, w http.ResponseWriter, r *http.Request, resp *http.Response, upstreamCancel context.CancelFunc, model string) {
+	peekAndForwardResponsesWithConfig(h, w, r, resp, upstreamCancel, model, responsesPrecommitPeekTimeout, responsesPrecommitMaxPeekBytes)
+}
+
+func peekAndForwardResponsesWithConfig(h *ProxyHandler, w http.ResponseWriter, r *http.Request, resp *http.Response, upstreamCancel context.CancelFunc, model string, peekTimeout time.Duration, maxPeekBytes int) {
+	pr, pw := io.Pipe()
+	peekDone := make(chan peekResult, 1)
+	commitCh := make(chan struct{})
+	abortCh := make(chan struct{})
+
+	var commitOnce sync.Once
+	commit := func() {
+		commitOnce.Do(func() {
+			close(commitCh)
+		})
+	}
+
+	var abortOnce sync.Once
+	abort := func() {
+		abortOnce.Do(func() {
+			close(abortCh)
+			upstreamCancel()
+			_ = resp.Body.Close()
+			_ = pr.Close()
+		})
+	}
+
+	go runResponsesPeekPump(resp.Body, pw, resp.Header, peekDone, commitCh, abortCh, maxPeekBytes)
+
+	timer := time.NewTimer(peekTimeout)
+	defer timer.Stop()
+
+	handleCommit := func(result *peekResult) {
+		if result != nil && result.failure != nil && result.decision == responsesPeekDecisionPassthrough {
+			logResponsesPrecommitFailOpen(h, result.failure, model, resp.Header)
+		}
+
+		commit()
+		copyPassthroughHeaders(w.Header(), resp.Header)
+		w.WriteHeader(http.StatusOK)
+		streamResponsesPipeWithFailureLog(h, w, pr, resp.Header)
+		abort()
+	}
+
+	handleResult := func(result peekResult) {
+		if result.decision == responsesPeekDecisionTranslate {
+			logResponsesPrecommitTranslated(h, result, model, resp.Header)
+			abort()
+			writeOpenAIErrorWithRetryAfter(w, result.status, result.message, result.errType, result.retryAfter, resp.Header)
+			return
+		}
+		handleCommit(&result)
+	}
+
+	for {
+		select {
+		case result := <-peekDone:
+			handleResult(result)
+			return
+		case <-timer.C:
+			select {
+			case result := <-peekDone:
+				handleResult(result)
+				return
+			default:
+			}
+			handleCommit(nil)
+			return
+		case <-r.Context().Done():
+			abort()
+			return
+		}
+	}
+}
+
+func runResponsesPeekPump(body io.ReadCloser, pw *io.PipeWriter, headers http.Header, peekDone chan<- peekResult, commitCh, abortCh <-chan struct{}, maxPeekBytes int) {
+	chunkCh := make(chan responsesPeekChunk, 1)
+	go readResponsesPeekChunks(body, chunkCh, abortCh)
+
+	parser := responsesSSEParser{allowBOM: true}
+	var prefix bytes.Buffer
+	start := time.Now()
+	decisionSent := false
+	streamEnded := false
+	var streamErr error
+
+	sendResult := func(result peekResult) {
+		if decisionSent {
+			return
+		}
+		result.bufferedBytes = prefix.Len()
+		result.peekDuration = time.Since(start)
+		decisionSent = true
+		select {
+		case peekDone <- result:
+		default:
+		}
+	}
+
+	for {
+		readCh := (<-chan responsesPeekChunk)(nil)
+		if !decisionSent && !streamEnded {
+			readCh = chunkCh
+		}
+
+		select {
+		case <-abortCh:
+			_ = pw.CloseWithError(context.Canceled)
+			return
+		case <-commitCh:
+			writePrefixAndDrainResponsesStream(pw, prefix.Bytes(), chunkCh, abortCh, streamEnded, streamErr)
+			return
+		case chunk, ok := <-readCh:
+			if !ok {
+				streamEnded = true
+				if !decisionSent {
+					sendResult(peekResult{decision: responsesPeekDecisionPassthrough})
+				}
+				continue
+			}
+
+			if len(chunk.data) > 0 {
+				_, _ = prefix.Write(chunk.data)
+				if !decisionSent {
+					parser.push(chunk.data)
+					if prefix.Len() >= maxPeekBytes {
+						sendResult(peekResult{decision: responsesPeekDecisionPassthrough})
+					} else if msg, ok := parser.nextSemantic(); ok {
+						sendResult(classifyResponsesPeekMessage(msg, headers))
+					}
+				}
+			}
+
+			if chunk.err != nil {
+				streamEnded = true
+				if chunk.err != io.EOF {
+					streamErr = chunk.err
+				}
+				if !decisionSent {
+					sendResult(peekResult{decision: responsesPeekDecisionPassthrough})
+				}
+			}
+		}
+	}
+}
+
+func readResponsesPeekChunks(body io.ReadCloser, chunkCh chan<- responsesPeekChunk, abortCh <-chan struct{}) {
+	defer close(chunkCh)
+
+	buf := make([]byte, responsesPeekReadChunkSize)
+	for {
+		n, err := body.Read(buf)
+		if n > 0 {
+			chunk := append([]byte(nil), buf[:n]...)
+			select {
+			case chunkCh <- responsesPeekChunk{data: chunk}:
+			case <-abortCh:
+				return
+			}
+		}
+		if err != nil {
+			select {
+			case chunkCh <- responsesPeekChunk{err: err}:
+			case <-abortCh:
+			}
+			return
+		}
+	}
+}
+
+func writePrefixAndDrainResponsesStream(pw *io.PipeWriter, prefix []byte, chunkCh <-chan responsesPeekChunk, abortCh <-chan struct{}, streamEnded bool, streamErr error) {
+	if len(prefix) > 0 {
+		if _, err := pw.Write(prefix); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+	}
+
+	if streamEnded {
+		if streamErr != nil {
+			_ = pw.CloseWithError(streamErr)
+			return
+		}
+		_ = pw.Close()
+		return
+	}
+
+	for {
+		select {
+		case <-abortCh:
+			_ = pw.CloseWithError(context.Canceled)
+			return
+		case chunk, ok := <-chunkCh:
+			if !ok {
+				_ = pw.Close()
+				return
+			}
+			if len(chunk.data) > 0 {
+				if _, err := pw.Write(chunk.data); err != nil {
+					_ = pw.CloseWithError(err)
+					return
+				}
+			}
+			if chunk.err != nil {
+				if chunk.err != io.EOF {
+					_ = pw.CloseWithError(chunk.err)
+					return
+				}
+				_ = pw.Close()
+				return
+			}
+		}
+	}
+}
+
+func classifyResponsesPeekMessage(msg responsesSSEMessage, headers http.Header) peekResult {
+	eventName := strings.TrimSpace(msg.event)
+	if eventName != "" && eventName != "response.failed" {
+		return peekResult{decision: responsesPeekDecisionPassthrough}
+	}
+
+	event, err := parseResponsesStreamEvent(msg.data)
+	if err != nil {
+		return peekResult{decision: responsesPeekDecisionPassthrough}
+	}
+
+	if eventName == "" && event.Type != "response.failed" {
+		return peekResult{decision: responsesPeekDecisionPassthrough}
+	}
+	if event.Type != "response.failed" {
+		return peekResult{decision: responsesPeekDecisionPassthrough}
+	}
+
+	status, errType, ok := classifyPrecommitResponsesFailure(event)
+	if !ok {
+		return peekResult{
+			decision: responsesPeekDecisionPassthrough,
+			failure:  &event,
+		}
+	}
+
+	retryAfter, source := "", ""
+	if status == http.StatusTooManyRequests || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout {
+		retryAfter, source = selectResponsesRetryAfter(headers)
+	}
+
+	return peekResult{
+		decision:         responsesPeekDecisionTranslate,
+		status:           status,
+		errType:          errType,
+		message:          responsesPrecommitErrorMessage(event, status),
+		retryAfter:       retryAfter,
+		retryAfterSource: source,
+		failure:          &event,
+	}
+}
+
+func classifyPrecommitResponsesFailure(event responsesWebSocketStreamEvent) (int, string, bool) {
+	code := strings.ToLower(strings.TrimSpace(event.Response.Error.Code))
+	switch code {
+	case "too_many_requests", "rate_limit_exceeded":
+		return http.StatusTooManyRequests, "rate_limit_error", true
+	case "model_overloaded", "engine_overloaded":
+		return http.StatusServiceUnavailable, "server_error", true
+	case "bad_gateway":
+		return http.StatusBadGateway, "server_error", true
+	case "timeout", "gateway_timeout":
+		return http.StatusGatewayTimeout, "server_error", true
+	}
+
+	if code == "" && strings.EqualFold(strings.TrimSpace(event.Response.Error.Type), "rate_limit_error") {
+		return http.StatusTooManyRequests, "rate_limit_error", true
+	}
+
+	return 0, "", false
+}
+
+func selectResponsesRetryAfter(headers http.Header) (string, string) {
+	if headers == nil {
+		return "", ""
+	}
+
+	if value := strings.TrimSpace(headerGetCI(headers, "retry-after-ms")); value != "" {
+		ms, err := strconv.Atoi(value)
+		if err == nil && ms > 0 {
+			seconds := (ms + 999) / 1000
+			if seconds > 0 {
+				return strconv.Itoa(seconds), "retry-after-ms"
+			}
+		}
+	}
+
+	if delay, ok := parseRetryAfter(strings.TrimSpace(headerGetCI(headers, "Retry-After"))); ok && delay > 0 {
+		return strconv.Itoa(int(delay / time.Second)), "Retry-After"
+	}
+
+	return "", ""
+}
+
+func streamResponsesPipeWithFailureLog(h *ProxyHandler, w http.ResponseWriter, r io.Reader, upstreamHeaders http.Header) {
+	if closer, ok := r.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	fw := &flushWriter{w: w}
+	if f, ok := w.(http.Flusher); ok {
+		fw.flusher = f
+	}
+
+	tap := newResponsesFailureTap(h, upstreamHeaders)
+	_, _ = io.Copy(fw, io.TeeReader(r, tap))
+}
+
+func parseResponsesStreamEvent(data string) (responsesWebSocketStreamEvent, error) {
+	var event responsesWebSocketStreamEvent
+	if err := json.Unmarshal([]byte(data), &event); err != nil {
+		return responsesWebSocketStreamEvent{}, err
+	}
+	return event, nil
+}
+
+func responsesPrecommitErrorMessage(event responsesWebSocketStreamEvent, status int) string {
+	message := strings.TrimSpace(event.Response.Error.Message)
+	if message != "" {
+		return message
+	}
+	if code := strings.TrimSpace(event.Response.Error.Code); code != "" {
+		return code
+	}
+	if errType := strings.TrimSpace(event.Response.Error.Type); errType != "" {
+		return errType
+	}
+	if text := http.StatusText(status); text != "" {
+		return text
+	}
+	return "upstream response.failed"
+}
+
+func responsesUpstreamRequestID(headers http.Header) string {
+	for _, name := range []string{"X-Request-Id", "X-Azure-Request-Id", "Openai-Request-Id"} {
+		if value := strings.TrimSpace(headerGetCI(headers, name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func logResponsesPrecommitTranslated(h *ProxyHandler, result peekResult, model string, headers http.Header) {
+	if result.failure == nil {
+		return
+	}
+	h.log.Info("translated responses stream failure before commit",
+		logger.F("endpoint", "responses_precommit_translated"),
+		logger.F("status", result.status),
+		logger.F("error_code", strings.TrimSpace(result.failure.Response.Error.Code)),
+		logger.F("error_type", strings.TrimSpace(result.failure.Response.Error.Type)),
+		logger.F("error_message", truncateResponsesFailureLogMessage(result.failure.Response.Error.Message)),
+		logger.F("retry_after_source", result.retryAfterSource),
+		logger.F("retry_after_seconds", result.retryAfter),
+		logger.F("upstream_request_id", responsesUpstreamRequestID(headers)),
+		logger.F("model", model),
+		logger.F("peek_bytes", result.bufferedBytes),
+		logger.F("peek_duration_ms", result.peekDuration.Milliseconds()),
+	)
+}
+
+func logResponsesPrecommitFailOpen(h *ProxyHandler, event *responsesWebSocketStreamEvent, model string, headers http.Header) {
+	if event == nil {
+		return
+	}
+	h.log.Info("left responses stream failure as passthrough",
+		logger.F("endpoint", "responses_precommit_failopen"),
+		logger.F("error_code", strings.TrimSpace(event.Response.Error.Code)),
+		logger.F("error_type", strings.TrimSpace(event.Response.Error.Type)),
+		logger.F("error_message", truncateResponsesFailureLogMessage(event.Response.Error.Message)),
+		logger.F("model", model),
+		logger.F("upstream_request_id", responsesUpstreamRequestID(headers)),
+	)
+}
+
+func truncateResponsesFailureLogMessage(message string) string {
+	message = strings.TrimSpace(message)
+	if len(message) <= responsesFailureLogMessageLimit {
+		return message
+	}
+	return message[:responsesFailureLogMessageLimit]
+}
+
+func headerGetCI(headers http.Header, name string) string {
+	values := headerValuesCI(headers, name)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func headerValuesCI(headers http.Header, name string) []string {
+	if headers == nil {
+		return nil
+	}
+	canonicalName := http.CanonicalHeaderKey(name)
+	for key, values := range headers {
+		if http.CanonicalHeaderKey(key) == canonicalName {
+			return values
+		}
+	}
+	return nil
+}
+
+func (p *responsesSSEParser) push(chunk []byte) {
+	p.pending = append(p.pending, chunk...)
+}
+
+func (p *responsesSSEParser) nextSemantic() (responsesSSEMessage, bool) {
+	for {
+		msg, consumed, incomplete := nextResponsesSSEMessage(p.pending, p.allowBOM)
+		if incomplete {
+			return responsesSSEMessage{}, false
+		}
+		p.allowBOM = false
+		p.pending = p.pending[consumed:]
+		if msg.semantic {
+			return msg, true
+		}
+	}
+}
+
+func nextResponsesSSEMessage(buf []byte, allowBOM bool) (responsesSSEMessage, int, bool) {
+	var msg responsesSSEMessage
+	index := 0
+
+	if allowBOM {
+		bom := []byte{0xEF, 0xBB, 0xBF}
+		switch {
+		case len(buf) >= len(bom) && bytes.Equal(buf[:len(bom)], bom):
+			index = len(bom)
+		case len(buf) < len(bom) && bytes.Equal(buf, bom[:len(buf)]):
+			return responsesSSEMessage{}, 0, true
+		}
+	}
+
+	var dataLines []string
+	for {
+		lineStart := index
+		newlineOffset := bytes.IndexByte(buf[index:], '\n')
+		if newlineOffset < 0 {
+			return responsesSSEMessage{}, 0, true
+		}
+		index += newlineOffset + 1
+		line := buf[lineStart : index-1]
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+
+		if len(line) == 0 {
+			msg.data = strings.Join(dataLines, "\n")
+			return msg, index, false
+		}
+
+		if line[0] == ':' {
+			continue
+		}
+
+		msg.semantic = true
+		field := line
+		value := ""
+		if colon := bytes.IndexByte(line, ':'); colon >= 0 {
+			field = line[:colon]
+			value = string(line[colon+1:])
+			if strings.HasPrefix(value, " ") {
+				value = value[1:]
+			}
+		}
+
+		switch string(field) {
+		case "event":
+			msg.event = value
+		case "data":
+			dataLines = append(dataLines, value)
+		}
+	}
+}
+
+type responsesFailureTap struct {
+	h               *ProxyHandler
+	upstreamHeaders http.Header
+	parser          responsesSSEParser
+}
+
+func newResponsesFailureTap(h *ProxyHandler, upstreamHeaders http.Header) *responsesFailureTap {
+	return &responsesFailureTap{
+		h:               h,
+		upstreamHeaders: upstreamHeaders,
+		parser:          responsesSSEParser{allowBOM: true},
+	}
+}
+
+func (t *responsesFailureTap) Write(p []byte) (int, error) {
+	t.parser.push(p)
+	for {
+		msg, ok := t.parser.nextSemantic()
+		if !ok {
+			break
+		}
+		t.maybeLog(msg)
+	}
+	if len(t.parser.pending) > responsesFailureTapMaxBuffer {
+		t.parser.pending = nil
+		t.parser.allowBOM = false
+	}
+	return len(p), nil
+}
+
+func (t *responsesFailureTap) maybeLog(msg responsesSSEMessage) {
+	eventName := strings.TrimSpace(msg.event)
+	if eventName != "response.failed" && eventName != "response.incomplete" && eventName != "" {
+		return
+	}
+
+	event, err := parseResponsesStreamEvent(msg.data)
+	if err != nil {
+		return
+	}
+
+	eventType := strings.TrimSpace(event.Type)
+	if eventName == "" {
+		eventName = eventType
+	}
+	if eventName != "response.failed" && eventName != "response.incomplete" {
+		return
+	}
+
+	fields := []logger.Field{
+		logger.F("endpoint", "responses_stream_failure"),
+		logger.F("event_type", eventName),
+		logger.F("upstream_request_id", responsesUpstreamRequestID(t.upstreamHeaders)),
+	}
+	switch eventName {
+	case "response.failed":
+		fields = append(fields,
+			logger.F("error_code", strings.TrimSpace(event.Response.Error.Code)),
+			logger.F("error_type", strings.TrimSpace(event.Response.Error.Type)),
+			logger.F("error_message", truncateResponsesFailureLogMessage(event.Response.Error.Message)),
+		)
+	case "response.incomplete":
+		fields = append(fields,
+			logger.F("reason", strings.TrimSpace(event.Response.IncompleteDetails.Reason)),
+		)
+	}
+	t.h.log.Info("responses stream reported failure after commit", fields...)
+}

--- a/proxy/responses_failure_translate_test.go
+++ b/proxy/responses_failure_translate_test.go
@@ -1,0 +1,385 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sozercan/vekil/logger"
+)
+
+func TestHandleResponses_PrecommitFailureTranslation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		body             string
+		headers          http.Header
+		wantStatus       int
+		wantContentType  string
+		wantRetryAfter   string
+		wantErrorType    string
+		wantErrorMessage string
+		wantRawBody      string
+		assertHeaders    func(t *testing.T, headers http.Header)
+	}{
+		{
+			name: "too_many_requests translates before commit",
+			body: "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-rate-limit\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"try again later\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type":       []string{"text/event-stream"},
+				"retry-after-ms":     []string{"1500"},
+				"X-Request-Id":       []string{"req-1"},
+				"X-Azure-Request-Id": []string{"az-1"},
+				"Openai-Request-Id":  []string{"oa-1"},
+			},
+			wantStatus:       http.StatusTooManyRequests,
+			wantContentType:  "application/json",
+			wantRetryAfter:   "2",
+			wantErrorType:    "rate_limit_error",
+			wantErrorMessage: "try again later",
+			assertHeaders: func(t *testing.T, headers http.Header) {
+				t.Helper()
+				if got := headers.Get("X-Request-Id"); got != "req-1" {
+					t.Fatalf("X-Request-Id = %q, want %q", got, "req-1")
+				}
+				if got := headers.Get("X-Azure-Request-Id"); got != "az-1" {
+					t.Fatalf("X-Azure-Request-Id = %q, want %q", got, "az-1")
+				}
+				if got := headers.Get("Openai-Request-Id"); got != "oa-1" {
+					t.Fatalf("Openai-Request-Id = %q, want %q", got, "oa-1")
+				}
+			},
+		},
+		{
+			name: "model_overloaded uses retry-after seconds",
+			body: "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-overloaded\",\"error\":{\"type\":\"server_error\",\"code\":\"model_overloaded\",\"message\":\"capacity\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+				"Retry-After":  []string{"5"},
+			},
+			wantStatus:       http.StatusServiceUnavailable,
+			wantContentType:  "application/json",
+			wantRetryAfter:   "5",
+			wantErrorType:    "server_error",
+			wantErrorMessage: "capacity",
+		},
+		{
+			name: "empty code with rate_limit_error still translates",
+			body: "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-rate-limit-type\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"slow down\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:       http.StatusTooManyRequests,
+			wantContentType:  "application/json",
+			wantErrorType:    "rate_limit_error",
+			wantErrorMessage: "slow down",
+		},
+		{
+			name: "unknown failure fails open",
+			body: "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-unknown\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"too long\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/event-stream",
+			wantRawBody:     "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-unknown\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"too long\"}}}\n\n",
+		},
+		{
+			name: "non failed first event stays passthrough",
+			body: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/event-stream",
+			wantRawBody:     "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+		},
+		{
+			name: "comments and bom preserve raw bytes",
+			body: "\xEF\xBB\xBF: keepalive\n\nevent: response.created\ndata: first snowman ☃\ndata: second line\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/event-stream",
+			wantRawBody:     "\xEF\xBB\xBF: keepalive\n\nevent: response.created\ndata: first snowman ☃\ndata: second line\n\n",
+		},
+		{
+			name: "crlf framing works",
+			body: "event: response.failed\r\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-crlf\",\"error\":{\"type\":\"server_error\",\"code\":\"bad_gateway\",\"message\":\"gateway\"}}}\r\n\r\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:       http.StatusBadGateway,
+			wantContentType:  "application/json",
+			wantErrorType:    "server_error",
+			wantErrorMessage: "gateway",
+		},
+		{
+			name: "unnamed failed event translates",
+			body: "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-unnamed\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"later\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type":   []string{"text/event-stream"},
+				"retry-after-ms": []string{"500"},
+			},
+			wantStatus:       http.StatusTooManyRequests,
+			wantContentType:  "application/json",
+			wantRetryAfter:   "1",
+			wantErrorType:    "rate_limit_error",
+			wantErrorMessage: "later",
+		},
+		{
+			name: "unnamed invalid payload fails open",
+			body: "data: not-json\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/event-stream",
+			wantRawBody:     "data: not-json\n\n",
+		},
+		{
+			name: "malformed failed json fails open",
+			body: "event: response.failed\ndata: {bad json}\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/event-stream",
+			wantRawBody:     "event: response.failed\ndata: {bad json}\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     cloneHeader(tt.headers),
+					Body:       io.NopCloser(strings.NewReader(tt.body)),
+				}, nil
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.4","input":"Hello","stream":true}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			handler.HandleResponses(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != tt.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d, body=%s", resp.StatusCode, tt.wantStatus, body)
+			}
+			if got := resp.Header.Get("Content-Type"); got != tt.wantContentType {
+				t.Fatalf("Content-Type = %q, want %q", got, tt.wantContentType)
+			}
+			if got := resp.Header.Get("Retry-After"); got != tt.wantRetryAfter {
+				t.Fatalf("Retry-After = %q, want %q", got, tt.wantRetryAfter)
+			}
+			if tt.assertHeaders != nil {
+				tt.assertHeaders(t, resp.Header)
+			}
+
+			body, _ := io.ReadAll(resp.Body)
+			if tt.wantRawBody != "" {
+				if string(body) != tt.wantRawBody {
+					t.Fatalf("body = %q, want %q", string(body), tt.wantRawBody)
+				}
+				return
+			}
+
+			var envelope struct {
+				Error struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(body, &envelope); err != nil {
+				t.Fatalf("decode error envelope: %v; body=%s", err, body)
+			}
+			if envelope.Error.Type != tt.wantErrorType {
+				t.Fatalf("error.type = %q, want %q", envelope.Error.Type, tt.wantErrorType)
+			}
+			if envelope.Error.Message != tt.wantErrorMessage {
+				t.Fatalf("error.message = %q, want %q", envelope.Error.Message, tt.wantErrorMessage)
+			}
+		})
+	}
+}
+
+func TestPeekAndForwardResponses_FailsOpenOnMaxPeekBytes(t *testing.T) {
+	t.Parallel()
+
+	raw := "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"too_many_requests\",\"message\":\"" + strings.Repeat("x", 128) + "\"}}}\n\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(raw)),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"stream":true}`))
+	w := httptest.NewRecorder()
+	h := &ProxyHandler{log: logger.New(logger.LevelInfo)}
+
+	peekAndForwardResponsesWithConfig(h, w, req, resp, func() {}, "gpt-5.4", 50*time.Millisecond, 32)
+
+	result := w.Result()
+	if result.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(result.Body)
+		t.Fatalf("status = %d, want 200: %s", result.StatusCode, body)
+	}
+	body, _ := io.ReadAll(result.Body)
+	if string(body) != raw {
+		t.Fatalf("body = %q, want %q", string(body), raw)
+	}
+}
+
+func TestPeekAndForwardResponses_FailsOpenOnPeekTimeout(t *testing.T) {
+	t.Parallel()
+
+	body := &timeoutReadCloser{}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       body,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"stream":true}`))
+	w := httptest.NewRecorder()
+	h := &ProxyHandler{log: logger.New(logger.LevelInfo)}
+
+	peekAndForwardResponsesWithConfig(h, w, req, resp, func() {}, "gpt-5.4", 20*time.Millisecond, 1024)
+
+	result := w.Result()
+	if result.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(result.Body)
+		t.Fatalf("status = %d, want 200: %s", result.StatusCode, raw)
+	}
+	raw, _ := io.ReadAll(result.Body)
+	want := ": keepalive\n\nevent: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-timeout\"}}\n\n"
+	if string(raw) != want {
+		t.Fatalf("body = %q, want %q", string(raw), want)
+	}
+}
+
+func TestPeekAndForwardResponses_ClientDisconnectDuringPeekClosesUpstream(t *testing.T) {
+	t.Parallel()
+
+	body := newBlockingReadCloser()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       body,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"stream":true}`)).WithContext(ctx)
+	w := httptest.NewRecorder()
+	h := &ProxyHandler{log: logger.New(logger.LevelInfo)}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		peekAndForwardResponsesWithConfig(h, w, req, resp, func() {}, "gpt-5.4", time.Second, 1024)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handler did not return after client disconnect")
+	}
+
+	select {
+	case <-body.closed:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("upstream body was not closed")
+	}
+}
+
+func cloneHeader(src http.Header) http.Header {
+	dst := make(http.Header, len(src))
+	for key, values := range src {
+		dst[key] = append([]string(nil), values...)
+	}
+	return dst
+}
+
+type timeoutReadCloser struct {
+	mu     sync.Mutex
+	step   int
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (r *timeoutReadCloser) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	step := r.step
+	r.step++
+	if r.closed == nil {
+		r.closed = make(chan struct{})
+	}
+	closed := r.closed
+	r.mu.Unlock()
+
+	switch step {
+	case 0:
+		return copy(p, []byte(": keepalive\n\n")), nil
+	case 1:
+		timer := time.NewTimer(60 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return copy(p, []byte("event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-timeout\"}}\n\n")), nil
+		case <-closed:
+			return 0, io.EOF
+		}
+	default:
+		return 0, io.EOF
+	}
+}
+
+func (r *timeoutReadCloser) Close() error {
+	r.once.Do(func() {
+		r.mu.Lock()
+		if r.closed == nil {
+			r.closed = make(chan struct{})
+		}
+		close(r.closed)
+		r.mu.Unlock()
+	})
+	return nil
+}
+
+type blockingReadCloser struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{closed: make(chan struct{})}
+}
+
+func (r *blockingReadCloser) Read(p []byte) (int, error) {
+	<-r.closed
+	return 0, io.EOF
+}
+
+func (r *blockingReadCloser) Close() error {
+	r.once.Do(func() {
+		close(r.closed)
+	})
+	return nil
+}

--- a/proxy/responses_failure_translate_test.go
+++ b/proxy/responses_failure_translate_test.go
@@ -112,6 +112,17 @@ func TestHandleResponses_PrecommitFailureTranslation(t *testing.T) {
 			wantRawBody:     "\xEF\xBB\xBF: keepalive\n\nevent: response.created\ndata: first snowman ☃\ndata: second line\n\n",
 		},
 		{
+			name: "control only message does not consume first semantic event",
+			body: "id: msg-1\nretry: 1000\n\nevent: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-control\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"back off\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			wantStatus:       http.StatusTooManyRequests,
+			wantContentType:  "application/json",
+			wantErrorType:    "rate_limit_error",
+			wantErrorMessage: "back off",
+		},
+		{
 			name: "crlf framing works",
 			body: "event: response.failed\r\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-crlf\",\"error\":{\"type\":\"server_error\",\"code\":\"bad_gateway\",\"message\":\"gateway\"}}}\r\n\r\n",
 			headers: http.Header{

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -41,7 +41,6 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = r.Body.Close() }()
 
 	bodyBytes = h.rewriteResponsesRequestBody(bodyBytes, "responses", true)
-	model := extractRequestModel(bodyBytes)
 
 	var partial struct {
 		Stream *bool `json:"stream,omitempty"`
@@ -86,6 +85,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
+		model := extractRequestModel(bodyBytes)
 		peekAndForwardResponses(h, w, r, resp, upstreamCancel, model)
 		return
 	}

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -41,6 +41,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = r.Body.Close() }()
 
 	bodyBytes = h.rewriteResponsesRequestBody(bodyBytes, "responses", true)
+	model := extractRequestModel(bodyBytes)
 
 	var partial struct {
 		Stream *bool `json:"stream,omitempty"`
@@ -85,8 +86,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		copyPassthroughHeaders(w.Header(), resp.Header)
-		StreamOpenAIPassthrough(w, resp.Body)
+		peekAndForwardResponses(h, w, r, resp, upstreamCancel, model)
 		return
 	}
 

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -590,17 +590,30 @@ func (s *responsesWebSocketSession) streamUpstreamResponse(body io.Reader, heade
 	var responseID string
 	var outputItems []json.RawMessage
 	sawCompleted := false
+	sawSemanticEvent := false
 
 	if err := consumeResponsesSSEData(body, func(data string) error {
 		if data == "" || data == "[DONE]" {
 			return nil
 		}
+
+		var event responsesWebSocketStreamEvent
+		parsedEvent := json.Unmarshal([]byte(data), &event) == nil
+		if !sawSemanticEvent {
+			sawSemanticEvent = true
+			if parsedEvent && event.Type == "response.failed" {
+				if status, _, ok := classifyPrecommitResponsesFailure(event); ok {
+					s.sendWrappedError(status, responsesPrecommitErrorMessage(event, status), strings.TrimSpace(event.Response.Error.Code), headers)
+					return errStreamFailedUpstream
+				}
+			}
+		}
+
 		if err := s.conn.WriteMessage(websocket.TextMessage, []byte(data)); err != nil {
 			return err
 		}
 
-		var event responsesWebSocketStreamEvent
-		if err := json.Unmarshal([]byte(data), &event); err != nil {
+		if !parsedEvent {
 			return nil
 		}
 
@@ -742,6 +755,10 @@ func extractResponsesWebSocketError(status int, body []byte) (string, string) {
 func responsesWebSocketStreamFailureDetails(event responsesWebSocketStreamEvent) (int, string, string) {
 	switch event.Type {
 	case "response.failed":
+		if status, _, ok := classifyPrecommitResponsesFailure(event); ok {
+			message := responsesPrecommitErrorMessage(event, status)
+			return status, message, strings.TrimSpace(event.Response.Error.Code)
+		}
 		errType := strings.TrimSpace(event.Response.Error.Type)
 		code := strings.TrimSpace(event.Response.Error.Code)
 		message := strings.TrimSpace(event.Response.Error.Message)

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -860,6 +860,89 @@ func TestHandleResponsesWebSocket_ResponseFailedKeepsSessionOpen(t *testing.T) {
 	}
 }
 
+func TestHandleResponsesWebSocket_FirstEventTransientResponseFailedSendsOnlyErrorFrame(t *testing.T) {
+	var upstreamRequests int
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamRequests++
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Retry-After", "3")
+		switch upstreamRequests {
+		case 1:
+			_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-rate-limit\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"Too Many Requests\"}}}\n\n")
+		case 2:
+			_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-next\"}}\n\n")
+			_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-next\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
+		default:
+			t.Fatalf("unexpected upstream request count %d", upstreamRequests)
+		}
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	errFrame := mustReadWebSocketJSON(t, conn)
+	if errFrame["type"] != "error" {
+		t.Fatalf("expected error frame for first-event transient failure, got %v", errFrame["type"])
+	}
+	if statusCode, _ := errFrame["status_code"].(float64); statusCode != float64(http.StatusTooManyRequests) {
+		t.Fatalf("expected error status %d, got %v", http.StatusTooManyRequests, errFrame["status_code"])
+	}
+	errPayload, ok := errFrame["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %T", errFrame["error"])
+	}
+	if errPayload["code"] != "too_many_requests" {
+		t.Fatalf("expected error code too_many_requests, got %v", errPayload["code"])
+	}
+	if errPayload["message"] != "Too Many Requests" {
+		t.Fatalf("expected error message Too Many Requests, got %v", errPayload["message"])
+	}
+	headers, ok := errFrame["headers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected forwarded headers, got %T", errFrame["headers"])
+	}
+	if headers["Retry-After"] != "3" {
+		t.Fatalf("expected Retry-After header 3, got %v", headers["Retry-After"])
+	}
+
+	next := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "after rate limit"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(next); err != nil {
+		t.Fatalf("failed to write follow-up websocket request: %v", err)
+	}
+
+	nextCreated := mustReadWebSocketJSON(t, conn)
+	if nextCreated["type"] != "response.created" {
+		t.Fatalf("expected follow-up response.created, got %v", nextCreated["type"])
+	}
+
+	nextCompleted := mustReadWebSocketJSON(t, conn)
+	if nextCompleted["type"] != "response.completed" {
+		t.Fatalf("expected follow-up response.completed, got %v", nextCompleted["type"])
+	}
+}
+
 func TestHandleResponsesWebSocket_ResponseIncompleteKeepsSessionOpen(t *testing.T) {
 	var upstreamRequests int
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1039,6 +1122,59 @@ func TestHandleResponsesWebSocket_ResponseFailedOnStalledUpstreamKeepsSessionOpe
 	nextCompleted := mustReadWebSocketJSON(t, conn)
 	if nextCompleted["type"] != "response.completed" {
 		t.Fatalf("expected follow-up response.completed, got %v", nextCompleted["type"])
+	}
+}
+
+func TestHandleResponsesWebSocket_LaterTransientResponseFailedStillRelaysEventAndMaps429(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-later-rate-limit\"}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-later-rate-limit\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"Too Many Requests\"}}}\n\n")
+	})
+
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	request := newResponsesWebSocketCreateRequest([]interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "input_text", "text": "hello"},
+			},
+		},
+	})
+	if err := conn.WriteJSON(request); err != nil {
+		t.Fatalf("failed to write websocket request: %v", err)
+	}
+
+	created := mustReadWebSocketJSON(t, conn)
+	if created["type"] != "response.created" {
+		t.Fatalf("expected response.created, got %v", created["type"])
+	}
+
+	failed := mustReadWebSocketJSON(t, conn)
+	if failed["type"] != "response.failed" {
+		t.Fatalf("expected response.failed, got %v", failed["type"])
+	}
+
+	errFrame := mustReadWebSocketJSON(t, conn)
+	if errFrame["type"] != "error" {
+		t.Fatalf("expected error frame after response.failed, got %v", errFrame["type"])
+	}
+	if statusCode, _ := errFrame["status_code"].(float64); statusCode != float64(http.StatusTooManyRequests) {
+		t.Fatalf("expected error status %d, got %v", http.StatusTooManyRequests, errFrame["status_code"])
+	}
+	errPayload, ok := errFrame["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %T", errFrame["error"])
+	}
+	if errPayload["code"] != "too_many_requests" {
+		t.Fatalf("expected error code too_many_requests, got %v", errPayload["code"])
+	}
+	if errPayload["message"] != "Too Many Requests" {
+		t.Fatalf("expected error message Too Many Requests, got %v", errPayload["message"])
 	}
 }
 


### PR DESCRIPTION
## What changed

This changes the streaming `POST /v1/responses` path so the proxy peeks the first semantic SSE event before committing `200 OK`.

If the first event is an immediate transient `response.failed` admission-time error, the proxy now translates it into a normal HTTP error instead of flushing SSE headers and forcing the client down a stream-disconnect retry path.

The change is intentionally narrow:

- only applies to streaming `POST /v1/responses`
- only applies when upstream returned `200 OK`
- only translates recognized transient first-event `response.failed` cases
- fails open to raw SSE passthrough for malformed, unknown, non-transient, timed-out, or inconclusive peeks

## Why

Some upstream providers can accept the request, open an SSE stream, and then immediately emit `response.failed` with errors like `too_many_requests` or `model_overloaded`.

Before this change, the proxy had already committed `200 OK`, so clients such as Codex CLI saw a stream-level failure instead of a normal HTTP backoff signal. That could turn a single admission-time transient error into an avoidable retry burst.

## Root cause

The proxy's existing retry/error handling only covered failures before streaming started. Immediate first-event streaming failures on `/v1/responses` were invisible to that path because headers had already been flushed downstream.

## Impact

- transient first-event admission failures now surface as normal HTTP errors with propagated request IDs
- `Retry-After` guidance is forwarded when it can be derived from upstream headers
- later streaming failures remain passthrough and are still logged
- healthy streams and inconclusive peeks still behave as passthrough streams

## Validation

- `make test`
- `make vet`
- `make build`
