### PR TITLE
Support static Azure model metadata with best-effort /models enrichment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,6 @@ Example:
       "type": "azure-openai",
       "base_url": "https://myresource.cognitiveservices.azure.com/openai/v1",
       "api_key_env": "AZURE_OPENAI_API_KEY",
-      "api_version": "2025-04-01-preview",
       "models": [
         {
           "public_id": "gpt-5.4-pro",
@@ -62,16 +61,18 @@ Routing rules:
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
 - Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
 - Azure `models[]` remains the routing source of truth. The proxy does not autodiscover new Azure deployments for inference.
-- Azure `base_url` must include the OpenAI-compatible `/openai/v1` prefix because the proxy appends routes like `/chat/completions`, `/responses`, and `/models` directly.
+- Azure `base_url` may use either the OpenAI-compatible `/openai/v1` prefix or the legacy `/openai` prefix.
+- For `/openai/v1` base URLs, omit `api_version`; the proxy calls `/chat/completions`, `/responses`, and `/models` directly with no `api-version` query string.
+- For legacy `/openai` base URLs, set `api_version`; the proxy appends `api-version=...` to upstream requests.
 - Public model IDs are global across all providers. Startup fails if two providers expose the same ID.
 - `exclude_models` lets one provider give ownership of a public ID to another provider.
-- When `api_version` is set for Azure OpenAI, the proxy appends `api-version=...` to upstream requests.
 - Only one Copilot provider is supported in a config today.
 - `models[].endpoints` is an allowlist, not a guess. Keep it limited to the routes you have validated for that deployment.
 - Static provider models can also advertise richer Codex `/v1/models` metadata via optional fields on each `models[]` entry:
   `model_picker_category`, `reasoning_effort`, `vision`, `parallel_tool_calls`, and `context_window`.
   Without those fields, the proxy exposes a minimal but valid model entry.
 - For Azure OpenAI, `/v1/models` also tries to enrich each configured `models[]` entry from Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
+- Azure's upstream `/models` catalog can be sparse for Codex-style fields such as reasoning levels, vision, and context window, so configure those fields statically when you need richer `/v1/models` output for an alias.
 - Explicit `models[]` metadata overrides discovered Azure metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,12 +61,18 @@ Routing rules:
 
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
 - Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
+- Azure `models[]` remains the routing source of truth. The proxy does not autodiscover new Azure deployments for inference.
 - Azure `base_url` must include the OpenAI-compatible `/openai/v1` prefix because the proxy appends routes like `/chat/completions`, `/responses`, and `/models` directly.
 - Public model IDs are global across all providers. Startup fails if two providers expose the same ID.
 - `exclude_models` lets one provider give ownership of a public ID to another provider.
 - When `api_version` is set for Azure OpenAI, the proxy appends `api-version=...` to upstream requests.
 - Only one Copilot provider is supported in a config today.
 - `models[].endpoints` is an allowlist, not a guess. Keep it limited to the routes you have validated for that deployment.
+- Static provider models can also advertise richer Codex `/v1/models` metadata via optional fields on each `models[]` entry:
+  `model_picker_category`, `reasoning_effort`, `vision`, `parallel_tool_calls`, and `context_window`.
+  Without those fields, the proxy exposes a minimal but valid model entry.
+- For Azure OpenAI, `/v1/models` also tries to enrich each configured `models[]` entry from Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
+- Explicit `models[]` metadata overrides discovered Azure metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 
 Use the JSON example above as a starting point for your local providers config file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,9 +71,9 @@ Routing rules:
 - Static provider models can also advertise richer Codex `/v1/models` metadata via optional fields on each `models[]` entry:
   `model_picker_category`, `reasoning_effort`, `vision`, `parallel_tool_calls`, and `context_window`.
   Without those fields, the proxy exposes a minimal but valid model entry.
-- For Azure OpenAI, `/v1/models` also tries to enrich each configured `models[]` entry from Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
-- Azure's upstream `/models` catalog can be sparse for Codex-style fields such as reasoning levels, vision, and context window, so configure those fields statically when you need richer `/v1/models` output for an alias.
-- Explicit `models[]` metadata overrides discovered Azure metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails.
+- For Azure OpenAI, `/v1/models` only does a best-effort metadata overlay for each configured `models[]` entry by probing Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
+- Azure's upstream `/models` catalog can omit Codex-style fields entirely. The proxy only copies fields that Azure already returns; it does not derive reasoning levels, vision, parallel tool calls, model picker metadata, or context window from other Azure docs or capability hints.
+- Explicit `models[]` metadata overrides discovered Azure metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails or returns a sparse payload.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 
 Use the JSON example above as a starting point for your local providers config file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ Routing rules:
   Without those fields, the proxy exposes a minimal but valid model entry.
 - For Azure OpenAI, `/v1/models` only does a best-effort metadata overlay for each configured `models[]` entry by probing Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
 - Azure's upstream `/models` catalog can omit Codex-style fields entirely. The proxy only copies fields that Azure already returns; it does not derive reasoning levels, vision, parallel tool calls, model picker metadata, or context window from other Azure docs or capability hints.
-- Explicit `models[]` metadata overrides discovered Azure metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails or returns a sparse payload.
+- Explicit `models[]` metadata overrides Azure `/models` overlay metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails or returns a sparse payload.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 
 Use the JSON example above as a starting point for your local providers config file.

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -719,7 +719,7 @@ func transformModelsResponse(body []byte) []byte {
 			visibility = "list"
 		}
 
-		var reasoningLevels []reasoningPreset
+		reasoningLevels := make([]reasoningPreset, 0, len(m.Capabilities.Supports.ReasoningEffort))
 		var defaultReasoning *string
 		for _, level := range m.Capabilities.Supports.ReasoningEffort {
 			reasoningLevels = append(reasoningLevels, reasoningPreset{

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3110,7 +3110,7 @@ func TestHandleModels(t *testing.T) {
 		}
 	})
 
-	t.Run("Azure model enriches configured metadata from discovered public model", func(t *testing.T) {
+	t.Run("Azure discovered metadata best-effort enriches configured public model", func(t *testing.T) {
 		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
 		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3219,7 +3219,125 @@ func TestHandleModels(t *testing.T) {
 		}
 	})
 
-	t.Run("Azure discovered metadata matches deployment and respects explicit overrides", func(t *testing.T) {
+	t.Run("Azure sparse discovered metadata leaves static model minimal but valid", func(t *testing.T) {
+		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/openai/v1/models" {
+				t.Fatalf("unexpected Azure path %q", r.URL.Path)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"azure-openai"}]}`))
+		}))
+		defer azureServer.Close()
+
+		handler, err := NewProxyHandler(
+			auth.NewTestAuthenticator("test-token"),
+			logger.New(logger.LevelInfo),
+			WithProvidersConfig(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   azureServer.URL + "/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4",
+						Deployment: "gpt-5-4-prod",
+						Endpoints:  []string{"/responses"},
+					}},
+				}},
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewProxyHandler returned error: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		var result struct {
+			Data []struct {
+				ID                 string   `json:"id"`
+				Name               string   `json:"name"`
+				SupportedEndpoints []string `json:"supported_endpoints"`
+			} `json:"data"`
+			Models []struct {
+				Slug                       string   `json:"slug"`
+				DisplayName                string   `json:"display_name"`
+				Visibility                 string   `json:"visibility"`
+				SupportedInAPI             bool     `json:"supported_in_api"`
+				DefaultReasoningLevel      *string  `json:"default_reasoning_level,omitempty"`
+				SupportedReasoningLevels   []string `json:"supported_reasoning_levels"`
+				SupportsReasoningSummaries bool     `json:"supports_reasoning_summaries"`
+				Priority                   int      `json:"priority"`
+				SupportsParallelToolCalls  bool     `json:"supports_parallel_tool_calls"`
+				ContextWindow              *int64   `json:"context_window,omitempty"`
+				InputModalities            []string `json:"input_modalities"`
+			} `json:"models"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(result.Data) != 1 || len(result.Models) != 1 {
+			t.Fatalf("expected one Azure model entry, got data=%d models=%d", len(result.Data), len(result.Models))
+		}
+		if result.Data[0].ID != "gpt-5.4" {
+			t.Fatalf("expected public id gpt-5.4, got %q", result.Data[0].ID)
+		}
+		if result.Data[0].Name != "gpt-5.4" {
+			t.Fatalf("expected static fallback name gpt-5.4, got %q", result.Data[0].Name)
+		}
+		if got := strings.Join(result.Data[0].SupportedEndpoints, ","); got != "/responses" {
+			t.Fatalf("expected configured supported_endpoints /responses, got %q", got)
+		}
+
+		model := result.Models[0]
+		if model.Slug != "gpt-5.4" {
+			t.Fatalf("expected slug gpt-5.4, got %q", model.Slug)
+		}
+		if model.DisplayName != "gpt-5.4" {
+			t.Fatalf("expected static fallback display name gpt-5.4, got %q", model.DisplayName)
+		}
+		if model.Visibility != "list" {
+			t.Fatalf("expected default visibility list for /responses model, got %q", model.Visibility)
+		}
+		if !model.SupportedInAPI {
+			t.Fatal("expected supported_in_api true from configured /responses endpoint")
+		}
+		if model.DefaultReasoningLevel != nil {
+			t.Fatalf("expected no default_reasoning_level for sparse metadata, got %v", model.DefaultReasoningLevel)
+		}
+		if len(model.SupportedReasoningLevels) != 0 {
+			t.Fatalf("expected no supported_reasoning_levels for sparse metadata, got %v", model.SupportedReasoningLevels)
+		}
+		if model.SupportsReasoningSummaries {
+			t.Fatal("expected supports_reasoning_summaries false for sparse metadata")
+		}
+		if model.Priority != 5 {
+			t.Fatalf("expected default versatile priority 5, got %d", model.Priority)
+		}
+		if model.SupportsParallelToolCalls {
+			t.Fatal("expected supports_parallel_tool_calls false for sparse metadata")
+		}
+		if model.ContextWindow != nil {
+			t.Fatalf("expected no context_window for sparse metadata, got %v", model.ContextWindow)
+		}
+		if got := strings.Join(model.InputModalities, ","); got != "text" {
+			t.Fatalf("expected text-only input_modalities for sparse metadata, got %q", got)
+		}
+	})
+
+	t.Run("Azure best-effort discovered metadata matches deployment and respects explicit overrides", func(t *testing.T) {
 		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
 		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3110,7 +3110,7 @@ func TestHandleModels(t *testing.T) {
 		}
 	})
 
-	t.Run("Azure discovered metadata best-effort enriches configured public model", func(t *testing.T) {
+	t.Run("Azure upstream metadata best-effort enriches configured public model", func(t *testing.T) {
 		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
 		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3125,7 +3125,7 @@ func TestHandleModels(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"azure-openai","supported_endpoints":["/chat/completions","/responses"],"capabilities":{"supports":{"parallel_tool_calls":true,"vision":true,"reasoning_effort":["low","medium","high"]},"limits":{"max_context_window_tokens":128000}},"model_picker_enabled":true,"model_picker_category":"powerful","name":"GPT-5.4 Discovered"}]}`))
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"azure-openai","supported_endpoints":["/chat/completions","/responses"],"capabilities":{"supports":{"parallel_tool_calls":true,"vision":true,"reasoning_effort":["low","medium","high"]},"limits":{"max_context_window_tokens":128000}},"model_picker_enabled":true,"model_picker_category":"powerful","name":"GPT-5.4 Overlay"}]}`))
 		}))
 		defer azureServer.Close()
 
@@ -3188,8 +3188,8 @@ func TestHandleModels(t *testing.T) {
 		if result.Data[0].ID != "gpt-5.4" {
 			t.Fatalf("expected public id gpt-5.4, got %q", result.Data[0].ID)
 		}
-		if result.Data[0].Name != "GPT-5.4 Discovered" {
-			t.Fatalf("expected discovered name, got %q", result.Data[0].Name)
+		if result.Data[0].Name != "GPT-5.4 Overlay" {
+			t.Fatalf("expected Azure overlay name, got %q", result.Data[0].Name)
 		}
 		if got := strings.Join(result.Data[0].SupportedEndpoints, ","); got != "/responses" {
 			t.Fatalf("expected configured supported_endpoints /responses, got %q", got)
@@ -3199,27 +3199,27 @@ func TestHandleModels(t *testing.T) {
 		if model.Slug != "gpt-5.4" {
 			t.Fatalf("expected slug gpt-5.4, got %q", model.Slug)
 		}
-		if model.DisplayName != "GPT-5.4 Discovered" {
-			t.Fatalf("expected discovered display name, got %q", model.DisplayName)
+		if model.DisplayName != "GPT-5.4 Overlay" {
+			t.Fatalf("expected Azure overlay display name, got %q", model.DisplayName)
 		}
 		if model.DefaultReasoningLevel == nil || *model.DefaultReasoningLevel != "medium" {
 			t.Fatalf("expected default_reasoning_level medium, got %v", model.DefaultReasoningLevel)
 		}
 		if !model.SupportsParallelToolCalls {
-			t.Fatal("expected discovered supports_parallel_tool_calls true")
+			t.Fatal("expected Azure overlay supports_parallel_tool_calls true")
 		}
 		if model.ContextWindow == nil || *model.ContextWindow != 128000 {
-			t.Fatalf("expected discovered context_window 128000, got %v", model.ContextWindow)
+			t.Fatalf("expected Azure overlay context_window 128000, got %v", model.ContextWindow)
 		}
 		if got := strings.Join(model.InputModalities, ","); got != "text,image" {
-			t.Fatalf("expected discovered input_modalities text,image, got %q", got)
+			t.Fatalf("expected Azure overlay input_modalities text,image, got %q", got)
 		}
 		if model.Priority != 0 {
 			t.Fatalf("expected powerful priority 0, got %d", model.Priority)
 		}
 	})
 
-	t.Run("Azure sparse discovered metadata leaves static model minimal but valid", func(t *testing.T) {
+	t.Run("Azure sparse upstream metadata leaves static model minimal but valid", func(t *testing.T) {
 		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
 		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3337,7 +3337,7 @@ func TestHandleModels(t *testing.T) {
 		}
 	})
 
-	t.Run("Azure best-effort discovered metadata matches deployment and respects explicit overrides", func(t *testing.T) {
+	t.Run("Azure best-effort upstream metadata matches deployment and respects explicit overrides", func(t *testing.T) {
 		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
 		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3345,7 +3345,7 @@ func TestHandleModels(t *testing.T) {
 				t.Fatalf("unexpected Azure path %q", r.URL.Path)
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5-4-prod","object":"model","created":0,"owned_by":"azure-openai","supported_endpoints":["/chat/completions","/responses"],"capabilities":{"supports":{"parallel_tool_calls":true,"vision":true,"reasoning_effort":["low","medium","high"]},"limits":{"max_context_window_tokens":128000}},"model_picker_enabled":true,"model_picker_category":"versatile","name":"Discovered GPT-5.4 Prod"}]}`))
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5-4-prod","object":"model","created":0,"owned_by":"azure-openai","supported_endpoints":["/chat/completions","/responses"],"capabilities":{"supports":{"parallel_tool_calls":true,"vision":true,"reasoning_effort":["low","medium","high"]},"limits":{"max_context_window_tokens":128000}},"model_picker_enabled":true,"model_picker_category":"versatile","name":"Overlay GPT-5.4 Prod"}]}`))
 		}))
 		defer azureServer.Close()
 
@@ -3450,7 +3450,7 @@ func TestHandleModels(t *testing.T) {
 			t.Fatalf("expected configured powerful priority 0, got %d", model.Priority)
 		}
 		if model.SupportsParallelToolCalls {
-			t.Fatal("expected configured parallel_tool_calls=false to win over discovered metadata")
+			t.Fatal("expected configured parallel_tool_calls=false to win over Azure overlay metadata")
 		}
 		if model.ContextWindow == nil || *model.ContextWindow != 64000 {
 			t.Fatalf("expected configured context_window 64000, got %v", model.ContextWindow)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2240,8 +2240,8 @@ func TestHandleOpenAIChatCompletions_RoutesConfiguredAzureModel(t *testing.T) {
 		if got := r.URL.Path; got != "/openai/v1/chat/completions" {
 			t.Fatalf("expected Azure path /openai/v1/chat/completions, got %s", got)
 		}
-		if got := r.URL.Query().Get("api-version"); got != "preview" {
-			t.Fatalf("expected api-version=preview, got %q", got)
+		if got := r.URL.RawQuery; got != "" {
+			t.Fatalf("expected no Azure query params for /openai/v1 base URL, got %q", got)
 		}
 		if got := r.Header.Get("api-key"); got != "azure-test-key" {
 			t.Fatalf("expected api-key header, got %q", got)
@@ -3117,8 +3117,8 @@ func TestHandleModels(t *testing.T) {
 			if r.URL.Path != "/openai/v1/models" {
 				t.Fatalf("unexpected Azure path %q", r.URL.Path)
 			}
-			if got := r.URL.Query().Get("api-version"); got != "preview" {
-				t.Fatalf("expected api-version=preview, got %q", got)
+			if got := r.URL.RawQuery; got != "" {
+				t.Fatalf("expected no Azure query params for /openai/v1 base URL, got %q", got)
 			}
 			if got := r.Header.Get("api-key"); got != "azure-test-key" {
 				t.Fatalf("expected api-key header, got %q", got)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -52,6 +52,27 @@ func newRoundTripTestProxyHandler(t testing.TB, transport roundTripFunc) *ProxyH
 	}
 }
 
+type trackingReadCloser struct {
+	reader    io.Reader
+	bytesRead int
+	closed    bool
+}
+
+func newTrackingReadCloser(body string) *trackingReadCloser {
+	return &trackingReadCloser{reader: strings.NewReader(body)}
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += n
+	return n, err
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
 func assertDeadlineApprox(t *testing.T, got, want time.Duration) {
 	t.Helper()
 	const tolerance = 15 * time.Second
@@ -2752,6 +2773,38 @@ func TestNewProviderJSONRequest_OmitsBodyForGetNilPayload(t *testing.T) {
 	}
 	if req.ContentLength != 0 {
 		t.Fatalf("expected ContentLength 0, got %d", req.ContentLength)
+	}
+}
+
+func TestFetchProviderModels_AzureNonOKDrainsResponseBody(t *testing.T) {
+	body := newTrackingReadCloser("azure metadata unavailable")
+	handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if got := r.URL.Path; got != "/openai/v1/models" {
+			t.Fatalf("expected /openai/v1/models, got %s", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+			Body:       body,
+		}, nil
+	}))
+
+	result, err := handler.fetchProviderModels(context.Background(), &providerRuntime{
+		id:      "azure",
+		kind:    providerTypeAzureOpenAI,
+		baseURL: "http://example.test/openai/v1",
+	}, "", "")
+	if err != nil {
+		t.Fatalf("fetchProviderModels returned error: %v", err)
+	}
+	if len(result.models) != 0 {
+		t.Fatalf("expected no models, got %+v", result.models)
+	}
+	if !body.closed {
+		t.Fatal("expected Azure /models body to be closed")
+	}
+	if body.bytesRead == 0 {
+		t.Fatal("expected Azure /models body to be drained before close")
 	}
 }
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2633,12 +2633,16 @@ func TestHandleModels_RefreshesDynamicProviderOwnershipForRouting(t *testing.T) 
 	defer copilotServer.Close()
 
 	azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/openai/v1/responses" {
+		switch r.URL.Path {
+		case "/openai/v1/models":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/openai/v1/responses":
+			atomic.AddInt32(&azureResponses, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-azure","object":"response","status":"completed"}`))
+		default:
 			t.Fatalf("unexpected Azure path %q", r.URL.Path)
 		}
-		atomic.AddInt32(&azureResponses, 1)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"resp-azure","object":"response","status":"completed"}`))
 	}))
 	defer azureServer.Close()
 
@@ -2928,6 +2932,413 @@ func TestHandleModels(t *testing.T) {
 		}
 		if len(result.Models[0].SupportedReasoningLevels) != 2 {
 			t.Fatalf("expected 2 supported reasoning levels, got %d", len(result.Models[0].SupportedReasoningLevels))
+		}
+	})
+
+	t.Run("static Azure model serializes empty reasoning levels as array", func(t *testing.T) {
+		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/openai/v1/models" {
+				t.Fatalf("unexpected Azure path %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer azureServer.Close()
+
+		handler, err := NewProxyHandler(
+			auth.NewTestAuthenticator("test-token"),
+			logger.New(logger.LevelInfo),
+			WithProvidersConfig(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   azureServer.URL + "/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4",
+						Deployment: "gpt-5-4-prod",
+						Endpoints:  []string{"/responses"},
+						Name:       "GPT-5.4",
+					}},
+				}},
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewProxyHandler returned error: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if !bytes.Contains(body, []byte(`"supported_reasoning_levels":[]`)) {
+			t.Fatalf("expected supported_reasoning_levels to serialize as [], got %s", body)
+		}
+
+		var result struct {
+			Models []struct {
+				Slug                     string `json:"slug"`
+				SupportedReasoningLevels []struct {
+					Effort string `json:"effort"`
+				} `json:"supported_reasoning_levels"`
+			} `json:"models"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if len(result.Models) != 1 {
+			t.Fatalf("expected 1 model entry, got %d", len(result.Models))
+		}
+		if result.Models[0].Slug != "gpt-5.4" {
+			t.Fatalf("expected model slug gpt-5.4, got %q", result.Models[0].Slug)
+		}
+		if result.Models[0].SupportedReasoningLevels == nil {
+			t.Fatal("expected supported_reasoning_levels to be a non-nil empty slice")
+		}
+		if len(result.Models[0].SupportedReasoningLevels) != 0 {
+			t.Fatalf("expected 0 supported reasoning levels, got %d", len(result.Models[0].SupportedReasoningLevels))
+		}
+	})
+
+	t.Run("static Azure model exposes configured Codex metadata", func(t *testing.T) {
+		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/openai/v1/models" {
+				t.Fatalf("unexpected Azure path %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer azureServer.Close()
+
+		parallelToolCalls := true
+		vision := true
+		contextWindow := int64(400000)
+		handler, err := NewProxyHandler(
+			auth.NewTestAuthenticator("test-token"),
+			logger.New(logger.LevelInfo),
+			WithProvidersConfig(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   azureServer.URL + "/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:            "gpt-5.4",
+						Deployment:          "gpt-5-4-prod",
+						Endpoints:           []string{"/responses"},
+						Name:                "GPT-5.4",
+						ModelPickerCategory: "powerful",
+						ReasoningEffort:     []string{"low", "medium", "high"},
+						Vision:              &vision,
+						ParallelToolCalls:   &parallelToolCalls,
+						ContextWindow:       &contextWindow,
+					}},
+				}},
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewProxyHandler returned error: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		var result struct {
+			Models []struct {
+				Slug                     string  `json:"slug"`
+				DefaultReasoningLevel    *string `json:"default_reasoning_level,omitempty"`
+				SupportedReasoningLevels []struct {
+					Effort string `json:"effort"`
+				} `json:"supported_reasoning_levels"`
+				Priority                   int      `json:"priority"`
+				SupportsReasoningSummaries bool     `json:"supports_reasoning_summaries"`
+				SupportsParallelToolCalls  bool     `json:"supports_parallel_tool_calls"`
+				ContextWindow              *int64   `json:"context_window,omitempty"`
+				InputModalities            []string `json:"input_modalities"`
+			} `json:"models"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(result.Models) != 1 {
+			t.Fatalf("expected 1 model entry, got %d", len(result.Models))
+		}
+		model := result.Models[0]
+		if model.Slug != "gpt-5.4" {
+			t.Fatalf("expected model slug gpt-5.4, got %q", model.Slug)
+		}
+		if model.DefaultReasoningLevel == nil || *model.DefaultReasoningLevel != "medium" {
+			t.Fatalf("expected default_reasoning_level medium, got %v", model.DefaultReasoningLevel)
+		}
+		if len(model.SupportedReasoningLevels) != 3 {
+			t.Fatalf("expected 3 supported reasoning levels, got %d", len(model.SupportedReasoningLevels))
+		}
+		if model.Priority != 0 {
+			t.Fatalf("expected powerful model priority 0, got %d", model.Priority)
+		}
+		if !model.SupportsReasoningSummaries {
+			t.Fatal("expected supports_reasoning_summaries true")
+		}
+		if !model.SupportsParallelToolCalls {
+			t.Fatal("expected supports_parallel_tool_calls true")
+		}
+		if model.ContextWindow == nil || *model.ContextWindow != 400000 {
+			t.Fatalf("expected context_window 400000, got %v", model.ContextWindow)
+		}
+		if got := strings.Join(model.InputModalities, ","); got != "text,image" {
+			t.Fatalf("expected input_modalities text,image, got %q", got)
+		}
+	})
+
+	t.Run("Azure model enriches configured metadata from discovered public model", func(t *testing.T) {
+		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/openai/v1/models" {
+				t.Fatalf("unexpected Azure path %q", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("api-version"); got != "preview" {
+				t.Fatalf("expected api-version=preview, got %q", got)
+			}
+			if got := r.Header.Get("api-key"); got != "azure-test-key" {
+				t.Fatalf("expected api-key header, got %q", got)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"azure-openai","supported_endpoints":["/chat/completions","/responses"],"capabilities":{"supports":{"parallel_tool_calls":true,"vision":true,"reasoning_effort":["low","medium","high"]},"limits":{"max_context_window_tokens":128000}},"model_picker_enabled":true,"model_picker_category":"powerful","name":"GPT-5.4 Discovered"}]}`))
+		}))
+		defer azureServer.Close()
+
+		handler, err := NewProxyHandler(
+			auth.NewTestAuthenticator("test-token"),
+			logger.New(logger.LevelInfo),
+			WithProvidersConfig(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:         "azure",
+					Type:       "azure-openai",
+					Default:    true,
+					BaseURL:    azureServer.URL + "/openai/v1",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
+					APIVersion: "preview",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4",
+						Deployment: "gpt-5-4-prod",
+						Endpoints:  []string{"/responses"},
+					}},
+				}},
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewProxyHandler returned error: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		var result struct {
+			Data []struct {
+				ID                 string   `json:"id"`
+				Name               string   `json:"name"`
+				SupportedEndpoints []string `json:"supported_endpoints"`
+			} `json:"data"`
+			Models []struct {
+				Slug                      string   `json:"slug"`
+				DisplayName               string   `json:"display_name"`
+				DefaultReasoningLevel     *string  `json:"default_reasoning_level,omitempty"`
+				SupportsParallelToolCalls bool     `json:"supports_parallel_tool_calls"`
+				ContextWindow             *int64   `json:"context_window,omitempty"`
+				InputModalities           []string `json:"input_modalities"`
+				Priority                  int      `json:"priority"`
+			} `json:"models"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(result.Data) != 1 || len(result.Models) != 1 {
+			t.Fatalf("expected one Azure model entry, got data=%d models=%d", len(result.Data), len(result.Models))
+		}
+		if result.Data[0].ID != "gpt-5.4" {
+			t.Fatalf("expected public id gpt-5.4, got %q", result.Data[0].ID)
+		}
+		if result.Data[0].Name != "GPT-5.4 Discovered" {
+			t.Fatalf("expected discovered name, got %q", result.Data[0].Name)
+		}
+		if got := strings.Join(result.Data[0].SupportedEndpoints, ","); got != "/responses" {
+			t.Fatalf("expected configured supported_endpoints /responses, got %q", got)
+		}
+
+		model := result.Models[0]
+		if model.Slug != "gpt-5.4" {
+			t.Fatalf("expected slug gpt-5.4, got %q", model.Slug)
+		}
+		if model.DisplayName != "GPT-5.4 Discovered" {
+			t.Fatalf("expected discovered display name, got %q", model.DisplayName)
+		}
+		if model.DefaultReasoningLevel == nil || *model.DefaultReasoningLevel != "medium" {
+			t.Fatalf("expected default_reasoning_level medium, got %v", model.DefaultReasoningLevel)
+		}
+		if !model.SupportsParallelToolCalls {
+			t.Fatal("expected discovered supports_parallel_tool_calls true")
+		}
+		if model.ContextWindow == nil || *model.ContextWindow != 128000 {
+			t.Fatalf("expected discovered context_window 128000, got %v", model.ContextWindow)
+		}
+		if got := strings.Join(model.InputModalities, ","); got != "text,image" {
+			t.Fatalf("expected discovered input_modalities text,image, got %q", got)
+		}
+		if model.Priority != 0 {
+			t.Fatalf("expected powerful priority 0, got %d", model.Priority)
+		}
+	})
+
+	t.Run("Azure discovered metadata matches deployment and respects explicit overrides", func(t *testing.T) {
+		t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+		azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/openai/v1/models" {
+				t.Fatalf("unexpected Azure path %q", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5-4-prod","object":"model","created":0,"owned_by":"azure-openai","supported_endpoints":["/chat/completions","/responses"],"capabilities":{"supports":{"parallel_tool_calls":true,"vision":true,"reasoning_effort":["low","medium","high"]},"limits":{"max_context_window_tokens":128000}},"model_picker_enabled":true,"model_picker_category":"versatile","name":"Discovered GPT-5.4 Prod"}]}`))
+		}))
+		defer azureServer.Close()
+
+		modelPickerEnabled := false
+		parallelToolCalls := false
+		vision := false
+		contextWindow := int64(64000)
+
+		handler, err := NewProxyHandler(
+			auth.NewTestAuthenticator("test-token"),
+			logger.New(logger.LevelInfo),
+			WithProvidersConfig(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   azureServer.URL + "/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:            "gpt-5.4-proxy",
+						Deployment:          "gpt-5-4-prod",
+						Endpoints:           []string{"/responses"},
+						Name:                "Alias GPT-5.4",
+						ModelPickerEnabled:  &modelPickerEnabled,
+						ModelPickerCategory: "powerful",
+						ReasoningEffort:     []string{"low"},
+						Vision:              &vision,
+						ParallelToolCalls:   &parallelToolCalls,
+						ContextWindow:       &contextWindow,
+					}},
+				}},
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewProxyHandler returned error: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleModels(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		var result struct {
+			Data []struct {
+				ID                 string   `json:"id"`
+				Name               string   `json:"name"`
+				SupportedEndpoints []string `json:"supported_endpoints"`
+			} `json:"data"`
+			Models []struct {
+				Slug                     string  `json:"slug"`
+				DisplayName              string  `json:"display_name"`
+				Visibility               string  `json:"visibility"`
+				DefaultReasoningLevel    *string `json:"default_reasoning_level,omitempty"`
+				SupportedReasoningLevels []struct {
+					Effort string `json:"effort"`
+				} `json:"supported_reasoning_levels"`
+				Priority                  int      `json:"priority"`
+				SupportsParallelToolCalls bool     `json:"supports_parallel_tool_calls"`
+				ContextWindow             *int64   `json:"context_window,omitempty"`
+				InputModalities           []string `json:"input_modalities"`
+			} `json:"models"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if len(result.Data) != 1 || len(result.Models) != 1 {
+			t.Fatalf("expected one Azure model entry, got data=%d models=%d", len(result.Data), len(result.Models))
+		}
+		if result.Data[0].ID != "gpt-5.4-proxy" {
+			t.Fatalf("expected aliased public id, got %q", result.Data[0].ID)
+		}
+		if result.Data[0].Name != "Alias GPT-5.4" {
+			t.Fatalf("expected configured name override, got %q", result.Data[0].Name)
+		}
+		if got := strings.Join(result.Data[0].SupportedEndpoints, ","); got != "/responses" {
+			t.Fatalf("expected configured supported_endpoints /responses, got %q", got)
+		}
+
+		model := result.Models[0]
+		if model.Slug != "gpt-5.4-proxy" {
+			t.Fatalf("expected aliased slug, got %q", model.Slug)
+		}
+		if model.DisplayName != "Alias GPT-5.4" {
+			t.Fatalf("expected configured display name override, got %q", model.DisplayName)
+		}
+		if model.Visibility != "hide" {
+			t.Fatalf("expected hidden visibility from configured model_picker_enabled=false, got %q", model.Visibility)
+		}
+		if model.DefaultReasoningLevel == nil || *model.DefaultReasoningLevel != "low" {
+			t.Fatalf("expected configured default_reasoning_level low, got %v", model.DefaultReasoningLevel)
+		}
+		if len(model.SupportedReasoningLevels) != 1 || model.SupportedReasoningLevels[0].Effort != "low" {
+			t.Fatalf("expected configured reasoning_effort override, got %+v", model.SupportedReasoningLevels)
+		}
+		if model.Priority != 0 {
+			t.Fatalf("expected configured powerful priority 0, got %d", model.Priority)
+		}
+		if model.SupportsParallelToolCalls {
+			t.Fatal("expected configured parallel_tool_calls=false to win over discovered metadata")
+		}
+		if model.ContextWindow == nil || *model.ContextWindow != 64000 {
+			t.Fatalf("expected configured context_window 64000, got %v", model.ContextWindow)
+		}
+		if got := strings.Join(model.InputModalities, ","); got != "text" {
+			t.Fatalf("expected configured vision=false to keep text-only input_modalities, got %q", got)
 		}
 	})
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -624,10 +624,18 @@ func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string
 
 	baseURL := strings.TrimRight(provider.baseURL, "/")
 	fullURL := baseURL + path
-	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" {
+	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" || azureUsesOpenAIV1BaseURL(baseURL) {
 		return appendRawQuery(fullURL, extraQuery), nil
 	}
 	return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+}
+
+func azureUsesOpenAIV1BaseURL(baseURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return strings.HasSuffix(strings.TrimRight(strings.TrimSpace(baseURL), "/"), "/openai/v1")
+	}
+	return strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/openai/v1")
 }
 
 func appendQuery(parts ...string) string {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -51,9 +51,9 @@ type ProviderModelConfig struct {
 	ModelPickerEnabled  *bool    `json:"model_picker_enabled,omitempty"`
 	ModelPickerCategory string   `json:"model_picker_category,omitempty"`
 	ReasoningEffort     []string `json:"reasoning_effort,omitempty"`
-	Vision              bool     `json:"vision,omitempty"`
+	Vision              *bool    `json:"vision,omitempty"`
 	ParallelToolCalls   *bool    `json:"parallel_tool_calls,omitempty"`
-	ContextWindow       int64    `json:"context_window,omitempty"`
+	ContextWindow       *int64   `json:"context_window,omitempty"`
 }
 
 type providerRuntime struct {
@@ -65,6 +65,7 @@ type providerRuntime struct {
 	apiVersion    string
 	excludeModels map[string]struct{}
 	staticModels  map[string]providerModel
+	staticConfigs map[string]ProviderModelConfig
 	staticOrder   []string
 }
 
@@ -376,6 +377,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 		isDefault:     cfg.Default,
 		excludeModels: make(map[string]struct{}, len(cfg.ExcludeModels)),
 		staticModels:  make(map[string]providerModel, len(cfg.Models)),
+		staticConfigs: make(map[string]ProviderModelConfig, len(cfg.Models)),
 	}
 
 	for _, excluded := range cfg.ExcludeModels {
@@ -417,6 +419,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 				return nil, fmt.Errorf("provider %q configures model %q more than once", id, model.publicID)
 			}
 			runtime.staticModels[model.publicID] = model
+			runtime.staticConfigs[model.publicID] = normalizeProviderModelConfig(modelCfg)
 			runtime.staticOrder = append(runtime.staticOrder, model.publicID)
 		}
 	}
@@ -453,6 +456,20 @@ func buildStaticProviderModel(providerID string, cfg ProviderModelConfig) (provi
 		supportedEndpoints: endpoints,
 		raw:                raw,
 	}, nil
+}
+
+func normalizeProviderModelConfig(cfg ProviderModelConfig) ProviderModelConfig {
+	cfg.PublicID = strings.TrimSpace(cfg.PublicID)
+	cfg.Deployment = strings.TrimSpace(cfg.Deployment)
+	cfg.Name = strings.TrimSpace(cfg.Name)
+	cfg.ModelPickerCategory = strings.TrimSpace(cfg.ModelPickerCategory)
+	if cfg.Endpoints != nil {
+		cfg.Endpoints = append([]string(nil), cfg.Endpoints...)
+	}
+	if cfg.ReasoningEffort != nil {
+		cfg.ReasoningEffort = append([]string(nil), cfg.ReasoningEffort...)
+	}
+	return cfg
 }
 
 func normalizeProviderEndpoints(endpoints []string) []string {
@@ -503,6 +520,16 @@ func synthesizeProviderModelRaw(providerID, publicID, name string, endpoints []s
 		parallelToolCalls = *cfg.ParallelToolCalls
 	}
 
+	vision := false
+	if cfg.Vision != nil {
+		vision = *cfg.Vision
+	}
+
+	contextWindow := int64(0)
+	if cfg.ContextWindow != nil {
+		contextWindow = *cfg.ContextWindow
+	}
+
 	category := strings.TrimSpace(cfg.ModelPickerCategory)
 	if category == "" {
 		category = "versatile"
@@ -517,12 +544,12 @@ func synthesizeProviderModelRaw(providerID, publicID, name string, endpoints []s
 		"supported_endpoints": endpoints,
 		"capabilities": capabilities{
 			Limits: limits{
-				MaxContextWindowTokens: cfg.ContextWindow,
+				MaxContextWindowTokens: contextWindow,
 			},
 			Supports: supports{
 				ParallelToolCalls: parallelToolCalls,
 				ReasoningEffort:   append([]string(nil), cfg.ReasoningEffort...),
-				Vision:            cfg.Vision,
+				Vision:            vision,
 			},
 		},
 		"model_picker_enabled":  modelPickerEnabled,
@@ -683,13 +710,45 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 
 	switch provider.kind {
 	case providerTypeAzureOpenAI:
-		models := make([]providerModel, 0, len(provider.staticModels))
-		for _, publicID := range provider.staticOrder {
-			model, ok := provider.staticModels[publicID]
-			if ok {
-				models = append(models, model)
-			}
+		models := orderedStaticProviderModels(provider)
+
+		resp, err := h.doWithRetry(func() (*http.Request, error) {
+			return h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, "")
+		})
+		if err != nil {
+			return providerModelsFetchResult{models: models}, nil
 		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return providerModelsFetchResult{models: models}, nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return providerModelsFetchResult{models: models}, nil
+		}
+
+		discoveredModels, err := decodeProviderModelsFromBody(provider.id, body, provider.excludeModels)
+		if err != nil {
+			return providerModelsFetchResult{models: models}, nil
+		}
+
+		discoveredByID := make(map[string]providerModel, len(discoveredModels))
+		for _, discovered := range discoveredModels {
+			discoveredByID[discovered.publicID] = discovered
+		}
+		for i, staticModel := range models {
+			cfg, ok := provider.staticConfigs[staticModel.publicID]
+			if !ok {
+				continue
+			}
+			discovered, ok := findDiscoveredProviderModel(cfg, discoveredByID)
+			if !ok {
+				continue
+			}
+			models[i] = mergeStaticProviderMetadata(staticModel, cfg, discovered)
+		}
+
 		return providerModelsFetchResult{models: models}, nil
 	case providerTypeCopilot:
 		resp, err := h.doWithRetry(func() (*http.Request, error) {
@@ -734,6 +793,186 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 	default:
 		return providerModelsFetchResult{}, fmt.Errorf("unsupported provider type %q", provider.kind)
 	}
+}
+
+func orderedStaticProviderModels(provider *providerRuntime) []providerModel {
+	if provider == nil {
+		return nil
+	}
+	models := make([]providerModel, 0, len(provider.staticModels))
+	for _, publicID := range provider.staticOrder {
+		model, ok := provider.staticModels[publicID]
+		if ok {
+			models = append(models, model)
+		}
+	}
+	return models
+}
+
+func findDiscoveredProviderModel(cfg ProviderModelConfig, discoveredByID map[string]providerModel) (providerModel, bool) {
+	publicID := strings.TrimSpace(cfg.PublicID)
+	if publicID != "" {
+		if discovered, ok := discoveredByID[publicID]; ok {
+			return discovered, true
+		}
+	}
+
+	deployment := strings.TrimSpace(cfg.Deployment)
+	if deployment != "" && deployment != publicID {
+		if discovered, ok := discoveredByID[deployment]; ok {
+			return discovered, true
+		}
+	}
+
+	return providerModel{}, false
+}
+
+func mergeStaticProviderMetadata(static providerModel, cfg ProviderModelConfig, discovered providerModel) providerModel {
+	mergedRaw, err := mergeDiscoveredProviderModelRaw(static.raw, discovered.raw, cfg)
+	if err != nil {
+		return static
+	}
+	static.raw = mergedRaw
+	return static
+}
+
+func mergeDiscoveredProviderModelRaw(baseRaw, discoveredRaw json.RawMessage, cfg ProviderModelConfig) (json.RawMessage, error) {
+	if len(baseRaw) == 0 || len(discoveredRaw) == 0 {
+		return append(json.RawMessage(nil), baseRaw...), nil
+	}
+
+	base, err := decodeRawJSONObject(baseRaw)
+	if err != nil {
+		return nil, err
+	}
+	discovered, err := decodeRawJSONObject(discoveredRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range discovered {
+		if _, exists := base[key]; !exists {
+			base[key] = append(json.RawMessage(nil), value...)
+		}
+	}
+
+	if strings.TrimSpace(cfg.Name) == "" {
+		copyRawField(base, discovered, "name")
+	}
+	if cfg.ModelPickerEnabled == nil {
+		copyRawField(base, discovered, "model_picker_enabled")
+	}
+	if strings.TrimSpace(cfg.ModelPickerCategory) == "" {
+		copyRawField(base, discovered, "model_picker_category")
+	}
+
+	if err := mergeDiscoveredProviderCapabilities(base, discovered, cfg); err != nil {
+		return nil, err
+	}
+
+	merged, err := json.Marshal(base)
+	if err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+func mergeDiscoveredProviderCapabilities(base, discovered map[string]json.RawMessage, cfg ProviderModelConfig) error {
+	baseCaps, err := decodeOptionalRawJSONObject(base["capabilities"])
+	if err != nil {
+		return err
+	}
+	discoveredCaps, err := decodeOptionalRawJSONObject(discovered["capabilities"])
+	if err != nil {
+		return err
+	}
+
+	baseSupports, err := decodeOptionalRawJSONObject(baseCaps["supports"])
+	if err != nil {
+		return err
+	}
+	discoveredSupports, err := decodeOptionalRawJSONObject(discoveredCaps["supports"])
+	if err != nil {
+		return err
+	}
+
+	if cfg.ReasoningEffort == nil {
+		copyRawField(baseSupports, discoveredSupports, "reasoning_effort")
+	}
+	if cfg.ParallelToolCalls == nil {
+		copyRawField(baseSupports, discoveredSupports, "parallel_tool_calls")
+	}
+	if cfg.Vision == nil {
+		copyRawField(baseSupports, discoveredSupports, "vision")
+	}
+
+	if len(baseSupports) > 0 {
+		encoded, err := json.Marshal(baseSupports)
+		if err != nil {
+			return err
+		}
+		baseCaps["supports"] = encoded
+	}
+
+	baseLimits, err := decodeOptionalRawJSONObject(baseCaps["limits"])
+	if err != nil {
+		return err
+	}
+	discoveredLimits, err := decodeOptionalRawJSONObject(discoveredCaps["limits"])
+	if err != nil {
+		return err
+	}
+
+	if cfg.ContextWindow == nil {
+		copyRawField(baseLimits, discoveredLimits, "max_context_window_tokens")
+	}
+
+	if len(baseLimits) > 0 {
+		encoded, err := json.Marshal(baseLimits)
+		if err != nil {
+			return err
+		}
+		baseCaps["limits"] = encoded
+	}
+
+	if len(baseCaps) > 0 {
+		encoded, err := json.Marshal(baseCaps)
+		if err != nil {
+			return err
+		}
+		base["capabilities"] = encoded
+	}
+
+	return nil
+}
+
+func decodeRawJSONObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		payload = map[string]json.RawMessage{}
+	}
+	return payload, nil
+}
+
+func decodeOptionalRawJSONObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	if len(raw) == 0 {
+		return map[string]json.RawMessage{}, nil
+	}
+	return decodeRawJSONObject(raw)
+}
+
+func copyRawField(dst, src map[string]json.RawMessage, field string) {
+	if dst == nil || src == nil {
+		return
+	}
+	value, ok := src[field]
+	if !ok {
+		return
+	}
+	dst[field] = append(json.RawMessage(nil), value...)
 }
 
 func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[string]struct{}) ([]providerModel, error) {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -720,6 +720,9 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 	case providerTypeAzureOpenAI:
 		models := orderedStaticProviderModels(provider)
 
+		// Azure /models is only a best-effort metadata overlay for the configured
+		// static catalog. Routing still comes from provider.models[], and sparse
+		// or failed discovery should leave the configured model list untouched.
 		resp, err := h.doWithRetry(func() (*http.Request, error) {
 			return h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, "")
 		})
@@ -844,6 +847,10 @@ func mergeStaticProviderMetadata(static providerModel, cfg ProviderModelConfig, 
 	return static
 }
 
+// mergeDiscoveredProviderModelRaw opportunistically copies provider metadata
+// that already exists in the discovered /models payload. It does not rewrite
+// configured public IDs or endpoint allowlists, and it does not synthesize
+// Codex-facing fields that an upstream provider omitted.
 func mergeDiscoveredProviderModelRaw(baseRaw, discoveredRaw json.RawMessage, cfg ProviderModelConfig) (json.RawMessage, error) {
 	if len(baseRaw) == 0 || len(discoveredRaw) == 0 {
 		return append(json.RawMessage(nil), baseRaw...), nil

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -729,7 +729,7 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 		if err != nil {
 			return providerModelsFetchResult{models: models}, nil
 		}
-		defer func() { _ = resp.Body.Close() }()
+		defer drainAndClose(resp.Body)
 		if resp.StatusCode != http.StatusOK {
 			return providerModelsFetchResult{models: models}, nil
 		}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -722,7 +722,7 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 
 		// Azure /models is only a best-effort metadata overlay for the configured
 		// static catalog. Routing still comes from provider.models[], and sparse
-		// or failed discovery should leave the configured model list untouched.
+		// or failed Azure metadata probes should leave the configured model list untouched.
 		resp, err := h.doWithRetry(func() (*http.Request, error) {
 			return h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, "")
 		})
@@ -739,25 +739,25 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 			return providerModelsFetchResult{models: models}, nil
 		}
 
-		discoveredModels, err := decodeProviderModelsFromBody(provider.id, body, provider.excludeModels)
+		overlayModels, err := decodeProviderModelsFromBody(provider.id, body, provider.excludeModels)
 		if err != nil {
 			return providerModelsFetchResult{models: models}, nil
 		}
 
-		discoveredByID := make(map[string]providerModel, len(discoveredModels))
-		for _, discovered := range discoveredModels {
-			discoveredByID[discovered.publicID] = discovered
+		overlayByID := make(map[string]providerModel, len(overlayModels))
+		for _, overlay := range overlayModels {
+			overlayByID[overlay.publicID] = overlay
 		}
 		for i, staticModel := range models {
 			cfg, ok := provider.staticConfigs[staticModel.publicID]
 			if !ok {
 				continue
 			}
-			discovered, ok := findDiscoveredProviderModel(cfg, discoveredByID)
+			overlay, ok := findProviderModelMetadataOverlay(cfg, overlayByID)
 			if !ok {
 				continue
 			}
-			models[i] = mergeStaticProviderMetadata(staticModel, cfg, discovered)
+			models[i] = mergeStaticProviderMetadata(staticModel, cfg, overlay)
 		}
 
 		return providerModelsFetchResult{models: models}, nil
@@ -820,26 +820,26 @@ func orderedStaticProviderModels(provider *providerRuntime) []providerModel {
 	return models
 }
 
-func findDiscoveredProviderModel(cfg ProviderModelConfig, discoveredByID map[string]providerModel) (providerModel, bool) {
+func findProviderModelMetadataOverlay(cfg ProviderModelConfig, overlayByID map[string]providerModel) (providerModel, bool) {
 	publicID := strings.TrimSpace(cfg.PublicID)
 	if publicID != "" {
-		if discovered, ok := discoveredByID[publicID]; ok {
-			return discovered, true
+		if overlay, ok := overlayByID[publicID]; ok {
+			return overlay, true
 		}
 	}
 
 	deployment := strings.TrimSpace(cfg.Deployment)
 	if deployment != "" && deployment != publicID {
-		if discovered, ok := discoveredByID[deployment]; ok {
-			return discovered, true
+		if overlay, ok := overlayByID[deployment]; ok {
+			return overlay, true
 		}
 	}
 
 	return providerModel{}, false
 }
 
-func mergeStaticProviderMetadata(static providerModel, cfg ProviderModelConfig, discovered providerModel) providerModel {
-	mergedRaw, err := mergeDiscoveredProviderModelRaw(static.raw, discovered.raw, cfg)
+func mergeStaticProviderMetadata(static providerModel, cfg ProviderModelConfig, overlay providerModel) providerModel {
+	mergedRaw, err := mergeProviderModelMetadataOverlayRaw(static.raw, overlay.raw, cfg)
 	if err != nil {
 		return static
 	}
@@ -847,12 +847,12 @@ func mergeStaticProviderMetadata(static providerModel, cfg ProviderModelConfig, 
 	return static
 }
 
-// mergeDiscoveredProviderModelRaw opportunistically copies provider metadata
-// that already exists in the discovered /models payload. It does not rewrite
+// mergeProviderModelMetadataOverlayRaw opportunistically copies provider metadata
+// that already exists in the Azure /models overlay payload. It does not rewrite
 // configured public IDs or endpoint allowlists, and it does not synthesize
 // Codex-facing fields that an upstream provider omitted.
-func mergeDiscoveredProviderModelRaw(baseRaw, discoveredRaw json.RawMessage, cfg ProviderModelConfig) (json.RawMessage, error) {
-	if len(baseRaw) == 0 || len(discoveredRaw) == 0 {
+func mergeProviderModelMetadataOverlayRaw(baseRaw, overlayRaw json.RawMessage, cfg ProviderModelConfig) (json.RawMessage, error) {
+	if len(baseRaw) == 0 || len(overlayRaw) == 0 {
 		return append(json.RawMessage(nil), baseRaw...), nil
 	}
 
@@ -860,28 +860,28 @@ func mergeDiscoveredProviderModelRaw(baseRaw, discoveredRaw json.RawMessage, cfg
 	if err != nil {
 		return nil, err
 	}
-	discovered, err := decodeRawJSONObject(discoveredRaw)
+	overlay, err := decodeRawJSONObject(overlayRaw)
 	if err != nil {
 		return nil, err
 	}
 
-	for key, value := range discovered {
+	for key, value := range overlay {
 		if _, exists := base[key]; !exists {
 			base[key] = append(json.RawMessage(nil), value...)
 		}
 	}
 
 	if strings.TrimSpace(cfg.Name) == "" {
-		copyRawField(base, discovered, "name")
+		copyRawField(base, overlay, "name")
 	}
 	if cfg.ModelPickerEnabled == nil {
-		copyRawField(base, discovered, "model_picker_enabled")
+		copyRawField(base, overlay, "model_picker_enabled")
 	}
 	if strings.TrimSpace(cfg.ModelPickerCategory) == "" {
-		copyRawField(base, discovered, "model_picker_category")
+		copyRawField(base, overlay, "model_picker_category")
 	}
 
-	if err := mergeDiscoveredProviderCapabilities(base, discovered, cfg); err != nil {
+	if err := mergeProviderModelCapabilitiesOverlay(base, overlay, cfg); err != nil {
 		return nil, err
 	}
 
@@ -892,12 +892,12 @@ func mergeDiscoveredProviderModelRaw(baseRaw, discoveredRaw json.RawMessage, cfg
 	return merged, nil
 }
 
-func mergeDiscoveredProviderCapabilities(base, discovered map[string]json.RawMessage, cfg ProviderModelConfig) error {
+func mergeProviderModelCapabilitiesOverlay(base, overlay map[string]json.RawMessage, cfg ProviderModelConfig) error {
 	baseCaps, err := decodeOptionalRawJSONObject(base["capabilities"])
 	if err != nil {
 		return err
 	}
-	discoveredCaps, err := decodeOptionalRawJSONObject(discovered["capabilities"])
+	overlayCaps, err := decodeOptionalRawJSONObject(overlay["capabilities"])
 	if err != nil {
 		return err
 	}
@@ -906,19 +906,19 @@ func mergeDiscoveredProviderCapabilities(base, discovered map[string]json.RawMes
 	if err != nil {
 		return err
 	}
-	discoveredSupports, err := decodeOptionalRawJSONObject(discoveredCaps["supports"])
+	overlaySupports, err := decodeOptionalRawJSONObject(overlayCaps["supports"])
 	if err != nil {
 		return err
 	}
 
 	if cfg.ReasoningEffort == nil {
-		copyRawField(baseSupports, discoveredSupports, "reasoning_effort")
+		copyRawField(baseSupports, overlaySupports, "reasoning_effort")
 	}
 	if cfg.ParallelToolCalls == nil {
-		copyRawField(baseSupports, discoveredSupports, "parallel_tool_calls")
+		copyRawField(baseSupports, overlaySupports, "parallel_tool_calls")
 	}
 	if cfg.Vision == nil {
-		copyRawField(baseSupports, discoveredSupports, "vision")
+		copyRawField(baseSupports, overlaySupports, "vision")
 	}
 
 	if len(baseSupports) > 0 {
@@ -933,13 +933,13 @@ func mergeDiscoveredProviderCapabilities(base, discovered map[string]json.RawMes
 	if err != nil {
 		return err
 	}
-	discoveredLimits, err := decodeOptionalRawJSONObject(discoveredCaps["limits"])
+	overlayLimits, err := decodeOptionalRawJSONObject(overlayCaps["limits"])
 	if err != nil {
 		return err
 	}
 
 	if cfg.ContextWindow == nil {
-		copyRawField(baseLimits, discoveredLimits, "max_context_window_tokens")
+		copyRawField(baseLimits, overlayLimits, "max_context_window_tokens")
 	}
 
 	if len(baseLimits) > 0 {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -1,0 +1,132 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadProvidersConfigFileAzureV1BaseURLAndModelMetadata(t *testing.T) {
+	t.Parallel()
+
+	providersPath := filepath.Join(t.TempDir(), "providers.json")
+	body := []byte(`{
+  "providers": [
+    {
+      "id": "copilot",
+      "type": "copilot",
+      "default": true,
+      "exclude_models": ["gpt-5.4-pro", "gpt-5.4"]
+    },
+    {
+      "id": "azure-openai",
+      "type": "azure-openai",
+      "base_url": "https://example.openai.azure.com/openai/v1",
+      "api_key": "test-key",
+      "api_version": "2025-04-01-preview",
+      "models": [
+        {
+          "public_id": "gpt-5.4-pro",
+          "deployment": "gpt-5.4-pro",
+          "endpoints": ["/responses"],
+          "name": "GPT-5.4 Pro"
+        },
+        {
+          "public_id": "gpt-5.4",
+          "deployment": "gpt-5.4",
+          "endpoints": ["/responses"],
+          "name": "GPT-5.4",
+          "model_picker_category": "powerful",
+          "reasoning_effort": ["low", "medium", "high"],
+          "vision": true,
+          "parallel_tool_calls": true,
+          "context_window": 400000
+        }
+      ]
+    }
+  ]
+}`)
+	if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := LoadProvidersConfigFile(providersPath)
+	if err != nil {
+		t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+	}
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	providers, _, defaultProviderID, err := handler.buildProviders(cfg)
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+
+	if defaultProviderID != "copilot" {
+		t.Fatalf("default provider = %q, want copilot", defaultProviderID)
+	}
+
+	provider := providers["azure-openai"]
+	if provider == nil {
+		t.Fatal("expected azure-openai provider to be built")
+	}
+
+	if provider.baseURL != "https://example.openai.azure.com/openai/v1" {
+		t.Fatalf("provider.baseURL = %q, want Azure /openai/v1 endpoint", provider.baseURL)
+	}
+
+	modelsURL, err := handler.providerRequestURL(provider, "/models", "")
+	if err != nil {
+		t.Fatalf("providerRequestURL() error = %v", err)
+	}
+	if modelsURL != "https://example.openai.azure.com/openai/v1/models" {
+		t.Fatalf("providerRequestURL() = %q", modelsURL)
+	}
+
+	proModel, ok := provider.staticModels["gpt-5.4-pro"]
+	if !ok {
+		t.Fatal("expected static model gpt-5.4-pro")
+	}
+	if !reflect.DeepEqual(proModel.supportedEndpoints, []string{"/responses"}) {
+		t.Fatalf("gpt-5.4-pro endpoints = %v, want [/responses]", proModel.supportedEndpoints)
+	}
+
+	cfgModel, ok := provider.staticConfigs["gpt-5.4"]
+	if !ok {
+		t.Fatal("expected static config for gpt-5.4")
+	}
+	if cfgModel.ModelPickerCategory != "powerful" {
+		t.Fatalf("model_picker_category = %q, want powerful", cfgModel.ModelPickerCategory)
+	}
+	if !reflect.DeepEqual(cfgModel.ReasoningEffort, []string{"low", "medium", "high"}) {
+		t.Fatalf("reasoning_effort = %v, want [low medium high]", cfgModel.ReasoningEffort)
+	}
+	if cfgModel.Vision == nil || !*cfgModel.Vision {
+		t.Fatalf("vision = %v, want true", cfgModel.Vision)
+	}
+	if cfgModel.ParallelToolCalls == nil || !*cfgModel.ParallelToolCalls {
+		t.Fatalf("parallel_tool_calls = %v, want true", cfgModel.ParallelToolCalls)
+	}
+	if cfgModel.ContextWindow == nil || *cfgModel.ContextWindow != 400000 {
+		t.Fatalf("context_window = %v, want 400000", cfgModel.ContextWindow)
+	}
+}
+
+func TestProviderRequestURLAzureLegacyBaseURLAppendsAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{}
+	provider := &providerRuntime{
+		kind:       providerTypeAzureOpenAI,
+		baseURL:    "https://example.openai.azure.com/openai",
+		apiVersion: "2025-04-01-preview",
+	}
+
+	modelsURL, err := handler.providerRequestURL(provider, "/models", "")
+	if err != nil {
+		t.Fatalf("providerRequestURL() error = %v", err)
+	}
+	if modelsURL != "https://example.openai.azure.com/openai/models?api-version=2025-04-01-preview" {
+		t.Fatalf("providerRequestURL() = %q", modelsURL)
+	}
+}


### PR DESCRIPTION
## Summary
- add optional Codex `/v1/models` metadata fields to static `providers[].models[]` entries so Azure-backed models can advertise reasoning levels, vision, parallel tool calls, model picker category, and context window
- treat Azure upstream `/models` as a best-effort metadata enrichment step for already configured models only, matched by `public_id` or `deployment`, with static config taking precedence
- support Azure `base_url` values using either `/openai/v1` or legacy `/openai`, and only append `api-version` for the legacy form
- document the behavior and cover static metadata, sparse/failing Azure `/models`, and serialization cases in tests

## What this does not do
- does not autodiscover Azure deployments or populate `models[]`
- does not change routing ownership or endpoint allowlists based on Azure `/models`
- does not synthesize missing Codex metadata from external Azure capability hints or other Azure docs

## Testing
- `go test ./proxy/...`
