### PR TITLE
fix: strip unsupported service_tier from responses requests

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -625,12 +625,8 @@ func TestHandleResponses(t *testing.T) {
 		if err := json.Unmarshal(body, &upstreamReq); err != nil {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
-		var serviceTier string
-		if err := json.Unmarshal(upstreamReq["service_tier"], &serviceTier); err != nil {
-			t.Fatalf("upstream request should preserve service_tier: %v", err)
-		}
-		if serviceTier != "auto" {
-			t.Fatalf("expected upstream service_tier auto, got %q", serviceTier)
+		if _, ok := upstreamReq["service_tier"]; ok {
+			t.Fatalf("upstream request should not include service_tier")
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -3883,12 +3879,8 @@ func TestOpenAIResponsesStreaming(t *testing.T) {
 		if err := json.Unmarshal(body, &upstreamReq); err != nil {
 			t.Fatalf("upstream received invalid JSON: %v", err)
 		}
-		var serviceTier string
-		if err := json.Unmarshal(upstreamReq["service_tier"], &serviceTier); err != nil {
-			t.Fatalf("upstream request should preserve service_tier: %v", err)
-		}
-		if serviceTier != "auto" {
-			t.Fatalf("expected upstream service_tier auto, got %q", serviceTier)
+		if _, ok := upstreamReq["service_tier"]; ok {
+			t.Fatalf("upstream request should not include service_tier")
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -407,7 +407,28 @@ func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint st
 }
 
 func stripUnsupportedResponsesRequestFields(bodyBytes []byte) ([]byte, []string) {
-	return bodyBytes, nil
+	var req map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		return bodyBytes, nil
+	}
+
+	var strippedFields []string
+	for _, field := range []string{"service_tier"} {
+		if _, ok := req[field]; ok {
+			delete(req, field)
+			strippedFields = append(strippedFields, field)
+		}
+	}
+	if len(strippedFields) == 0 {
+		return bodyBytes, nil
+	}
+
+	rewrittenBody, err := json.Marshal(req)
+	if err != nil {
+		return bodyBytes, nil
+	}
+
+	return rewrittenBody, strippedFields
 }
 
 func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, bodyBytes []byte, extraHeaders http.Header) (*http.Response, error) {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -67,12 +67,8 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		if _, ok := body["previous_response_id"]; ok {
 			t.Fatalf("upstream request should not include websocket previous_response_id")
 		}
-		var serviceTier string
-		if err := json.Unmarshal(body["service_tier"], &serviceTier); err != nil {
-			t.Fatalf("upstream request should preserve service_tier: %v", err)
-		}
-		if serviceTier != "auto" {
-			t.Fatalf("expected upstream service_tier auto, got %q", serviceTier)
+		if _, ok := body["service_tier"]; ok {
+			t.Fatalf("upstream request should not include service_tier")
 		}
 
 		w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## Summary
- strip `service_tier` from forwarded `/v1/responses` requests before they reach the upstream
- cover regular responses, streaming responses, and the websocket bridge with regression tests
- keep the stripping in the shared responses request rewrite path so compact and websocket flows inherit it

## Testing
- go test ./... -count=1
