### PR TITLE
fix: validate Azure OpenAI base_url

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ Routing rules:
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
 - Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
 - Azure `models[]` remains the routing source of truth. The proxy does not autodiscover new Azure deployments for inference.
-- Azure `base_url` must end with either the OpenAI-compatible `/openai/v1` prefix or the legacy `/openai` prefix.
+- Azure `base_url` must be an absolute URL whose path ends with either the OpenAI-compatible `/openai/v1` path or the legacy `/openai` path, with no query string or fragment.
 - Azure AI Foundry inference URLs ending in `/models` are not supported in `type: "azure-openai"` configs. Use the corresponding OpenAI-compatible `.../openai/v1` endpoint instead.
 - For `/openai/v1` base URLs, omit `api_version`; the proxy calls `/chat/completions`, `/responses`, and `/models` directly with no `api-version` query string.
 - For legacy `/openai` base URLs, set `api_version`; the proxy appends `api-version=...` to upstream requests.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,8 @@ Routing rules:
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
 - Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
 - Azure `models[]` remains the routing source of truth. The proxy does not autodiscover new Azure deployments for inference.
-- Azure `base_url` may use either the OpenAI-compatible `/openai/v1` prefix or the legacy `/openai` prefix.
+- Azure `base_url` must end with either the OpenAI-compatible `/openai/v1` prefix or the legacy `/openai` prefix.
+- Azure AI Foundry inference URLs ending in `/models` are not supported in `type: "azure-openai"` configs. Use the corresponding OpenAI-compatible `.../openai/v1` endpoint instead.
 - For `/openai/v1` base URLs, omit `api_version`; the proxy calls `/chat/completions`, `/responses`, and `/models` directly with no `api-version` query string.
 - For legacy `/openai` base URLs, set `api_version`; the proxy appends `api-version=...` to upstream requests.
 - Public model IDs are global across all providers. Startup fails if two providers expose the same ID.

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -409,7 +409,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 		case azureBaseURLKindModels:
 			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: Azure AI Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", id, baseURL)
 		default:
-			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected a URL ending in /openai/v1 or /openai", id, baseURL)
+			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected an absolute URL whose path ends in /openai/v1 or /openai, with no query string or fragment", id, baseURL)
 		}
 		runtime.baseURL = baseURL
 		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
@@ -652,13 +652,15 @@ func classifyAzureBaseURL(baseURL string) azureBaseURLKind {
 		return azureBaseURLKindInvalid
 	}
 
-	path := trimmed
 	parsed, err := url.Parse(trimmed)
-	if err == nil {
-		path = parsed.Path
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return azureBaseURLKindInvalid
 	}
-	path = strings.TrimRight(path, "/")
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Contains(trimmed, "#") {
+		return azureBaseURLKindInvalid
+	}
 
+	path := strings.TrimRight(parsed.Path, "/")
 	switch {
 	case strings.HasSuffix(path, "/openai/v1"):
 		return azureBaseURLKindOpenAIV1

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -98,6 +98,15 @@ type providerRequestError struct {
 	err        error
 }
 
+type azureBaseURLKind int
+
+const (
+	azureBaseURLKindInvalid azureBaseURLKind = iota
+	azureBaseURLKindLegacyOpenAI
+	azureBaseURLKindOpenAIV1
+	azureBaseURLKindModels
+)
+
 func (e *providerRequestError) Error() string {
 	if e == nil || e.err == nil {
 		return ""
@@ -395,6 +404,13 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 		if baseURL == "" {
 			return nil, fmt.Errorf("provider %q must set base_url", id)
 		}
+		switch classifyAzureBaseURL(baseURL) {
+		case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI:
+		case azureBaseURLKindModels:
+			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: Azure AI Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", id, baseURL)
+		default:
+			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected a URL ending in /openai/v1 or /openai", id, baseURL)
+		}
 		runtime.baseURL = baseURL
 		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
 		runtime.apiKey = strings.TrimSpace(cfg.APIKey)
@@ -624,18 +640,35 @@ func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string
 
 	baseURL := strings.TrimRight(provider.baseURL, "/")
 	fullURL := baseURL + path
-	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" || azureUsesOpenAIV1BaseURL(baseURL) {
+	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" || classifyAzureBaseURL(baseURL) == azureBaseURLKindOpenAIV1 {
 		return appendRawQuery(fullURL, extraQuery), nil
 	}
 	return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
 }
 
-func azureUsesOpenAIV1BaseURL(baseURL string) bool {
-	parsed, err := url.Parse(strings.TrimSpace(baseURL))
-	if err != nil {
-		return strings.HasSuffix(strings.TrimRight(strings.TrimSpace(baseURL), "/"), "/openai/v1")
+func classifyAzureBaseURL(baseURL string) azureBaseURLKind {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if trimmed == "" {
+		return azureBaseURLKindInvalid
 	}
-	return strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/openai/v1")
+
+	path := trimmed
+	parsed, err := url.Parse(trimmed)
+	if err == nil {
+		path = parsed.Path
+	}
+	path = strings.TrimRight(path, "/")
+
+	switch {
+	case strings.HasSuffix(path, "/openai/v1"):
+		return azureBaseURLKindOpenAIV1
+	case strings.HasSuffix(path, "/openai"):
+		return azureBaseURLKindLegacyOpenAI
+	case strings.HasSuffix(path, "/models"):
+		return azureBaseURLKindModels
+	default:
+		return azureBaseURLKindInvalid
+	}
 }
 
 func appendQuery(parts ...string) string {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -128,5 +129,81 @@ func TestProviderRequestURLAzureLegacyBaseURLAppendsAPIVersion(t *testing.T) {
 	}
 	if modelsURL != "https://example.openai.azure.com/openai/models?api-version=2025-04-01-preview" {
 		t.Fatalf("providerRequestURL() = %q", modelsURL)
+	}
+}
+
+func TestBuildProvidersAzureLegacyBaseURLAccepted(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:         "azure-openai",
+			Type:       "azure-openai",
+			BaseURL:    "https://example.openai.azure.com/openai",
+			APIKey:     "test-key",
+			APIVersion: "2025-04-01-preview",
+			Models: []ProviderModelConfig{{
+				PublicID:   "gpt-4.1",
+				Deployment: "gpt-4.1",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+
+	provider := providers["azure-openai"]
+	if provider == nil {
+		t.Fatal("expected azure-openai provider to be built")
+	}
+	if provider.baseURL != "https://example.openai.azure.com/openai" {
+		t.Fatalf("provider.baseURL = %q, want Azure /openai endpoint", provider.baseURL)
+	}
+}
+
+func TestBuildProvidersAzureModelsBaseURLRejected(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	_, _, _, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:      "azure-openai",
+			Type:    "azure-openai",
+			BaseURL: "https://example.services.ai.azure.com/models",
+			APIKey:  "test-key",
+			Models: []ProviderModelConfig{{
+				PublicID: "Kimi-K2.6",
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("buildProviders() error = nil, want unsupported /models base_url error")
+	}
+	if !strings.Contains(err.Error(), "use the OpenAI-compatible endpoint ending in /openai/v1 instead") {
+		t.Fatalf("buildProviders() error = %v, want /openai/v1 guidance", err)
+	}
+}
+
+func TestBuildProvidersAzureUnsupportedBaseURLRejected(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	_, _, _, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:      "azure-openai",
+			Type:    "azure-openai",
+			BaseURL: "https://example.services.ai.azure.com/inference",
+			APIKey:  "test-key",
+			Models: []ProviderModelConfig{{
+				PublicID: "Kimi-K2.6",
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("buildProviders() error = nil, want unsupported Azure base_url error")
+	}
+	if !strings.Contains(err.Error(), "expected a URL ending in /openai/v1 or /openai") {
+		t.Fatalf("buildProviders() error = %v, want supported Azure base_url suffixes", err)
 	}
 }

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -203,7 +203,51 @@ func TestBuildProvidersAzureUnsupportedBaseURLRejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("buildProviders() error = nil, want unsupported Azure base_url error")
 	}
-	if !strings.Contains(err.Error(), "expected a URL ending in /openai/v1 or /openai") {
-		t.Fatalf("buildProviders() error = %v, want supported Azure base_url suffixes", err)
+	if !strings.Contains(err.Error(), "expected an absolute URL whose path ends in /openai/v1 or /openai") {
+		t.Fatalf("buildProviders() error = %v, want supported Azure base_url guidance", err)
+	}
+}
+
+func TestBuildProvidersAzureMalformedBaseURLRejected(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		baseURL string
+	}{
+		{name: "missing scheme", baseURL: "example.openai.azure.com/openai/v1"},
+		{name: "missing host", baseURL: "https:///openai/v1"},
+		{name: "query string", baseURL: "https://example.openai.azure.com/openai/v1?api-version=2025-04-01-preview"},
+		{name: "empty query string", baseURL: "https://example.openai.azure.com/openai/v1?"},
+		{name: "fragment", baseURL: "https://example.openai.azure.com/openai/v1#chat"},
+		{name: "empty fragment", baseURL: "https://example.openai.azure.com/openai/v1#"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+			_, _, _, err := handler.buildProviders(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:      "azure-openai",
+					Type:    "azure-openai",
+					BaseURL: tc.baseURL,
+					APIKey:  "test-key",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-4.1",
+						Deployment: "gpt-4.1",
+					}},
+				}},
+			})
+			if err == nil {
+				t.Fatalf("buildProviders() error = nil for base_url %q, want unsupported Azure base_url error", tc.baseURL)
+			}
+			if !strings.Contains(err.Error(), "expected an absolute URL whose path ends in /openai/v1 or /openai") {
+				t.Fatalf("buildProviders() error = %v, want absolute Azure base_url guidance", err)
+			}
+			if !strings.Contains(err.Error(), "no query string or fragment") {
+				t.Fatalf("buildProviders() error = %v, want query/fragment guidance", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- validate `azure-openai` provider `base_url` values at startup
- allow OpenAI-compatible `/openai/v1` and legacy `/openai` Azure endpoints
- reject Azure AI Foundry `/models` inference URLs with guidance to switch to `/openai/v1`
- document the supported Azure base URL formats and add config coverage tests

## Testing
- `go test ./proxy/...`
- `go test ./...`