### PR TITLE
test: add responses provider routing coverage

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2494,6 +2494,60 @@ func TestHandleOpenAIChatCompletions_RejectsConfiguredAzureModelWithoutChatSuppo
 	}
 }
 
+func TestHandleResponses_RejectsConfiguredAzureModelWithoutResponsesSupport(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:        "azure",
+				Type:      "azure-openai",
+				Default:   true,
+				BaseURL:   "https://example.openai.azure.com/openai",
+				APIKeyEnv: "TEST_AZURE_API_KEY",
+				Models: []ProviderModelConfig{{
+					PublicID:   "gpt-5.4-pro",
+					Deployment: "gpt-5.4-pro",
+					Endpoints:  []string{"/chat/completions"},
+					Name:       "GPT-5.4 Pro",
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model": "gpt-5.4-pro",
+		"input": "Hello"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+
+	var errResp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if !strings.Contains(errResp.Error.Message, `does not support /responses`) {
+		t.Fatalf("expected unsupported endpoint message, got %q", errResp.Error.Message)
+	}
+}
+
 func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
 	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 

--- a/proxy/upstream_http_test.go
+++ b/proxy/upstream_http_test.go
@@ -1,6 +1,43 @@
 package proxy
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
+)
+
+func newProviderRoutingTestHandler(t *testing.T, endpoints []string) *ProxyHandler {
+	t.Helper()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:      "azure",
+				Type:    "azure-openai",
+				Default: true,
+				BaseURL: "https://example.openai.azure.com/openai/v1",
+				APIKey:  "azure-test-key",
+				Models: []ProviderModelConfig{{
+					PublicID:   "gpt-5-public",
+					Deployment: "gpt-5-4-prod",
+					Endpoints:  append([]string(nil), endpoints...),
+					Name:       "GPT-5 Public",
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	return handler
+}
 
 func TestExtractRequestModel(t *testing.T) {
 	tests := []struct {
@@ -41,5 +78,98 @@ func TestExtractRequestModel(t *testing.T) {
 				t.Fatalf("extractRequestModel() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveProviderRequest_RewritesConfiguredResponsesModelToProviderDeployment(t *testing.T) {
+	handler := newProviderRoutingTestHandler(t, []string{"/responses"})
+
+	provider, rewrittenBody, err := handler.resolveProviderRequest([]byte(`{"model":"gpt-5-public","input":"hello"}`), "/responses")
+	if err != nil {
+		t.Fatalf("resolveProviderRequest() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("resolveProviderRequest() provider = nil, want azure provider")
+	}
+	if provider.id != "azure" {
+		t.Fatalf("resolveProviderRequest() provider.id = %q, want azure", provider.id)
+	}
+	if got := extractResponsesRequestModel(rewrittenBody); got != "gpt-5-4-prod" {
+		t.Fatalf("rewritten model = %q, want gpt-5-4-prod", got)
+	}
+
+	var payload struct {
+		Input string `json:"input"`
+	}
+	if err := json.Unmarshal(rewrittenBody, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(rewrittenBody) error = %v", err)
+	}
+	if payload.Input != "hello" {
+		t.Fatalf("rewritten input = %q, want hello", payload.Input)
+	}
+}
+
+func TestResolveProviderRequest_RejectsKnownModelWithoutEndpointSupport(t *testing.T) {
+	handler := newProviderRoutingTestHandler(t, []string{"/responses"})
+
+	provider, rewrittenBody, err := handler.resolveProviderRequest([]byte(`{"model":"gpt-5-public","messages":[{"role":"user","content":"hello"}]}`), "/chat/completions")
+	if err == nil {
+		t.Fatal("resolveProviderRequest() error = nil, want unsupported endpoint error")
+	}
+	if provider != nil {
+		t.Fatalf("resolveProviderRequest() provider = %#v, want nil on error", provider)
+	}
+	if rewrittenBody != nil {
+		t.Fatalf("resolveProviderRequest() rewrittenBody = %q, want nil on error", rewrittenBody)
+	}
+
+	var providerErr *providerRequestError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("resolveProviderRequest() error = %T, want *providerRequestError", err)
+	}
+	if providerErr.statusCode != http.StatusBadRequest {
+		t.Fatalf("providerRequestError.statusCode = %d, want %d", providerErr.statusCode, http.StatusBadRequest)
+	}
+	if !strings.Contains(providerErr.Error(), `does not support /chat/completions`) {
+		t.Fatalf("providerRequestError.Error() = %q, want unsupported endpoint message", providerErr.Error())
+	}
+}
+
+func TestRewriteRequestModelForProvider_RewritesGenericJSONModelAndNoopsWhenUnchanged(t *testing.T) {
+	originalBody := []byte(`{"model":"gpt-5-public","messages":[{"role":"user","content":"hello"}]}`)
+
+	rewrittenBody, rewritten, err := rewriteRequestModelForProvider(originalBody, "gpt-5-4-prod")
+	if err != nil {
+		t.Fatalf("rewriteRequestModelForProvider() error = %v", err)
+	}
+	if !rewritten {
+		t.Fatal("rewriteRequestModelForProvider() rewritten = false, want true")
+	}
+	if got := extractRequestModel(rewrittenBody); got != "gpt-5-4-prod" {
+		t.Fatalf("rewritten model = %q, want gpt-5-4-prod", got)
+	}
+
+	var payload struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(rewrittenBody, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(rewrittenBody) error = %v", err)
+	}
+	if len(payload.Messages) != 1 || payload.Messages[0].Content != "hello" {
+		t.Fatalf("rewritten messages = %+v, want original message content preserved", payload.Messages)
+	}
+
+	unchangedBody, rewritten, err := rewriteRequestModelForProvider(rewrittenBody, "gpt-5-4-prod")
+	if err != nil {
+		t.Fatalf("rewriteRequestModelForProvider(already mapped) error = %v", err)
+	}
+	if rewritten {
+		t.Fatal("rewriteRequestModelForProvider(already mapped) rewritten = true, want false")
+	}
+	if string(unchangedBody) != string(rewrittenBody) {
+		t.Fatalf("rewriteRequestModelForProvider(already mapped) body changed: got %s want %s", unchangedBody, rewrittenBody)
 	}
 }


### PR DESCRIPTION
## Summary
- add /responses provider resolution coverage for configured Azure deployments
- verify request model rewriting to provider deployment IDs and no-op behavior when unchanged
- reject configured models with a 400 when the requested endpoint is unsupported

## Testing
- go test ./proxy/...
