### PR TITLE
feat: add OpenAI Codex provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Go reverse proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs. By default it forwards requests to GitHub Copilot's backend (`api.githubcopilot.com`), and it can also route selected models to configured providers such as Azure OpenAI behind the same proxy endpoint. This lets clients use a Copilot subscription by default while still exposing additional provider-backed models when configured.
+Go reverse proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs behind one local endpoint. Vekil can run in zero-config mode against GitHub Copilot, or use explicit provider routing to send selected models to configured upstreams such as Azure OpenAI and OpenAI Codex. The public API surface stays the same while provider ownership of models is configured behind the proxy.
 
 ## Build & Test
 
@@ -29,11 +29,11 @@ Documentation is intentionally split under `docs/` into small, single-purpose fi
 | `README.md` | Short landing page only |
 | `docs/README.md` | Documentation index and doc map |
 | `docs/getting-started.md` | install, run, first auth, deployment entry points |
-| `docs/configuration.md` | flags, env vars, websocket tuning |
+| `docs/configuration.md` | flags, env vars, provider routing, websocket tuning |
 | `docs/clients.md` | copy-paste client examples |
 | `docs/api.md` | endpoint behavior and compatibility notes |
 | `docs/architecture.md` | package boundaries and design notes |
-| `docs/menubar.md` | macOS app usage |
+| `docs/menubar.md` | macOS/Linux tray app usage |
 | `docs/development.md` | build, test, benchmark, CI |
 
 Documentation update rules:
@@ -41,6 +41,7 @@ Documentation update rules:
 - Keep `README.md` concise; put detail into the focused file under `docs/`.
 - When behavior changes, update the narrowest relevant doc instead of appending to the root README.
 - Prefer linking between docs rather than duplicating long sections.
+- Separate provider-agnostic behavior from provider-specific auth and routing details when possible.
 
 ## Architecture
 
@@ -50,9 +51,10 @@ Documentation update rules:
 | `auth/` | GitHub OAuth device code flow and Copilot token caching/refresh (`sync.RWMutex` + double-check) |
 | `proxy/chat_handlers.go` | Anthropic and OpenAI chat handlers, including forced-streaming aggregation for tool calls |
 | `proxy/responses_handler.go` | OpenAI Responses passthrough plus Codex compatibility endpoints (`/v1/responses/compact`, `/v1/memories/trace_summarize`) |
-| `proxy/handler.go` | Shared proxy plumbing: health/ready/models handlers, request-body decoding, provider-aware model catalogs, Copilot headers, caches |
+| `proxy/handler.go` | Shared proxy plumbing: health/ready/models handlers, request-body decoding, provider-aware model catalogs, provider headers, caches |
 | `proxy/providers.go` | Provider config loading, model ownership, Azure metadata overlay, endpoint allowlists, and routing state |
 | `proxy/upstream_http.go` | Provider selection, public→upstream model rewriting, and provider-specific upstream HTTP dispatch |
+| `proxy/openai_codex_auth.go` | OpenAI Codex CLI auth.json loading, refresh, and request credentials |
 | `proxy/gemini_handler.go` | Gemini-native HTTP handlers and countTokens probe flow |
 | `proxy/gemini.go` | Gemini↔OpenAI request/response translation and validation |
 | `proxy/gemini_streaming.go` | OpenAI SSE → Gemini SSE translation |
@@ -62,22 +64,23 @@ Documentation update rules:
 | `models/` | Data-only structs for Anthropic and OpenAI API types (no logic) |
 | `logger/` | Structured JSON logger to stderr |
 | `server/` | HTTP server lifecycle (`Start`/`Stop`/`IsRunning`) |
-| `cmd/menubar/` | macOS systray app (separate binary) |
+| `cmd/menubar/` | tray app binary |
 
 ## Key Design Decisions
 
 - **No frameworks**: Pure `net/http` with Go 1.22+ `ServeMux` method routing. Do not add web frameworks.
-- **Default behavior is Copilot; multi-provider routing is additive**: Zero-config startup still targets GitHub Copilot. Configured providers can extend or replace that default behind the same public API surface.
+- **Vekil is a multi-provider proxy**: zero-config startup currently targets GitHub Copilot, but explicit provider configs can extend or replace that default behind the same public API surface.
 - **Public model IDs are global across providers**: Model ownership is explicit and startup must fail on collisions rather than silently shadowing one provider with another.
-- **Forced streaming for reliable parallel tool calls**: Non-streaming requests with tools may be force-streamed upstream then aggregated back before returning to the client. This behavior started as a Copilot reliability workaround and still applies to provider-backed OpenAI chat handling.
+- **Forced streaming for reliable parallel tool calls**: Non-streaming requests with tools may be force-streamed upstream then aggregated back before returning to the client. This behavior started as an upstream compatibility workaround and still applies to provider-backed OpenAI chat handling.
 - **Gemini is a translation layer**: Gemini endpoints are implemented like Anthropic, not as zero-copy passthrough. Keep Gemini-specific protocol logic in `proxy/gemini*.go`.
 - **Responses compatibility is proxy-owned**: `/v1/responses/compact` and `/v1/memories/trace_summarize` are compatibility shims implemented on top of the upstream `/responses` API. Preserve this behavior for Codex-style clients.
 - **OpenAI passthrough is near-zero-copy, not literal zero-copy**: chat completions may inject `parallel_tool_calls` and force streaming; `/v1/responses` may rewrite proxy-owned compaction items before forwarding.
 - **Provider endpoint support is explicit**: `models[].endpoints` is an allowlist. Do not advertise `/chat/completions` or other routes for a provider/model unless that upstream capability has been verified. The Azure `gpt-5.4-pro` example configuration is `/responses`-only.
 - **Azure support is OpenAI-compatible provider routing, not a separate public surface**: Azure deployment names stay internal to provider config, and Azure `/models` probing is only a best-effort metadata overlay for configured models.
+- **OpenAI Codex support is file-auth-backed provider routing**: Codex models use the CLI ChatGPT auth file, dynamic `/models` discovery, and `/responses`-only routing.
 - **Proxy websocket bridging is not upstream realtime**: `GET /v1/responses` remains a proxy-owned websocket transport over upstream HTTP `/responses`. Do not describe it as native Azure websocket or `/realtime` support.
 - **Minimal dependencies**: Keep third-party deps minimal. Current non-stdlib dependencies used in production code are `systray`, `uuid`, and `klauspost/compress`.
-- **Distroless container**: Single static binary, CGO_ENABLED=0.
+- **Distroless container**: Single static binary, `CGO_ENABLED=0`.
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ### OpenAI Codex CLI
 
-Use any public `/responses`-capable model ID exposed by your current setup. If you want the proxy to expose an OpenAI Codex subscription model, add an `openai-codex` provider first; model IDs still stay unprefixed for clients.
+Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models. Public model IDs still stay unprefixed for clients.
 
 ```bash
 env OPENAI_API_KEY=dummy \

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ### OpenAI Codex CLI
 
-For OpenAI Codex subscription models, configure an `openai-codex` provider first; exposed IDs stay unprefixed.
+Use any public `/responses`-capable model ID exposed by your current setup. If you want the proxy to expose an OpenAI Codex subscription model, add an `openai-codex` provider first; model IDs still stay unprefixed for clients.
 
 ```bash
 env OPENAI_API_KEY=dummy \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ### OpenAI Codex CLI
 
-Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models. Public model IDs still stay unprefixed for clients.
+Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models.
 
 ```bash
 env OPENAI_API_KEY=dummy \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vekil
 
-High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs. By default it forwards requests to GitHub Copilot's backend (`api.githubcopilot.com`), and it can also route selected models to configured providers such as Azure OpenAI behind the same proxy endpoint. This lets you use tools that speak the Anthropic, Gemini, or OpenAI protocol with your GitHub Copilot subscription, while still exposing additional provider-backed models when configured.
+High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs behind one local endpoint. Vekil can run in zero-config mode against GitHub Copilot, or route selected models to configured providers such as Azure OpenAI and OpenAI Codex. The client-facing API surface stays the same while model ownership is configured behind the proxy.
 
 ## What It Supports
 
@@ -8,9 +8,9 @@ High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible 
 - Gemini Generate Content and Count Tokens APIs
 - OpenAI Chat Completions API
 - OpenAI Responses API, including Codex websocket bridging
-- Multi-provider model routing, including Azure OpenAI deployments behind the same `/v1` endpoint
+- Multi-provider model routing across GitHub Copilot, Azure OpenAI, and OpenAI Codex
 - Proxy-owned Codex compatibility endpoints for compaction and memory summarization
-- Streaming, tool use, parallel tool calls, compressed request bodies, and OAuth token caching
+- Streaming, tool use, parallel tool calls, compressed request bodies, and auth/token caching
 
 ## Quick Start
 
@@ -23,6 +23,8 @@ docker run -p 1337:1337 \
   -v ~/.config/vekil:/home/nonroot/.config/vekil \
   ghcr.io/sozercan/vekil:latest
 ```
+
+For explicit provider routing, start the proxy with `--providers-config /path/to/providers.json`.
 
 On Apple Silicon Macs, you can also use the native menubar app.
 
@@ -38,9 +40,12 @@ brew install --cask sozercan/repo/vekil
 
 Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
 
-If your setup includes a Copilot provider, first run starts GitHub's device code flow. Tokens are cached in `~/.config/vekil/`.
+Depending on your active providers:
 
-For multi-provider setup and non-Copilot-only deployments, see [Configuration](docs/configuration.md).
+- Copilot-backed setups start GitHub's device code flow on first run.
+- OpenAI Codex setups require `codex login` so `~/.codex/auth.json` exists.
+
+For provider configuration, model routing, and provider-specific auth details, see [Getting Started](docs/getting-started.md) and [Configuration](docs/configuration.md).
 
 ## Docs
 
@@ -55,7 +60,9 @@ The full documentation now lives under [`docs/`](docs/README.md) in smaller, top
 - [macOS Menubar App](docs/menubar.md)
 - [Development](docs/development.md)
 
-## Most Common Client Setup
+## Common Client Setup
+
+Use any public model ID exposed by `/v1/models`; the local client configuration stays the same even when a different upstream provider owns that model.
 
 ### Claude Code
 
@@ -67,10 +74,12 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ### OpenAI Codex CLI
 
+For OpenAI Codex subscription models, configure an `openai-codex` provider first; exposed IDs stay unprefixed.
+
 ```bash
 env OPENAI_API_KEY=dummy \
   OPENAI_BASE_URL=http://localhost:1337/v1 \
-  codex exec --skip-git-repo-check -m gpt-5.4 "Reply with exactly PROXY_OK"
+  codex exec --skip-git-repo-check -m gpt-5.5 "Reply with exactly PROXY_OK"
 ```
 
 ### Gemini CLI

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ### OpenAI Codex CLI
 
-Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models.
-
 ```bash
 env OPENAI_API_KEY=dummy \
   OPENAI_BASE_URL=http://localhost:1337/v1 \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ High-performance Go proxy that exposes Anthropic, Gemini, and OpenAI-compatible 
 ## What It Supports
 
 - Anthropic Messages API
-- Gemini Generate Content and Count Tokens APIs
+- Gemini Generate Content, Stream Generate Content, and Count Tokens APIs
 - OpenAI Chat Completions API
 - OpenAI Responses API, including Codex websocket bridging
 - Multi-provider model routing across GitHub Copilot, Azure OpenAI, and OpenAI Codex
@@ -26,7 +26,7 @@ docker run -p 1337:1337 \
 
 For explicit provider routing, start the proxy with `--providers-config /path/to/providers.json`.
 
-On Apple Silicon Macs, you can also use the native menubar app.
+On Apple Silicon Macs, you can also use the native macOS tray app.
 
 ```bash
 brew install --cask sozercan/repo/vekil
@@ -38,12 +38,14 @@ brew install --cask sozercan/repo/vekil
 > xattr -cr /Applications/Vekil.app
 > ```
 
-Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [macOS Menubar App](docs/menubar.md).
+Manual downloads still work through the `vekil-macos-arm64.zip` asset on [GitHub Releases](https://github.com/sozercan/vekil/releases/latest). See [Tray App (macOS/Linux)](docs/menubar.md).
 
 Depending on your active providers:
 
 - Copilot-backed setups start GitHub's device code flow on first run.
 - OpenAI Codex setups require `codex login` so `~/.codex/auth.json` exists.
+
+If you run an `openai-codex` provider inside Docker, mount your Codex home into the same in-container path referenced by `CODEX_HOME` (default `/home/nonroot/.codex`).
 
 For provider configuration, model routing, and provider-specific auth details, see [Getting Started](docs/getting-started.md) and [Configuration](docs/configuration.md).
 
@@ -57,7 +59,7 @@ The full documentation now lives under [`docs/`](docs/README.md) in smaller, top
 - [Client Usage Examples](docs/clients.md)
 - [API Reference](docs/api.md)
 - [Architecture](docs/architecture.md)
-- [macOS Menubar App](docs/menubar.md)
+- [Tray App (macOS/Linux)](docs/menubar.md)
 - [Development](docs/development.md)
 
 ## Common Client Setup

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,17 @@
 # Documentation Index
 
-This folder is intentionally split into small, single-purpose files so humans and coding agents can load only the topic they need.
+This folder is intentionally split into small, single-purpose files so humans and coding agents can load only the topic they need. It covers both provider-agnostic proxy behavior and provider-specific notes for GitHub Copilot, Azure OpenAI, and OpenAI Codex.
 
 ## Doc Map
 
 | File | Scope | Update When |
 |------|-------|-------------|
 | [`getting-started.md`](getting-started.md) | install, run, first authentication, deployment entry points | startup flow or distribution changes |
-| [`configuration.md`](configuration.md) | CLI flags, env vars, websocket tuning | flags, defaults, or runtime knobs change |
+| [`configuration.md`](configuration.md) | CLI flags, env vars, provider routing, websocket tuning | flags, defaults, providers, or runtime knobs change |
 | [`clients.md`](clients.md) | copy-paste client examples | onboarding snippets or client compatibility changes |
 | [`api.md`](api.md) | endpoint behavior and compatibility notes | request/response semantics change |
 | [`architecture.md`](architecture.md) | package responsibilities and data flow | implementation boundaries or design decisions change |
-| [`menubar.md`](menubar.md) | macOS menubar app usage | menubar behavior or packaging changes |
+| [`menubar.md`](menubar.md) | macOS/Linux tray app usage | tray behavior or packaging changes |
 | [`development.md`](development.md) | build, test, benchmark, and CI workflows | local dev or CI commands change |
 
 ## Agent Notes
@@ -19,4 +19,5 @@ This folder is intentionally split into small, single-purpose files so humans an
 - Prefer linking to one focused file instead of expanding the root `README.md`.
 - When behavior changes, update the smallest relevant doc instead of adding more material to the root README.
 - Keep each doc narrowly scoped and avoid duplicating long explanations across files.
+- Separate provider-agnostic API behavior from provider-specific auth or routing details when possible.
 - When documenting provider features, distinguish proxy-owned websocket bridging from upstream-native websocket or realtime APIs.

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,9 @@ When multiple providers are configured:
 
 The exact catalog depends on your configured providers and current upstream availability. Query `/v1/models` in your own deployment instead of hard-coding one global model list.
 
-## `POST /v1beta/models/{model}:generateContent` and `POST /models/{model}:generateContent` (Gemini)
+## `POST /v1beta/models/{model}:generateContent`, `POST /v1/models/{model}:generateContent`, and `POST /models/{model}:generateContent` (Gemini)
+
+The proxy accepts all three Gemini route prefixes: `/v1beta/models/{model}:...`, `/v1/models/{model}:...`, and `/models/{model}:...`.
 
 Gemini is implemented as a translation layer, not a zero-copy passthrough layer. Gemini requests are translated to OpenAI Chat Completions, routed through the provider that owns the selected public model, and translated back into Gemini responses.
 
@@ -77,9 +79,22 @@ Explicit `501 UNIMPLEMENTED` cases include:
 
 Validation failures (`400 INVALID_ARGUMENT`) include path/body model mismatches, malformed content parts, invalid function-call history, and unmatched `functionResponse` parts.
 
-## `POST /v1beta/models/{model}:countTokens` and `POST /models/{model}:countTokens` (Gemini)
+## `POST /v1beta/models/{model}:streamGenerateContent`, `POST /v1/models/{model}:streamGenerateContent`, and `POST /models/{model}:streamGenerateContent` (Gemini)
 
-`countTokens` normalizes the Gemini request into the same prompt/tool payload used by `generateContent`, performs a minimal upstream `/chat/completions` probe, and returns `usage.prompt_tokens` as Gemini `totalTokens`. Normalized requests are cached for 60 seconds.
+`streamGenerateContent` uses the same request body, translation rules, and validation behavior as `generateContent`, but returns data-only SSE frames instead of a single JSON response.
+
+Streaming behavior:
+
+- each SSE `data:` frame contains a partial Gemini `GenerateContentResponse` payload
+- text deltas are emitted as Gemini `candidates[].content.parts[].text` parts
+- tool calls are buffered until the proxy has valid JSON arguments, then emitted as Gemini `functionCall` parts
+- a final frame can include Gemini `finishReason` and `usageMetadata`
+
+Use `curl -N` or another SSE-capable client so streamed frames are not buffered locally.
+
+## `POST /v1beta/models/{model}:countTokens`, `POST /v1/models/{model}:countTokens`, and `POST /models/{model}:countTokens` (Gemini)
+
+`countTokens` uses the same accepted route prefixes as the other Gemini compatibility routes. It normalizes the Gemini request into the same prompt/tool payload used by `generateContent`, performs a minimal upstream `/chat/completions` probe, and returns `usage.prompt_tokens` as Gemini `totalTokens`. Normalized requests are cached for 60 seconds.
 
 ## `POST /v1/chat/completions` (OpenAI)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 ## `POST /v1/messages` (Anthropic)
 
-Anthropic Messages compatibility for the supported content and tool subset. Requests are translated to OpenAI Chat Completions, forwarded upstream, and translated back to Anthropic.
+Anthropic Messages compatibility for the supported content and tool subset. Requests are translated to OpenAI Chat Completions, routed through the provider that owns the selected public model, and translated back to Anthropic.
 
 Supported features:
 
@@ -18,9 +18,9 @@ Model normalization:
 - dated suffixes are stripped automatically, for example `claude-sonnet-4-20250514`
 - hyphenated version numbers are mapped to dotted form, for example `claude-sonnet-4-5` to `claude-sonnet-4.5`
 
-### `GET /v1/models`
+## `GET /v1/models`
 
-The proxy builds a merged model catalog across the configured providers. It preserves the OpenAI-style `data` payload and also adds a Codex-compatible top-level `models` array.
+The proxy builds a merged model catalog across the active providers. It preserves the OpenAI-style `data` payload and also adds a Codex-compatible top-level `models` array.
 
 ```bash
 curl http://localhost:1337/v1/models
@@ -31,36 +31,14 @@ When multiple providers are configured:
 - public model IDs stay unprefixed, for example `gpt-5.4`
 - each public ID must be owned by exactly one provider
 - startup fails if providers collide on the same model ID
-- Azure OpenAI deployments can be exposed under a different public ID while the proxy rewrites the upstream `model` field
+- dynamic providers such as Copilot or OpenAI Codex can be narrowed with `include_models` or `exclude_models`
+- static providers such as Azure OpenAI can expose a deployment under a different public ID while the proxy rewrites the upstream `model` field
 
-Example IDs in recent upstream responses have included:
-
-- `gpt-4o`
-- `gpt-4.1`
-- `gpt-5-mini`
-- `gpt-5.1`
-- `gpt-5.1-codex`
-- `gpt-5.1-codex-mini`
-- `gpt-5.1-codex-max`
-- `gpt-5.2`
-- `gpt-5.2-codex`
-- `gpt-5.3-codex`
-- `gpt-5.4`
-- `claude-haiku-4.5`
-- `claude-sonnet-4`
-- `claude-sonnet-4.5`
-- `claude-sonnet-4.6`
-- `claude-opus-4.5`
-- `claude-opus-4.6`
-- `claude-opus-4.6-1m`
-- `gemini-2.5-pro`
-- `gemini-3-pro-preview`
-- `gemini-3-flash-preview`
-- `gemini-3.1-pro-preview`
+The exact catalog depends on your configured providers and current upstream availability. Query `/v1/models` in your own deployment instead of hard-coding one global model list.
 
 ## `POST /v1beta/models/{model}:generateContent` and `POST /models/{model}:generateContent` (Gemini)
 
-Gemini is implemented as a translation layer, not a zero-copy passthrough layer. Gemini requests are translated to OpenAI Chat Completions, sent upstream, and translated back into Gemini responses.
+Gemini is implemented as a translation layer, not a zero-copy passthrough layer. Gemini requests are translated to OpenAI Chat Completions, routed through the provider that owns the selected public model, and translated back into Gemini responses.
 
 The decoder accepts both standard Gemini camelCase fields and LiteLLM-style snake_case aliases such as `system_instruction`, `function_declarations`, `inline_data`, `max_output_tokens`, and `response_json_schema`.
 
@@ -109,7 +87,7 @@ Near zero-copy passthrough for requests without tools. When tools are present, t
 
 When provider routing is configured, the request is routed by the public `model` ID. If the selected provider uses a different upstream model or deployment name, the proxy rewrites the outgoing `model` field before forwarding.
 
-The proxy also enforces the model's configured `supported_endpoints` before forwarding. If a model is exposed as `/responses`-only, `POST /v1/chat/completions` fails fast with `400` instead of probing an unsupported upstream route. The Azure `gpt-5.4-pro` example configuration is set up this way.
+The proxy also enforces the model's configured `supported_endpoints` before forwarding. If a model is exposed as `/responses`-only, `POST /v1/chat/completions` fails fast with `400` instead of probing an unsupported upstream route. The Azure `gpt-5.4-pro` example configuration and OpenAI Codex subscription models are set up this way.
 
 ## `POST /v1/responses` and `GET /v1/responses` (OpenAI)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,30 +3,22 @@
 ## System Shape
 
 ```text
-┌─────────────────────────────────────────────────────┐
-│                   vekil                     │
-│                                                     │
-│  /v1/messages ──► Translate ──► /chat/completions   │
-│                   Anthropic→OAI   api.githubcopilot │
-│                   Translate ◄──   .com              │
-│                   OAI→Anthropic                     │
-│                                                     │
-│  /v1beta/models/... ─► Translate ─► /chat/completions│
-│  /models/...          Gemini→OAI     api.githubcopilot│
-│                       Translate ◄──   .com           │
-│                       OAI→Gemini                     │
-│                                                     │
-│  /v1/chat/completions ─────────► Provider router ─► │
-│  /v1/responses ────────────────► (Copilot / Azure  │
-│                   HTTP /responses)                 │
-│                   (passthrough + proxy compaction   │
-│                    expansion when needed)           │
-│  /v1/responses/compact ────────► /responses         │
-│  /v1/memories/trace_summarize ─► /responses         │
-│                   (proxy-owned Codex compatibility) │
-│                                                     │
-│  auth/ ── Device code flow ── Token cache & refresh │
-└─────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│                              vekil                               │
+│                                                                  │
+│  /v1/messages ─┐                                                 │
+│  /v1beta/... ──┼─► Translate to OpenAI payloads ─► Provider router│
+│  /models/... ──┤                                   │             │
+│  /v1/chat/... ─┤                                   ├─► Copilot   │
+│  /v1/responses ┘                                   ├─► Azure     │
+│                                                      └─► Codex   │
+│                                                                  │
+│  /v1/responses/compact ─┐                                        │
+│  /v1/memories/... ──────┴─► Proxy-owned Responses compatibility  │
+│                                                                  │
+│  auth + provider state ─► GitHub device flow, token caches,      │
+│                           Codex auth.json refresh helpers         │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ## Package Responsibilities
@@ -35,15 +27,16 @@
 |---------|---------------|
 | `main` | CLI flags, HTTP server setup, graceful shutdown |
 | `auth/` | GitHub OAuth device code flow, Copilot token exchange, disk caching, auto-refresh |
-| `proxy/` | HTTP handlers, provider routing, Anthropic/OpenAI and Gemini/OpenAI translation, SSE streaming, retry logic |
+| `proxy/` | HTTP handlers, provider routing, Anthropic/OpenAI and Gemini/OpenAI translation, Responses compatibility, SSE streaming, retry logic, and provider-specific request/auth helpers outside GitHub OAuth |
 | `models/` | Request and response type definitions only |
 | `logger/` | Structured JSON logging |
 | `server/` | Reusable HTTP server lifecycle |
-| `cmd/menubar/` | macOS menubar app |
+| `cmd/menubar/` | macOS/Linux tray app |
 
 ## Key Decisions
 
 - Pure `net/http` with Go `ServeMux` routing; no web framework.
+- Vekil is a multi-provider proxy. Zero-config startup currently uses GitHub Copilot, but explicit provider config can extend or replace that default behind the same public surface.
 - Public model IDs are a single namespace across providers. The proxy validates ownership during startup and fails fast on collisions.
 - Provider endpoint support is explicit. `models[].endpoints` is an allowlist, so do not expose `/chat/completions` or other routes for a provider/model until that upstream capability is verified.
 - Gemini is a translation path like Anthropic, not a passthrough path.
@@ -51,4 +44,5 @@
 - OpenAI Responses compatibility is partly proxy-owned, especially for Codex compaction and websocket bridging.
 - The Codex websocket bridge is transport adaptation over upstream HTTP `/responses`, not a claim that the selected provider has native websocket or realtime support.
 - Azure OpenAI support is implemented as an OpenAI-compatible provider behind the existing proxy surface; Azure deployment names are internal to provider config.
+- OpenAI Codex subscription support is a Responses-only dynamic provider backed by Codex CLI ChatGPT credentials.
 - Production dependencies stay minimal.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,5 +1,7 @@
 # Client Usage Examples
 
+These examples all target the same local proxy. Replace model IDs with public IDs from `/v1/models` in your deployment; client setup does not need to change when a model is backed by GitHub Copilot, Azure OpenAI, or OpenAI Codex.
+
 ## Claude Code
 
 ```bash
@@ -10,10 +12,12 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ## OpenAI Codex CLI
 
+Use any public `/responses`-capable model ID exposed by your current setup. For an OpenAI Codex subscription model, first add an `openai-codex` provider with an `include_models` entry such as `gpt-5.5`; the model remains unprefixed for clients.
+
 ```bash
 env OPENAI_API_KEY=dummy \
   OPENAI_BASE_URL=http://localhost:1337/v1 \
-  codex exec --skip-git-repo-check -m gpt-5.4 "Reply with exactly PROXY_OK"
+  codex exec --skip-git-repo-check -m gpt-5.5 "Reply with exactly PROXY_OK"
 ```
 
 ## Gemini CLI

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,8 +12,6 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ## OpenAI Codex CLI
 
-Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models.
-
 ```bash
 env OPENAI_API_KEY=dummy \
   OPENAI_BASE_URL=http://localhost:1337/v1 \

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,7 +12,7 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ## OpenAI Codex CLI
 
-Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models. Public model IDs still stay unprefixed for clients.
+Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models.
 
 ```bash
 env OPENAI_API_KEY=dummy \

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,7 +12,7 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ## OpenAI Codex CLI
 
-Use any public `/responses`-capable model ID exposed by your current setup. If you want the proxy to expose an OpenAI Codex subscription model, add an `openai-codex` provider with an `include_models` entry such as `gpt-5.5`; the model remains unprefixed for clients.
+Use any public model ID exposed by `/v1/models` that Codex CLI can use in your setup. Chat Completions-backed models work too; you only need an `openai-codex` provider if you specifically want to expose OpenAI Codex subscription-backed models. Public model IDs still stay unprefixed for clients.
 
 ```bash
 env OPENAI_API_KEY=dummy \

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -12,7 +12,7 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ## OpenAI Codex CLI
 
-Use any public `/responses`-capable model ID exposed by your current setup. For an OpenAI Codex subscription model, first add an `openai-codex` provider with an `include_models` entry such as `gpt-5.5`; the model remains unprefixed for clients.
+Use any public `/responses`-capable model ID exposed by your current setup. If you want the proxy to expose an OpenAI Codex subscription model, add an `openai-codex` provider with an `include_models` entry such as `gpt-5.5`; the model remains unprefixed for clients.
 
 ```bash
 env OPENAI_API_KEY=dummy \

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -101,7 +101,7 @@ curl http://localhost:1337/v1beta/models/gemini-2.5-pro:generateContent \
 ## Gemini Stream Generate Content API
 
 ```bash
-curl http://localhost:1337/v1beta/models/gemini-2.5-pro:streamGenerateContent \
+curl -N http://localhost:1337/v1/models/gemini-2.5-pro:streamGenerateContent \
   -H "Content-Type: application/json" \
   -d '{
     "contents": [
@@ -112,6 +112,8 @@ curl http://localhost:1337/v1beta/models/gemini-2.5-pro:streamGenerateContent \
     ]
   }'
 ```
+
+`-N` disables curl buffering so SSE chunks print as they arrive. The proxy accepts Gemini routes under `/v1beta/models`, `/v1/models`, and `/models`.
 
 ## Gemini Count Tokens API
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,33 +1,81 @@
 # Configuration
 
-## Core Flags
+Vekil supports two runtime patterns:
+
+- **Zero-config mode**: no `--providers-config`; the proxy uses its built-in GitHub Copilot upstream.
+- **Explicit provider routing**: pass `--providers-config` with any mix of `copilot`, `azure-openai`, and `openai-codex`. If the config omits Copilot, GitHub auth is not used.
+
+## Generic Flags
 
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|
 | `--port` | `PORT` | `1337` | Listen port |
 | `--host` | `HOST` | `0.0.0.0` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
-| `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON provider configuration for multi-provider model routing |
+| `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
+
+## Copilot Header Overrides
+
+These overrides only affect Copilot-backed upstream requests.
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
 | `--copilot-editor-version` | `COPILOT_EDITOR_VERSION` | `vscode/1.95.0` | Upstream `editor-version` header |
 | `--copilot-plugin-version` | `COPILOT_PLUGIN_VERSION` | `copilot-chat/0.26.7` | Upstream `editor-plugin-version` header |
 | `--copilot-user-agent` | `COPILOT_USER_AGENT` | `GitHubCopilotChat/0.26.7` | Upstream `user-agent` header |
 | `--copilot-github-api-version` | `COPILOT_GITHUB_API_VERSION` | `2025-04-01` | Upstream `x-github-api-version` header |
 
-## Non-Interactive Authentication
+## Provider Authentication
 
-For CI or other non-interactive environments, the proxy also accepts a GitHub token from `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`.
+### GitHub Copilot
+
+For CI or other non-interactive environments, the proxy accepts a GitHub token from `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`.
 
 If one of these is set, it overrides any cached login state and is exchanged for a short-lived Copilot token at startup.
 
-If your provider config does not include a Copilot provider, startup skips the GitHub auth check.
+### OpenAI Codex
 
-## Multi-Provider Routing
+OpenAI Codex uses the ChatGPT/Codex CLI credentials in `~/.codex/auth.json` by default. Set `CODEX_HOME` if your Codex home lives elsewhere.
 
-Use `--providers-config` to expose non-Copilot models such as Azure OpenAI deployments behind the same proxy endpoint.
+OpenAI Codex requires file-based ChatGPT auth from `codex login`; API-key auth and OS keychain-backed credentials are not read by the proxy.
 
-Example:
+### Azure OpenAI
+
+Azure OpenAI credentials are configured in the provider entry, using either `api_key` or `api_key_env`.
+
+## Provider Routing
+
+Use `--providers-config` when you want explicit ownership of public model IDs across providers such as GitHub Copilot, Azure OpenAI, and OpenAI Codex.
+
+You can run Azure-only or Codex-only configs, or mix those providers with Copilot behind the same local endpoint.
+
+### Azure-Only Example
+
+```json
+{
+  "providers": [
+    {
+      "id": "azure-openai",
+      "type": "azure-openai",
+      "default": true,
+      "base_url": "https://myresource.cognitiveservices.azure.com/openai/v1",
+      "api_key_env": "AZURE_OPENAI_API_KEY",
+      "models": [
+        {
+          "public_id": "gpt-5.4-pro",
+          "deployment": "gpt-5.4-pro",
+          "endpoints": ["/responses"],
+          "name": "GPT-5.4 Pro"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Copilot + Azure Example
 
 ```json
 {
@@ -56,28 +104,48 @@ Example:
 }
 ```
 
+### OpenAI Codex Subscription Example
+
+```json
+{
+  "providers": [
+    {
+      "id": "copilot",
+      "type": "copilot",
+      "default": true
+    },
+    {
+      "id": "openai-codex",
+      "type": "openai-codex",
+      "include_models": ["gpt-5.5"]
+    }
+  ]
+}
+```
+
 Routing rules:
 
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
 - Azure `deployment` is the upstream model name; the proxy rewrites the public ID before forwarding.
 - Azure `models[]` remains the routing source of truth. The proxy does not autodiscover new Azure deployments for inference.
+- OpenAI Codex discovers models dynamically from its upstream `/models` endpoint and exposes only models that are listed and supported in the API.
+- OpenAI Codex models are `/responses`-only. The proxy rejects `/chat/completions` for those models instead of probing an unsupported route.
 - Azure `base_url` must be an absolute URL whose path ends with either the OpenAI-compatible `/openai/v1` path or the legacy `/openai` path, with no query string or fragment.
 - Azure AI Foundry inference URLs ending in `/models` are not supported in `type: "azure-openai"` configs. Use the corresponding OpenAI-compatible `.../openai/v1` endpoint instead.
 - For `/openai/v1` base URLs, omit `api_version`; the proxy calls `/chat/completions`, `/responses`, and `/models` directly with no `api-version` query string.
 - For legacy `/openai` base URLs, set `api_version`; the proxy appends `api-version=...` to upstream requests.
 - Public model IDs are global across all providers. Startup fails if two providers expose the same ID.
+- `include_models` is the recommended way to use dynamic providers without prefixes. It lets you opt into only the discovered model IDs that should belong to that provider.
 - `exclude_models` lets one provider give ownership of a public ID to another provider.
 - Only one Copilot provider is supported in a config today.
 - `models[].endpoints` is an allowlist, not a guess. Keep it limited to the routes you have validated for that deployment.
-- Static provider models can also advertise richer Codex `/v1/models` metadata via optional fields on each `models[]` entry:
-  `model_picker_category`, `reasoning_effort`, `vision`, `parallel_tool_calls`, and `context_window`.
-  Without those fields, the proxy exposes a minimal but valid model entry.
+- Static provider models can also advertise richer Codex `/v1/models` metadata via optional fields on each `models[]` entry: `model_picker_category`, `reasoning_effort`, `vision`, `parallel_tool_calls`, and `context_window`. Without those fields, the proxy exposes a minimal but valid model entry.
 - For Azure OpenAI, `/v1/models` only does a best-effort metadata overlay for each configured `models[]` entry by probing Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
 - Azure's upstream `/models` catalog can omit Codex-style fields entirely. The proxy only copies fields that Azure already returns; it does not derive reasoning levels, vision, parallel tool calls, model picker metadata, or context window from other Azure docs or capability hints.
 - Explicit `models[]` metadata overrides Azure `/models` overlay metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails or returns a sparse payload.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 
-Use the JSON example above as a starting point for your local providers config file.
+Use the JSON examples above as a starting point for your local providers config file.
 
 ## WebSocket Session Tuning
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,7 @@ The macOS menubar app has its own workflow in [`.github/workflows/macos-app.yaml
 
 ## Release
 
-Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) now use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
+Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 
 The same release workflow also:
 
@@ -64,6 +64,8 @@ It builds the proxy, installs Codex, Claude Code, and Gemini CLI on a GitHub-hos
 
 The smoke script starts the proxy with a non-interactive GitHub token, waits for `/readyz`, selects currently available OpenAI, Anthropic, and Gemini models from `/v1/models`, and runs one file-reading headless check per CLI using isolated temp-home config directories.
 
+This workflow is intentionally provider-specific: it exercises a live Copilot-backed deployment because zero-config startup is the simplest upstream path to run in GitHub Actions. It is useful as a real integration smoke test, but it is not the complete provider matrix for Azure OpenAI or OpenAI Codex configs.
+
 To use it:
 
 1. Create a GitHub token for a user that has GitHub Copilot access.
@@ -71,6 +73,6 @@ To use it:
 3. Save it as the repository secret `COPILOT_GITHUB_TOKEN`.
 4. Run the `Live Copilot Smoke` workflow from the Actions tab.
 
-This workflow is intentionally separate from the normal CI workflow so pull requests and forked builds remain deterministic and do not depend on Copilot credentials.
+This workflow is intentionally separate from the normal CI workflow so pull requests and forked builds remain deterministic and do not depend on live provider credentials.
 
 You can also run the same smoke script locally after building `vekil` and installing those three CLIs.

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,7 @@ make lint
 
 GitHub Actions in [`.github/workflows/ci.yaml`](../.github/workflows/ci.yaml) runs lint, tests, build, vet, and e2e validation before merge.
 
-The macOS menubar app has its own workflow in [`.github/workflows/macos-app.yaml`](../.github/workflows/macos-app.yaml). It runs `scripts/macos-app-smoke.sh` on a macOS runner, which builds `Vekil.app`, validates the bundle contents, launches the app through Launch Services, verifies it stays up, and then quits it cleanly.
+The macOS tray app has its own workflow in [`.github/workflows/macos-app.yaml`](../.github/workflows/macos-app.yaml). It runs `scripts/macos-app-smoke.sh` on a macOS runner, which builds `Vekil.app`, validates the bundle contents, launches the app through Launch Services, verifies it stays up, and then quits it cleanly.
 
 ## Release
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,10 @@
 # Getting Started
 
+Vekil commonly runs in one of two modes:
+
+- **Zero-config mode**: start the proxy with no `--providers-config`; it uses the built-in GitHub Copilot upstream.
+- **Explicit provider routing**: pass `--providers-config` to expose any mix of `copilot`, `azure-openai`, and `openai-codex` providers behind the same local API surface.
+
 ## Download From GitHub Releases
 
 Download the latest binary for your platform from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest).
@@ -29,6 +34,8 @@ go build -o vekil .
 
 ## Docker
 
+Base container run:
+
 ```bash
 docker pull ghcr.io/sozercan/vekil:latest
 docker run -p 1337:1337 \
@@ -36,7 +43,28 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/vekil:latest
 ```
 
-Or build locally:
+If you use explicit provider routing, mount your config file and pass `--providers-config`:
+
+```bash
+docker run -p 1337:1337 \
+  -v ~/.config/vekil:/home/nonroot/.config/vekil \
+  -v /path/to/providers.json:/config/providers.json:ro \
+  ghcr.io/sozercan/vekil:latest \
+  --providers-config /config/providers.json
+```
+
+If your provider config includes `type: "openai-codex"`, also mount the Codex home read-only so the proxy can read `auth.json`:
+
+```bash
+docker run -p 1337:1337 \
+  -v ~/.config/vekil:/home/nonroot/.config/vekil \
+  -v ~/.codex:/home/nonroot/.codex:ro \
+  -v /path/to/providers.json:/config/providers.json:ro \
+  ghcr.io/sozercan/vekil:latest \
+  --providers-config /config/providers.json
+```
+
+To build a local image instead of pulling GHCR:
 
 ```bash
 docker build -t vekil .
@@ -44,6 +72,8 @@ docker run -p 1337:1337 \
   -v ~/.config/vekil:/home/nonroot/.config/vekil \
   vekil
 ```
+
+The same extra mounts and `--providers-config` flag shown above also apply to a locally built image.
 
 The published image supports `linux/amd64` and `linux/arm64`.
 
@@ -55,9 +85,13 @@ A sample manifest is included at [`k8s/vekil.yaml`](../k8s/vekil.yaml).
 kubectl apply -f k8s/vekil.yaml
 ```
 
-## First Run
+## First Run And Authentication
 
-If your setup includes a Copilot provider, the proxy starts GitHub's device code flow on first run:
+Startup behavior depends on the providers that are active in your deployment.
+
+### GitHub Copilot
+
+If you are using zero-config startup or an explicit `type: "copilot"` provider, the proxy starts GitHub's device code flow on first run:
 
 1. Visit the URL shown in the terminal.
 2. Enter the one-time code.
@@ -66,4 +100,14 @@ If your setup includes a Copilot provider, the proxy starts GitHub's device code
 Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry.
 If `HTTP_PROXY` or `HTTPS_PROXY` points at a local loopback proxy that is not running, the auth flow automatically retries GitHub requests directly.
 
-If your provider config does not include Copilot, startup skips GitHub authentication. See [configuration.md](configuration.md) for multi-provider setup details.
+### Azure OpenAI
+
+Azure OpenAI credentials are configured per provider entry, usually with `api_key` or `api_key_env` in the providers JSON file. There is no separate interactive login flow in the proxy.
+
+### OpenAI Codex
+
+When your providers config includes `type: "openai-codex"`, first sign in with the OpenAI Codex CLI using ChatGPT auth so `~/.codex/auth.json` exists. The proxy reads that file directly and refreshes the access token as needed.
+
+Codex API-key auth and OS keychain-backed credentials are not read by the proxy. If your Codex home is not `~/.codex`, set `CODEX_HOME` before starting the proxy.
+
+If your provider config does not include Copilot, startup skips GitHub authentication entirely. See [configuration.md](configuration.md) for provider routing examples and provider-specific knobs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ Download the latest binary for your platform from [GitHub Releases](https://gith
 
 Published binaries are available for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`. Windows release assets are published as `.exe` binaries. After downloading, make the binary executable if needed and run it locally.
 
-On Apple Silicon Macs, you can use the native menubar app:
+On Apple Silicon Macs, you can use the native macOS tray app:
 
 ```bash
 brew install --cask sozercan/repo/vekil
@@ -23,7 +23,7 @@ brew install --cask sozercan/repo/vekil
 > xattr -cr /Applications/Vekil.app
 > ```
 
-GitHub Releases also includes a `vekil-macos-arm64.zip` menubar app bundle if you prefer a manual download.
+GitHub Releases also includes a `vekil-macos-arm64.zip` tray app bundle if you prefer a manual download.
 
 ## Build From Source
 
@@ -59,6 +59,18 @@ If your provider config includes `type: "openai-codex"`, also mount the Codex ho
 docker run -p 1337:1337 \
   -v ~/.config/vekil:/home/nonroot/.config/vekil \
   -v ~/.codex:/home/nonroot/.codex:ro \
+  -v /path/to/providers.json:/config/providers.json:ro \
+  ghcr.io/sozercan/vekil:latest \
+  --providers-config /config/providers.json
+```
+
+If you customize `CODEX_HOME`, remember that the container reads the container-side path, not your host path. Mount your host Codex directory to the same path you set in `CODEX_HOME`, for example:
+
+```bash
+docker run -p 1337:1337 \
+  -e CODEX_HOME=/codex-home \
+  -v ~/.config/vekil:/home/nonroot/.config/vekil \
+  -v /path/to/custom-codex-home:/codex-home:ro \
   -v /path/to/providers.json:/config/providers.json:ro \
   ghcr.io/sozercan/vekil:latest \
   --providers-config /config/providers.json
@@ -108,6 +120,22 @@ Azure OpenAI credentials are configured per provider entry, usually with `api_ke
 
 When your providers config includes `type: "openai-codex"`, first sign in with the OpenAI Codex CLI using ChatGPT auth so `~/.codex/auth.json` exists. The proxy reads that file directly and refreshes the access token as needed.
 
-Codex API-key auth and OS keychain-backed credentials are not read by the proxy. If your Codex home is not `~/.codex`, set `CODEX_HOME` before starting the proxy.
+Codex API-key auth and OS keychain-backed credentials are not read by the proxy. If your Codex home is not `~/.codex`, set `CODEX_HOME` before starting the proxy. In Docker, `CODEX_HOME` is resolved inside the container, so your bind mount target must match the in-container `CODEX_HOME` path.
 
 If your provider config does not include Copilot, startup skips GitHub authentication entirely. See [configuration.md](configuration.md) for provider routing examples and provider-specific knobs.
+
+## Verify The Proxy Is Up
+
+After the proxy is running and any first-run authentication has completed, check the basic health and model endpoints:
+
+```bash
+curl http://localhost:1337/healthz
+curl http://localhost:1337/readyz
+curl http://localhost:1337/v1/models
+```
+
+What each endpoint tells you:
+
+- `/healthz` confirms the process is listening and serving HTTP. It should return `{"status":"ok"}`.
+- `/readyz` verifies the proxy can authenticate to and probe the configured upstream providers. It should return `{"status":"ready"}`; `503` usually means auth or upstream reachability still needs attention.
+- `/v1/models` shows the merged public model catalog that clients will see. Use it to confirm the models you expect are actually exposed before testing a client.

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -53,8 +53,9 @@ open "Vekil.app"
 Use `Choose Providers Config…` from the menubar menu to select the same JSON file you would pass to the CLI with `--providers-config`.
 
 - The app saves the selected path in its menubar config so it is reused on the next launch and when started at login.
-- `Use Default Copilot Routing` clears the saved path and returns to the zero-config Copilot-only behavior.
+- `Use Default Copilot Routing` clears the saved path and returns to zero-config startup, which currently uses the built-in Copilot provider.
 - If the selected config does not include a Copilot provider, the app no longer requires GitHub sign-in before starting the proxy.
+- Provider-specific extra state still comes from the normal locations, for example `~/.codex/auth.json` for `type: "openai-codex"`.
 
 ## Release Assets
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -1,10 +1,10 @@
-# System Tray App
+# macOS/Linux Tray App
 
-The repo includes a system tray app for running the proxy without keeping a terminal open. It supports macOS and Linux. Published macOS app bundles also include Sparkle-based update checks.
+The repo includes a tray app for running the proxy without keeping a terminal open. It supports macOS and Linux. Published macOS app bundles also include Sparkle-based update checks.
 
 ## Download And Run
 
-Install the menubar app from Homebrew:
+Install the macOS tray app from Homebrew:
 
 ```bash
 brew install --cask sozercan/repo/vekil
@@ -27,7 +27,7 @@ make build-app
 open "Vekil.app"
 ```
 
-`make build-app` downloads Sparkle 2.9.0 into `.build/sparkle/`, builds the menubar app with the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.
+`make build-app` downloads Sparkle 2.9.0 into `.build/sparkle/`, builds the macOS tray app with the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.
 
 If `SPARKLE_PUBLIC_ED_KEY` is not set, the app still builds, but `Check for Updates…` is disabled because Sparkle cannot start without a public EdDSA key.
 
@@ -40,7 +40,7 @@ open "Vekil.app"
 
 ## Features
 
-- start/stop toggle from the menubar
+- start/stop toggle from the tray menu
 - status icon: white robot when running, gray when stopped
 - current app version shown in the menu
 - choose and persist a `providers-config` JSON file from the menu
@@ -50,9 +50,9 @@ open "Vekil.app"
 
 ## Providers Config
 
-Use `Choose Providers Config…` from the menubar menu to select the same JSON file you would pass to the CLI with `--providers-config`.
+Use `Choose Providers Config…` from the tray menu to select the same JSON file you would pass to the CLI with `--providers-config`.
 
-- The app saves the selected path in its menubar config so it is reused on the next launch and when started at login.
+- The app saves the selected path in its local app config so it is reused on the next launch and when started at login.
 - `Use Default Copilot Routing` clears the saved path and returns to zero-config startup, which currently uses the built-in Copilot provider.
 - If the selected config does not include a Copilot provider, the app no longer requires GitHub sign-in before starting the proxy.
 - Provider-specific extra state still comes from the normal locations, for example `~/.codex/auth.json` for `type: "openai-codex"`.

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -465,6 +465,12 @@ func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *pr
 		req.Header.Set("api-key", provider.apiKey)
 		req.Header.Set("Content-Type", "application/json")
 		return req, nil
+	case providerTypeOpenAICodex:
+		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, openAICodexModelsRawQuery(""))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create provider %q probe request: %w", provider.id, err)
+		}
+		return req, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider type %q", provider.kind)
 	}
@@ -592,7 +598,20 @@ func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifN
 			return cachedModelsResponse{}, false, err
 		}
 
-		if provider.kind == providerTypeCopilot {
+		if result.notModified {
+			for _, model := range setup.modelsForProvider(provider.id) {
+				if existingProvider, exists := owners[model.publicID]; exists {
+					if existingProvider == model.providerID {
+						continue
+					}
+					return cachedModelsResponse{}, false, providerModelCollisionError(model.publicID, existingProvider, model.providerID)
+				}
+				owners[model.publicID] = model.providerID
+				rawEntries = append(rawEntries, model.raw)
+			}
+		}
+
+		if providerUsesDynamicModels(provider) {
 			sawDynamicProvider = true
 			if result.notModified {
 				continue
@@ -611,7 +630,7 @@ func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifN
 				if existingProvider == model.providerID {
 					continue
 				}
-				return cachedModelsResponse{}, false, fmt.Errorf("model %q is exposed by both provider %q and provider %q", model.publicID, existingProvider, model.providerID)
+				return cachedModelsResponse{}, false, providerModelCollisionError(model.publicID, existingProvider, model.providerID)
 			}
 			owners[model.publicID] = model.providerID
 			rawEntries = append(rawEntries, model.raw)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2494,6 +2494,141 @@ func TestHandleOpenAIChatCompletions_RejectsConfiguredAzureModelWithoutChatSuppo
 	}
 }
 
+func TestHandleResponses_RoutesConfiguredOpenAICodexProvider(t *testing.T) {
+	tokens := testOpenAICodexTokens(t, time.Now().Add(time.Hour), "acct-123", true, "refresh-token")
+	codexHome := t.TempDir()
+	writeTestOpenAICodexAuth(t, codexHome, tokens)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	codexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/responses" {
+			t.Fatalf("expected OpenAI Codex path /responses, got %s", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+tokens.AccessToken {
+			t.Fatalf("expected Codex Authorization header, got %q", got)
+		}
+		if got := r.Header.Get("ChatGPT-Account-ID"); got != "acct-123" {
+			t.Fatalf("expected ChatGPT-Account-ID acct-123, got %q", got)
+		}
+		if got := r.Header.Get("X-OpenAI-Fedramp"); got != "true" {
+			t.Fatalf("expected X-OpenAI-Fedramp true, got %q", got)
+		}
+		if got := r.Header.Get("X-Codex-Turn-State"); got != "sticky-turn-state" {
+			t.Fatalf("expected X-Codex-Turn-State passthrough, got %q", got)
+		}
+		if got := r.Header.Get("api-key"); got != "" {
+			t.Fatalf("expected no Azure api-key header, got %q", got)
+		}
+
+		var upstreamReq struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "gpt-5.5" {
+			t.Fatalf("upstream model = %q, want gpt-5.5", upstreamReq.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-codex","object":"response","status":"completed"}`))
+	}))
+	defer codexServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:      "codex",
+				Type:    "openai-codex",
+				Default: true,
+				BaseURL: codexServer.URL,
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.5","input":"Hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Codex-Turn-State", "sticky-turn-state")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var responseBody struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		t.Fatalf("decode responses body: %v", err)
+	}
+	if responseBody.ID != "resp-codex" {
+		t.Fatalf("expected OpenAI Codex response, got %+v", responseBody)
+	}
+}
+
+func TestHandleOpenAIChatCompletions_RejectsOpenAICodexProvider(t *testing.T) {
+	codexHome := t.TempDir()
+	writeTestOpenAICodexAuth(t, codexHome, testOpenAICodexTokens(t, time.Now().Add(time.Hour), "acct-123", false, "refresh-token"))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	codexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("OpenAI Codex upstream should not be called for chat completions")
+	}))
+	defer codexServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:      "codex",
+				Type:    "openai-codex",
+				Default: true,
+				BaseURL: codexServer.URL,
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model": "gpt-5.5",
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+
+	var errResp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if !strings.Contains(errResp.Error.Message, `provider "codex" does not support /chat/completions`) {
+		t.Fatalf("expected provider unsupported endpoint message, got %q", errResp.Error.Message)
+	}
+}
+
 func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
 	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 
@@ -2538,6 +2673,185 @@ func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "copilot") || !strings.Contains(err.Error(), "azure") {
 		t.Fatalf("expected both provider ids in error, got %v", err)
+	}
+}
+
+func TestNewProxyHandler_FailsWhenOpenAICodexModelCollidesWithAzure(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+	codexHome := t.TempDir()
+	writeTestOpenAICodexAuth(t, codexHome, testOpenAICodexTokens(t, time.Now().Add(time.Hour), "acct-123", false, "refresh-token"))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	codexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/models" {
+			t.Fatalf("expected /models lookup, got %s", got)
+		}
+		if got := r.URL.Query().Get("client_version"); got != defaultOpenAICodexClientVersion {
+			t.Fatalf("client_version = %q, want %q", got, defaultOpenAICodexClientVersion)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"slug":"gpt-5.4","display_name":"GPT-5.4","visibility":"list","supported_in_api":true,"supported_reasoning_levels":[{"effort":"medium"}],"context_window":128000}]}`))
+	}))
+	defer codexServer.Close()
+
+	_, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:      "codex",
+					Type:    "openai-codex",
+					BaseURL: codexServer.URL,
+				},
+				{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   "https://example.openai.azure.com/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4",
+						Deployment: "gpt-5-4-prod",
+					}},
+				},
+			},
+		}),
+	)
+	if err == nil {
+		t.Fatal("expected provider model collision error")
+	}
+	if !strings.Contains(err.Error(), "gpt-5.4") {
+		t.Fatalf("expected model id in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "codex") || !strings.Contains(err.Error(), "azure") {
+		t.Fatalf("expected both provider ids in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "include_models") || !strings.Contains(err.Error(), "exclude_models") {
+		t.Fatalf("expected include/exclude guidance in error, got %v", err)
+	}
+}
+
+func TestNewProxyHandler_OpenAICodexIncludeModelsAvoidsCollision(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+	codexHome := t.TempDir()
+	writeTestOpenAICodexAuth(t, codexHome, testOpenAICodexTokens(t, time.Now().Add(time.Hour), "acct-123", false, "refresh-token"))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	codexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[
+				{"slug":"gpt-5.4","display_name":"GPT-5.4","visibility":"list","supported_in_api":true},
+				{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","supported_in_api":true,"supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"}],"supports_parallel_tool_calls":true,"context_window":272000,"input_modalities":["text","image"],"priority":0}
+			]}`))
+		default:
+			t.Fatalf("unexpected OpenAI Codex path %q", r.URL.Path)
+		}
+	}))
+	defer codexServer.Close()
+
+	azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openai/v1/models" {
+			t.Fatalf("unexpected Azure path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer azureServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:            "codex",
+					Type:          "openai-codex",
+					BaseURL:       codexServer.URL,
+					IncludeModels: []string{"gpt-5.5"},
+				},
+				{
+					ID:        "azure",
+					Type:      "azure-openai",
+					Default:   true,
+					BaseURL:   azureServer.URL + "/openai/v1",
+					APIKeyEnv: "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-5.4",
+						Deployment: "gpt-5-4-prod",
+						Endpoints:  []string{"/responses"},
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Data []struct {
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+		} `json:"data"`
+		Models []struct {
+			Slug                      string  `json:"slug"`
+			DefaultReasoningLevel     *string `json:"default_reasoning_level,omitempty"`
+			SupportsParallelToolCalls bool    `json:"supports_parallel_tool_calls"`
+			ContextWindow             *int64  `json:"context_window,omitempty"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+
+	ids := make(map[string][]string)
+	for _, model := range result.Data {
+		ids[model.ID] = model.SupportedEndpoints
+	}
+	if _, ok := ids["gpt-5.4"]; !ok {
+		t.Fatalf("expected Azure model gpt-5.4 in merged catalog, got %+v", ids)
+	}
+	if endpoints, ok := ids["gpt-5.5"]; !ok {
+		t.Fatalf("expected OpenAI Codex model gpt-5.5 in merged catalog, got %+v", ids)
+	} else if got := strings.Join(endpoints, ","); got != "/responses" {
+		t.Fatalf("expected gpt-5.5 responses-only endpoint, got %q", got)
+	}
+
+	var codexModel *struct {
+		Slug                      string  `json:"slug"`
+		DefaultReasoningLevel     *string `json:"default_reasoning_level,omitempty"`
+		SupportsParallelToolCalls bool    `json:"supports_parallel_tool_calls"`
+		ContextWindow             *int64  `json:"context_window,omitempty"`
+	}
+	for i := range result.Models {
+		if result.Models[i].Slug == "gpt-5.5" {
+			codexModel = &result.Models[i]
+			break
+		}
+	}
+	if codexModel == nil {
+		t.Fatalf("expected Codex model metadata for gpt-5.5, got %+v", result.Models)
+	}
+	if codexModel.DefaultReasoningLevel == nil || *codexModel.DefaultReasoningLevel != "medium" {
+		t.Fatalf("expected default reasoning medium, got %v", codexModel.DefaultReasoningLevel)
+	}
+	if !codexModel.SupportsParallelToolCalls {
+		t.Fatal("expected supports_parallel_tool_calls true")
+	}
+	if codexModel.ContextWindow == nil || *codexModel.ContextWindow != 272000 {
+		t.Fatalf("expected context_window 272000, got %v", codexModel.ContextWindow)
 	}
 }
 

--- a/proxy/openai_codex_auth.go
+++ b/proxy/openai_codex_auth.go
@@ -1,0 +1,340 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultOpenAICodexBaseURL       = "https://chatgpt.com/backend-api/codex"
+	defaultOpenAICodexClientVersion = "1.0.0"
+	openAICodexAuthMode             = "chatgpt"
+	openAICodexClientID             = "app_EMoamEEZ73f0CkXaXp7hrann"
+	openAICodexRefreshURL           = "https://auth.openai.com/oauth/token"
+	openAICodexRefreshURLEnv        = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
+	openAICodexRefreshSkew          = 30 * time.Second
+	openAICodexRefreshInterval      = 8 * 24 * time.Hour
+)
+
+type openAICodexAuth struct {
+	path string
+	mu   sync.Mutex
+}
+
+type openAICodexTokenData struct {
+	IDToken      string `json:"id_token,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+}
+
+type openAICodexAuthState struct {
+	raw         map[string]json.RawMessage
+	tokens      openAICodexTokenData
+	lastRefresh *time.Time
+}
+
+type openAICodexCredentials struct {
+	accessToken string
+	accountID   string
+	fedRAMP     bool
+}
+
+type openAICodexRefreshResponse struct {
+	IDToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+func newOpenAICodexAuth() (*openAICodexAuth, error) {
+	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if codexHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve CODEX_HOME: %w", err)
+		}
+		codexHome = filepath.Join(home, ".codex")
+	}
+	return &openAICodexAuth{path: filepath.Join(codexHome, "auth.json")}, nil
+}
+
+func (a *openAICodexAuth) credentials(ctx context.Context, client *http.Client) (openAICodexCredentials, error) {
+	if a == nil {
+		return openAICodexCredentials{}, fmt.Errorf("OpenAI Codex auth is not configured")
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	state, err := a.read()
+	if err != nil {
+		return openAICodexCredentials{}, err
+	}
+	tokens := state.tokens
+	if !openAICodexNeedsRefresh(tokens.AccessToken, state.lastRefresh, time.Now()) {
+		return openAICodexCredentialsFromTokens(tokens), nil
+	}
+	if strings.TrimSpace(tokens.RefreshToken) == "" {
+		return openAICodexCredentials{}, fmt.Errorf("OpenAI Codex access token expired or stale and auth.json has no refresh_token; run `codex login`")
+	}
+
+	refreshed, err := requestOpenAICodexTokenRefresh(ctx, client, tokens.RefreshToken)
+	if err != nil {
+		return openAICodexCredentials{}, err
+	}
+	if strings.TrimSpace(refreshed.AccessToken) != "" {
+		tokens.AccessToken = refreshed.AccessToken
+	}
+	if strings.TrimSpace(refreshed.IDToken) != "" {
+		tokens.IDToken = refreshed.IDToken
+	}
+	if strings.TrimSpace(refreshed.RefreshToken) != "" {
+		tokens.RefreshToken = refreshed.RefreshToken
+	}
+	if strings.TrimSpace(tokens.AccessToken) == "" {
+		return openAICodexCredentials{}, fmt.Errorf("OpenAI Codex token refresh returned no access_token")
+	}
+
+	if err := a.write(state.raw, tokens); err != nil {
+		return openAICodexCredentials{}, err
+	}
+	return openAICodexCredentialsFromTokens(tokens), nil
+}
+
+func (a *openAICodexAuth) read() (openAICodexAuthState, error) {
+	body, err := os.ReadFile(a.path)
+	if err != nil {
+		return openAICodexAuthState{}, fmt.Errorf("read OpenAI Codex auth file %q: %w; run `codex login` first", a.path, err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return openAICodexAuthState{}, fmt.Errorf("decode OpenAI Codex auth file %q: %w", a.path, err)
+	}
+
+	var authMode string
+	if err := json.Unmarshal(raw["auth_mode"], &authMode); err != nil || authMode != openAICodexAuthMode {
+		return openAICodexAuthState{}, fmt.Errorf("OpenAI Codex auth file %q must use auth_mode %q; run `codex login` with ChatGPT auth", a.path, openAICodexAuthMode)
+	}
+
+	var tokens openAICodexTokenData
+	if len(raw["tokens"]) == 0 || string(raw["tokens"]) == "null" {
+		return openAICodexAuthState{}, fmt.Errorf("OpenAI Codex auth file %q has no ChatGPT tokens; run `codex login`", a.path)
+	}
+	if err := json.Unmarshal(raw["tokens"], &tokens); err != nil {
+		return openAICodexAuthState{}, fmt.Errorf("decode OpenAI Codex tokens in %q: %w", a.path, err)
+	}
+	if strings.TrimSpace(tokens.AccessToken) == "" {
+		return openAICodexAuthState{}, fmt.Errorf("OpenAI Codex auth file %q has no access_token; run `codex login`", a.path)
+	}
+
+	lastRefresh := parseOpenAICodexLastRefresh(raw["last_refresh"])
+
+	return openAICodexAuthState{raw: raw, tokens: tokens, lastRefresh: lastRefresh}, nil
+}
+
+func (a *openAICodexAuth) write(raw map[string]json.RawMessage, tokens openAICodexTokenData) error {
+	tokensRaw, err := json.Marshal(tokens)
+	if err != nil {
+		return fmt.Errorf("marshal refreshed OpenAI Codex tokens: %w", err)
+	}
+	lastRefreshRaw, err := json.Marshal(time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("marshal OpenAI Codex last_refresh: %w", err)
+	}
+	raw["tokens"] = tokensRaw
+	raw["last_refresh"] = lastRefreshRaw
+
+	body, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal OpenAI Codex auth file %q: %w", a.path, err)
+	}
+	body = append(body, '\n')
+
+	tmpPath := a.path + ".tmp"
+	if err := os.WriteFile(tmpPath, body, 0o600); err != nil {
+		return fmt.Errorf("write temporary OpenAI Codex auth file %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, a.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace OpenAI Codex auth file %q: %w", a.path, err)
+	}
+	if err := os.Chmod(a.path, 0o600); err != nil {
+		return fmt.Errorf("chmod OpenAI Codex auth file %q: %w", a.path, err)
+	}
+	return nil
+}
+
+func openAICodexCredentialsFromTokens(tokens openAICodexTokenData) openAICodexCredentials {
+	accountID := strings.TrimSpace(tokens.AccountID)
+	idClaims := openAICodexJWTClaims(tokens.IDToken)
+	if accountID == "" {
+		accountID = idClaims.chatGPTAccountID
+	}
+	return openAICodexCredentials{
+		accessToken: strings.TrimSpace(tokens.AccessToken),
+		accountID:   accountID,
+		fedRAMP:     idClaims.fedRAMP,
+	}
+}
+
+func requestOpenAICodexTokenRefresh(ctx context.Context, client *http.Client, refreshToken string) (openAICodexRefreshResponse, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	refreshURL := strings.TrimSpace(os.Getenv(openAICodexRefreshURLEnv))
+	if refreshURL == "" {
+		refreshURL = openAICodexRefreshURL
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"client_id":     openAICodexClientID,
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	})
+	if err != nil {
+		return openAICodexRefreshResponse{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, refreshURL, bytes.NewReader(body))
+	if err != nil {
+		return openAICodexRefreshResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return openAICodexRefreshResponse{}, fmt.Errorf("OpenAI Codex token refresh failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return openAICodexRefreshResponse{}, fmt.Errorf("read OpenAI Codex token refresh response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return openAICodexRefreshResponse{}, fmt.Errorf("OpenAI Codex token refresh failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var refreshed openAICodexRefreshResponse
+	if err := json.Unmarshal(respBody, &refreshed); err != nil {
+		return openAICodexRefreshResponse{}, fmt.Errorf("decode OpenAI Codex token refresh response: %w", err)
+	}
+	return refreshed, nil
+}
+
+func openAICodexNeedsRefresh(accessToken string, lastRefresh *time.Time, now time.Time) bool {
+	if openAICodexJWTExpiresSoon(accessToken, now, openAICodexRefreshSkew) {
+		return true
+	}
+	if _, ok := openAICodexJWTExpiration(accessToken); ok {
+		return false
+	}
+	if lastRefresh == nil || lastRefresh.IsZero() {
+		return true
+	}
+	return !now.Before(lastRefresh.Add(openAICodexRefreshInterval))
+}
+
+func parseOpenAICodexLastRefresh(raw json.RawMessage) *time.Time {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+
+	var value string
+	if err := json.Unmarshal(raw, &value); err == nil {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil
+		}
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if parsed, err := time.Parse(layout, value); err == nil {
+				parsed = parsed.UTC()
+				return &parsed
+			}
+		}
+		return nil
+	}
+
+	var unixSeconds int64
+	if err := json.Unmarshal(raw, &unixSeconds); err == nil {
+		parsed := time.Unix(unixSeconds, 0).UTC()
+		return &parsed
+	}
+
+	return nil
+}
+
+func openAICodexJWTExpiresSoon(token string, now time.Time, skew time.Duration) bool {
+	exp, ok := openAICodexJWTExpiration(token)
+	if !ok {
+		return false
+	}
+	return !now.Before(exp.Add(-skew))
+}
+
+func openAICodexJWTExpiration(token string) (time.Time, bool) {
+	claims := openAICodexJWTClaims(token)
+	if claims.exp == 0 {
+		return time.Time{}, false
+	}
+	exp := time.Unix(claims.exp, 0)
+	return exp, true
+}
+
+type openAICodexClaims struct {
+	exp              int64
+	chatGPTAccountID string
+	fedRAMP          bool
+}
+
+func openAICodexJWTClaims(token string) openAICodexClaims {
+	payload, ok := decodeOpenAICodexJWTPayload(token)
+	if !ok {
+		return openAICodexClaims{}
+	}
+
+	var claims struct {
+		Exp  int64 `json:"exp"`
+		Auth struct {
+			ChatGPTAccountID      string `json:"chatgpt_account_id"`
+			ChatGPTAccountFedRAMP bool   `json:"chatgpt_account_is_fedramp"`
+		} `json:"https://api.openai.com/auth"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return openAICodexClaims{}
+	}
+	return openAICodexClaims{
+		exp:              claims.Exp,
+		chatGPTAccountID: strings.TrimSpace(claims.Auth.ChatGPTAccountID),
+		fedRAMP:          claims.Auth.ChatGPTAccountFedRAMP,
+	}
+}
+
+func decodeOpenAICodexJWTPayload(token string) ([]byte, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 || parts[1] == "" {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err == nil {
+		return payload, true
+	}
+	payload, err = base64.URLEncoding.DecodeString(parts[1])
+	if err == nil {
+		return payload, true
+	}
+	return nil, false
+}

--- a/proxy/openai_codex_auth.go
+++ b/proxy/openai_codex_auth.go
@@ -28,8 +28,14 @@ const (
 
 type openAICodexAuth struct {
 	path string
-	mu   sync.Mutex
 }
+
+type openAICodexAuthSharedState struct {
+	mu    sync.Mutex
+	state *openAICodexAuthState
+}
+
+var openAICodexAuthSharedStates sync.Map
 
 type openAICodexTokenData struct {
 	IDToken      string `json:"id_token,omitempty"`
@@ -73,42 +79,165 @@ func (a *openAICodexAuth) credentials(ctx context.Context, client *http.Client) 
 		return openAICodexCredentials{}, fmt.Errorf("OpenAI Codex auth is not configured")
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	shared := a.sharedState()
+	shared.mu.Lock()
+	defer shared.mu.Unlock()
 
-	state, err := a.read()
+	now := time.Now().UTC()
+	state, err := a.loadState(shared, now)
 	if err != nil {
 		return openAICodexCredentials{}, err
 	}
-	tokens := state.tokens
-	if !openAICodexNeedsRefresh(tokens.AccessToken, state.lastRefresh, time.Now()) {
-		return openAICodexCredentialsFromTokens(tokens), nil
+	if !openAICodexNeedsRefresh(state.tokens.AccessToken, state.lastRefresh, now) {
+		return openAICodexCredentialsFromTokens(state.tokens), nil
 	}
-	if strings.TrimSpace(tokens.RefreshToken) == "" {
+	if strings.TrimSpace(state.tokens.RefreshToken) == "" {
 		return openAICodexCredentials{}, fmt.Errorf("OpenAI Codex access token expired or stale and auth.json has no refresh_token; run `codex login`")
 	}
 
-	refreshed, err := requestOpenAICodexTokenRefresh(ctx, client, tokens.RefreshToken)
+	refreshed, err := requestOpenAICodexTokenRefresh(ctx, client, state.tokens.RefreshToken)
 	if err != nil {
 		return openAICodexCredentials{}, err
 	}
 	if strings.TrimSpace(refreshed.AccessToken) != "" {
-		tokens.AccessToken = refreshed.AccessToken
+		state.tokens.AccessToken = refreshed.AccessToken
 	}
 	if strings.TrimSpace(refreshed.IDToken) != "" {
-		tokens.IDToken = refreshed.IDToken
+		state.tokens.IDToken = refreshed.IDToken
 	}
 	if strings.TrimSpace(refreshed.RefreshToken) != "" {
-		tokens.RefreshToken = refreshed.RefreshToken
+		state.tokens.RefreshToken = refreshed.RefreshToken
 	}
-	if strings.TrimSpace(tokens.AccessToken) == "" {
+	if strings.TrimSpace(state.tokens.AccessToken) == "" {
 		return openAICodexCredentials{}, fmt.Errorf("OpenAI Codex token refresh returned no access_token")
 	}
 
-	if err := a.write(state.raw, tokens); err != nil {
-		return openAICodexCredentials{}, err
+	refreshedAt := time.Now().UTC()
+	state = openAICodexStateWithTokens(state, state.tokens, refreshedAt)
+	shared.state = openAICodexCloneStatePtr(&state)
+	if err := a.write(state.raw, state.tokens, refreshedAt); err != nil {
+		return openAICodexCredentialsFromTokens(state.tokens), nil
 	}
-	return openAICodexCredentialsFromTokens(tokens), nil
+	return openAICodexCredentialsFromTokens(state.tokens), nil
+}
+
+func (a *openAICodexAuth) loadState(shared *openAICodexAuthSharedState, now time.Time) (openAICodexAuthState, error) {
+	diskState, err := a.read()
+	cachedState := openAICodexCloneStatePtr(shared.state)
+	if err != nil {
+		if cachedState != nil {
+			return *cachedState, nil
+		}
+		return openAICodexAuthState{}, err
+	}
+
+	state := openAICodexPreferState(diskState, cachedState, now)
+	shared.state = openAICodexCloneStatePtr(&state)
+	return state, nil
+}
+
+func (a *openAICodexAuth) sharedState() *openAICodexAuthSharedState {
+	key := openAICodexAuthPathKey(a.path)
+	if shared, ok := openAICodexAuthSharedStates.Load(key); ok {
+		return shared.(*openAICodexAuthSharedState)
+	}
+	shared := &openAICodexAuthSharedState{}
+	actual, _ := openAICodexAuthSharedStates.LoadOrStore(key, shared)
+	return actual.(*openAICodexAuthSharedState)
+}
+
+func openAICodexAuthPathKey(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}
+
+func openAICodexPreferState(diskState openAICodexAuthState, cachedState *openAICodexAuthState, now time.Time) openAICodexAuthState {
+	if cachedState == nil {
+		return openAICodexCloneState(diskState)
+	}
+
+	diskNeedsRefresh := openAICodexNeedsRefresh(diskState.tokens.AccessToken, diskState.lastRefresh, now)
+	cachedNeedsRefresh := openAICodexNeedsRefresh(cachedState.tokens.AccessToken, cachedState.lastRefresh, now)
+	if diskNeedsRefresh && !cachedNeedsRefresh {
+		return openAICodexCloneState(*cachedState)
+	}
+	if !diskNeedsRefresh && cachedNeedsRefresh {
+		return openAICodexCloneState(diskState)
+	}
+	if !diskNeedsRefresh && !cachedNeedsRefresh {
+		return openAICodexCloneState(diskState)
+	}
+	if openAICodexLastRefreshUnix(cachedState.lastRefresh) > openAICodexLastRefreshUnix(diskState.lastRefresh) {
+		return openAICodexCloneState(*cachedState)
+	}
+	return openAICodexCloneState(diskState)
+}
+
+func openAICodexLastRefreshUnix(lastRefresh *time.Time) int64 {
+	if lastRefresh == nil {
+		return 0
+	}
+	return lastRefresh.UTC().UnixNano()
+}
+
+func openAICodexStateWithTokens(state openAICodexAuthState, tokens openAICodexTokenData, refreshedAt time.Time) openAICodexAuthState {
+	updated := openAICodexCloneState(state)
+	updated.tokens = tokens
+	refreshedAt = refreshedAt.UTC()
+	updated.lastRefresh = &refreshedAt
+	if updated.raw == nil {
+		updated.raw = map[string]json.RawMessage{}
+	}
+	if tokensRaw, err := json.Marshal(tokens); err == nil {
+		updated.raw["tokens"] = tokensRaw
+	}
+	if lastRefreshRaw, err := json.Marshal(refreshedAt.Format(time.RFC3339)); err == nil {
+		updated.raw["last_refresh"] = lastRefreshRaw
+	}
+	return updated
+}
+
+func openAICodexCloneStatePtr(state *openAICodexAuthState) *openAICodexAuthState {
+	if state == nil {
+		return nil
+	}
+	cloned := openAICodexCloneState(*state)
+	return &cloned
+}
+
+func openAICodexCloneState(state openAICodexAuthState) openAICodexAuthState {
+	cloned := openAICodexAuthState{
+		raw:    openAICodexCloneRaw(state.raw),
+		tokens: state.tokens,
+	}
+	if state.lastRefresh != nil {
+		refreshedAt := state.lastRefresh.UTC()
+		cloned.lastRefresh = &refreshedAt
+	}
+	return cloned
+}
+
+func openAICodexCloneRaw(raw map[string]json.RawMessage) map[string]json.RawMessage {
+	if raw == nil {
+		return nil
+	}
+	cloned := make(map[string]json.RawMessage, len(raw))
+	for key, value := range raw {
+		if value == nil {
+			cloned[key] = nil
+			continue
+		}
+		copied := make(json.RawMessage, len(value))
+		copy(copied, value)
+		cloned[key] = copied
+	}
+	return cloned
 }
 
 func (a *openAICodexAuth) read() (openAICodexAuthState, error) {
@@ -143,14 +272,17 @@ func (a *openAICodexAuth) read() (openAICodexAuthState, error) {
 	return openAICodexAuthState{raw: raw, tokens: tokens, lastRefresh: lastRefresh}, nil
 }
 
-func (a *openAICodexAuth) write(raw map[string]json.RawMessage, tokens openAICodexTokenData) error {
+func (a *openAICodexAuth) write(raw map[string]json.RawMessage, tokens openAICodexTokenData, refreshedAt time.Time) error {
 	tokensRaw, err := json.Marshal(tokens)
 	if err != nil {
 		return fmt.Errorf("marshal refreshed OpenAI Codex tokens: %w", err)
 	}
-	lastRefreshRaw, err := json.Marshal(time.Now().UTC().Format(time.RFC3339))
+	lastRefreshRaw, err := json.Marshal(refreshedAt.UTC().Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("marshal OpenAI Codex last_refresh: %w", err)
+	}
+	if raw == nil {
+		raw = map[string]json.RawMessage{}
 	}
 	raw["tokens"] = tokensRaw
 	raw["last_refresh"] = lastRefreshRaw

--- a/proxy/openai_codex_auth_test.go
+++ b/proxy/openai_codex_auth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -263,6 +264,145 @@ func TestOpenAICodexAuthCredentialsRefreshesExpiredToken(t *testing.T) {
 	}
 	if state.lastRefresh.Before(before) || state.lastRefresh.After(after) {
 		t.Fatalf("last_refresh = %v, want between %v and %v", state.lastRefresh, before, after)
+	}
+}
+
+func TestOpenAICodexAuthCredentialsSharesRefreshAcrossInstances(t *testing.T) {
+	oldTokens := testOpenAICodexTokens(t, time.Now().Add(-time.Hour), "acct-123", false, "old-refresh")
+	newAccessToken := testOpenAICodexJWT(t, map[string]interface{}{"exp": time.Now().Add(time.Hour).Unix()})
+	newIDToken := testOpenAICodexJWT(t, map[string]interface{}{
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id":         "acct-123",
+			"chatgpt_account_is_fedramp": true,
+		},
+	})
+
+	var refreshCalls atomic.Int32
+	firstRequestSeen := make(chan struct{})
+	allowFirstResponse := make(chan struct{}, 1)
+	refreshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := refreshCalls.Add(1)
+		if call == 1 {
+			close(firstRequestSeen)
+			<-allowFirstResponse
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  newAccessToken,
+			"id_token":      newIDToken,
+			"refresh_token": "new-refresh",
+		})
+	}))
+	defer refreshServer.Close()
+	t.Setenv(openAICodexRefreshURLEnv, refreshServer.URL)
+
+	authPath := writeTestOpenAICodexAuth(t, t.TempDir(), oldTokens)
+	authA := &openAICodexAuth{path: authPath}
+	authB := &openAICodexAuth{path: authPath}
+
+	type result struct {
+		credentials openAICodexCredentials
+		err         error
+	}
+	results := make(chan result, 2)
+
+	go func() {
+		credentials, err := authA.credentials(context.Background(), refreshServer.Client())
+		results <- result{credentials: credentials, err: err}
+	}()
+
+	select {
+	case <-firstRequestSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first refresh request")
+	}
+
+	go func() {
+		credentials, err := authB.credentials(context.Background(), refreshServer.Client())
+		results <- result{credentials: credentials, err: err}
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	if got := refreshCalls.Load(); got != 1 {
+		t.Fatalf("refreshCalls before releasing first response = %d, want 1", got)
+	}
+	allowFirstResponse <- struct{}{}
+
+	for i := 0; i < 2; i++ {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("credentials() error = %v", result.err)
+		}
+		if result.credentials.accessToken != newAccessToken {
+			t.Fatalf("accessToken = %q, want refreshed token", result.credentials.accessToken)
+		}
+	}
+
+	if got := refreshCalls.Load(); got != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", got)
+	}
+
+	state, err := (&openAICodexAuth{path: authPath}).read()
+	if err != nil {
+		t.Fatalf("read() error = %v", err)
+	}
+	if state.tokens.AccessToken != newAccessToken || state.tokens.IDToken != newIDToken || state.tokens.RefreshToken != "new-refresh" {
+		t.Fatalf("tokens were not persisted after shared refresh: %+v", state.tokens)
+	}
+}
+
+func TestOpenAICodexAuthCredentialsUsesCachedRefreshWhenPersistFails(t *testing.T) {
+	oldTokens := testOpenAICodexTokens(t, time.Now().Add(-time.Hour), "acct-123", false, "old-refresh")
+	newAccessToken := testOpenAICodexJWT(t, map[string]interface{}{"exp": time.Now().Add(time.Hour).Unix()})
+
+	var refreshCalls atomic.Int32
+	refreshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  newAccessToken,
+			"refresh_token": "new-refresh",
+		})
+	}))
+	defer refreshServer.Close()
+	t.Setenv(openAICodexRefreshURLEnv, refreshServer.URL)
+
+	authPath := writeTestOpenAICodexAuth(t, t.TempDir(), oldTokens)
+	if err := os.Mkdir(authPath+".tmp", 0o700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	authA := &openAICodexAuth{path: authPath}
+	credentialsA, err := authA.credentials(context.Background(), refreshServer.Client())
+	if err != nil {
+		t.Fatalf("credentials() error = %v", err)
+	}
+	if credentialsA.accessToken != newAccessToken {
+		t.Fatalf("accessToken = %q, want refreshed token", credentialsA.accessToken)
+	}
+	if got := refreshCalls.Load(); got != 1 {
+		t.Fatalf("refreshCalls after first refresh = %d, want 1", got)
+	}
+
+	state, err := (&openAICodexAuth{path: authPath}).read()
+	if err != nil {
+		t.Fatalf("read() error = %v", err)
+	}
+	if state.tokens.AccessToken != oldTokens.AccessToken || state.tokens.RefreshToken != oldTokens.RefreshToken {
+		t.Fatalf("expected auth.json to remain stale after persistence failure: %+v", state.tokens)
+	}
+	if state.lastRefresh != nil {
+		t.Fatalf("lastRefresh = %v, want nil after persistence failure", state.lastRefresh)
+	}
+
+	authB := &openAICodexAuth{path: authPath}
+	credentialsB, err := authB.credentials(context.Background(), refreshServer.Client())
+	if err != nil {
+		t.Fatalf("second credentials() error = %v", err)
+	}
+	if credentialsB.accessToken != newAccessToken {
+		t.Fatalf("second accessToken = %q, want refreshed token", credentialsB.accessToken)
+	}
+	if got := refreshCalls.Load(); got != 1 {
+		t.Fatalf("refreshCalls after cached lookup = %d, want 1", got)
 	}
 }
 

--- a/proxy/openai_codex_auth_test.go
+++ b/proxy/openai_codex_auth_test.go
@@ -1,0 +1,348 @@
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testOpenAICodexJWT(t testing.TB, claims map[string]interface{}) string {
+	t.Helper()
+
+	header, err := json.Marshal(map[string]string{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal jwt header: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal jwt payload: %v", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func testOpenAICodexTokens(t testing.TB, accessExp time.Time, accountID string, fedRAMP bool, refreshToken string) openAICodexTokenData {
+	t.Helper()
+
+	accessClaims := map[string]interface{}{"exp": accessExp.Unix()}
+	idClaims := map[string]interface{}{
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id":         accountID,
+			"chatgpt_account_is_fedramp": fedRAMP,
+		},
+	}
+
+	return openAICodexTokenData{
+		IDToken:      testOpenAICodexJWT(t, idClaims),
+		AccessToken:  testOpenAICodexJWT(t, accessClaims),
+		RefreshToken: refreshToken,
+		AccountID:    accountID,
+	}
+}
+
+func testOpenAICodexOpaqueTokens(t testing.TB, accessToken, accountID string, fedRAMP bool, refreshToken string) openAICodexTokenData {
+	t.Helper()
+
+	idClaims := map[string]interface{}{
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id":         accountID,
+			"chatgpt_account_is_fedramp": fedRAMP,
+		},
+	}
+
+	return openAICodexTokenData{
+		IDToken:      testOpenAICodexJWT(t, idClaims),
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		AccountID:    accountID,
+	}
+}
+
+func writeTestOpenAICodexAuth(t testing.TB, codexHome string, tokens openAICodexTokenData) string {
+	t.Helper()
+	return writeTestOpenAICodexAuthWithLastRefresh(t, codexHome, tokens, nil)
+}
+
+func writeTestOpenAICodexAuthWithLastRefresh(t testing.TB, codexHome string, tokens openAICodexTokenData, lastRefresh *time.Time) string {
+	t.Helper()
+
+	if err := os.MkdirAll(codexHome, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	body := map[string]interface{}{
+		"auth_mode": "chatgpt",
+		"tokens":    tokens,
+	}
+	if lastRefresh != nil {
+		body["last_refresh"] = lastRefresh.UTC().Format(time.RFC3339)
+	}
+
+	encoded, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent() error = %v", err)
+	}
+
+	authPath := filepath.Join(codexHome, "auth.json")
+	if err := os.WriteFile(authPath, append(encoded, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return authPath
+}
+
+func TestOpenAICodexAuthCredentialsUsesValidAuthJSON(t *testing.T) {
+	t.Parallel()
+
+	authPath := writeTestOpenAICodexAuth(
+		t,
+		t.TempDir(),
+		testOpenAICodexTokens(t, time.Now().Add(time.Hour), "acct-123", true, "refresh-token"),
+	)
+
+	credentials, err := (&openAICodexAuth{path: authPath}).credentials(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("credentials() error = %v", err)
+	}
+	if credentials.accessToken == "" {
+		t.Fatal("expected access token")
+	}
+	if credentials.accountID != "acct-123" {
+		t.Fatalf("accountID = %q, want acct-123", credentials.accountID)
+	}
+	if !credentials.fedRAMP {
+		t.Fatal("expected fedRAMP true")
+	}
+}
+
+func TestOpenAICodexNeedsRefreshUsesJWTExpiryWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	staleRefresh := now.Add(-(openAICodexRefreshInterval + time.Hour))
+	recentRefresh := now.Add(-time.Hour)
+
+	tests := []struct {
+		name        string
+		accessToken string
+		lastRefresh *time.Time
+		want        bool
+	}{
+		{
+			name:        "fresh jwt ignores stale last_refresh",
+			accessToken: testOpenAICodexJWT(t, map[string]interface{}{"exp": now.Add(time.Hour).Unix()}),
+			lastRefresh: &staleRefresh,
+			want:        false,
+		},
+		{
+			name:        "expiring jwt refreshes even with recent last_refresh",
+			accessToken: testOpenAICodexJWT(t, map[string]interface{}{"exp": now.Add(openAICodexRefreshSkew / 2).Unix()}),
+			lastRefresh: &recentRefresh,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := openAICodexNeedsRefresh(tt.accessToken, tt.lastRefresh, now); got != tt.want {
+				t.Fatalf("openAICodexNeedsRefresh() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAICodexNeedsRefreshFallsBackToLastRefreshForOpaqueTokens(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	recentRefresh := now.Add(-time.Hour)
+	staleRefresh := now.Add(-(openAICodexRefreshInterval + time.Hour))
+
+	tests := []struct {
+		name        string
+		lastRefresh *time.Time
+		want        bool
+	}{
+		{
+			name:        "missing last_refresh",
+			lastRefresh: nil,
+			want:        true,
+		},
+		{
+			name:        "recent last_refresh",
+			lastRefresh: &recentRefresh,
+			want:        false,
+		},
+		{
+			name:        "stale last_refresh",
+			lastRefresh: &staleRefresh,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := openAICodexNeedsRefresh("opaque-access-token", tt.lastRefresh, now); got != tt.want {
+				t.Fatalf("openAICodexNeedsRefresh() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAICodexAuthCredentialsRefreshesExpiredToken(t *testing.T) {
+	oldTokens := testOpenAICodexTokens(t, time.Now().Add(-time.Hour), "acct-123", false, "old-refresh")
+	newAccessToken := testOpenAICodexJWT(t, map[string]interface{}{"exp": time.Now().Add(time.Hour).Unix()})
+	newIDToken := testOpenAICodexJWT(t, map[string]interface{}{
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id":         "acct-456",
+			"chatgpt_account_is_fedramp": true,
+		},
+	})
+
+	refreshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("refresh method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode refresh request: %v", err)
+		}
+		if req["client_id"] != openAICodexClientID {
+			t.Fatalf("client_id = %q, want %q", req["client_id"], openAICodexClientID)
+		}
+		if req["grant_type"] != "refresh_token" {
+			t.Fatalf("grant_type = %q, want refresh_token", req["grant_type"])
+		}
+		if req["refresh_token"] != "old-refresh" {
+			t.Fatalf("refresh_token = %q, want old-refresh", req["refresh_token"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  newAccessToken,
+			"id_token":      newIDToken,
+			"refresh_token": "new-refresh",
+		})
+	}))
+	defer refreshServer.Close()
+	t.Setenv(openAICodexRefreshURLEnv, refreshServer.URL)
+
+	authPath := writeTestOpenAICodexAuth(t, t.TempDir(), oldTokens)
+	before := time.Now().Add(-time.Second)
+	credentials, err := (&openAICodexAuth{path: authPath}).credentials(context.Background(), refreshServer.Client())
+	if err != nil {
+		t.Fatalf("credentials() error = %v", err)
+	}
+	after := time.Now().Add(time.Second)
+	if credentials.accessToken != newAccessToken {
+		t.Fatalf("accessToken was not refreshed")
+	}
+	if credentials.accountID != "acct-123" {
+		t.Fatalf("accountID = %q, want existing account_id acct-123", credentials.accountID)
+	}
+	if !credentials.fedRAMP {
+		t.Fatal("expected refreshed id_token fedRAMP true")
+	}
+
+	state, err := (&openAICodexAuth{path: authPath}).read()
+	if err != nil {
+		t.Fatalf("read() error = %v", err)
+	}
+	if state.tokens.AccessToken != newAccessToken || state.tokens.IDToken != newIDToken || state.tokens.RefreshToken != "new-refresh" {
+		t.Fatalf("tokens were not persisted after refresh: %+v", state.tokens)
+	}
+	if state.lastRefresh == nil {
+		t.Fatal("expected last_refresh to be persisted after refresh")
+	}
+	if state.lastRefresh.Before(before) || state.lastRefresh.After(after) {
+		t.Fatalf("last_refresh = %v, want between %v and %v", state.lastRefresh, before, after)
+	}
+}
+
+func TestOpenAICodexAuthCredentialsRefreshesOpaqueTokenWhenLastRefreshMissing(t *testing.T) {
+	oldTokens := testOpenAICodexOpaqueTokens(t, "opaque-access-token", "acct-123", false, "old-refresh")
+	newAccessToken := testOpenAICodexJWT(t, map[string]interface{}{"exp": time.Now().Add(time.Hour).Unix()})
+
+	refreshCalls := 0
+	refreshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshCalls++
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token": newAccessToken,
+		})
+	}))
+	defer refreshServer.Close()
+	t.Setenv(openAICodexRefreshURLEnv, refreshServer.URL)
+
+	authPath := writeTestOpenAICodexAuth(t, t.TempDir(), oldTokens)
+	credentials, err := (&openAICodexAuth{path: authPath}).credentials(context.Background(), refreshServer.Client())
+	if err != nil {
+		t.Fatalf("credentials() error = %v", err)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", refreshCalls)
+	}
+	if credentials.accessToken != newAccessToken {
+		t.Fatalf("accessToken = %q, want refreshed token", credentials.accessToken)
+	}
+
+	state, err := (&openAICodexAuth{path: authPath}).read()
+	if err != nil {
+		t.Fatalf("read() error = %v", err)
+	}
+	if state.lastRefresh == nil {
+		t.Fatal("expected last_refresh to be written after opaque-token refresh")
+	}
+}
+
+func TestOpenAICodexAuthCredentialsUsesOpaqueTokenWhenLastRefreshRecent(t *testing.T) {
+	recentRefresh := time.Now().Add(-time.Hour)
+	tokens := testOpenAICodexOpaqueTokens(t, "opaque-access-token", "acct-123", true, "refresh-token")
+	authPath := writeTestOpenAICodexAuthWithLastRefresh(t, t.TempDir(), tokens, &recentRefresh)
+
+	refreshCalls := 0
+	refreshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshCalls++
+		t.Fatalf("unexpected refresh request for recent opaque token")
+	}))
+	defer refreshServer.Close()
+	t.Setenv(openAICodexRefreshURLEnv, refreshServer.URL)
+
+	credentials, err := (&openAICodexAuth{path: authPath}).credentials(context.Background(), refreshServer.Client())
+	if err != nil {
+		t.Fatalf("credentials() error = %v", err)
+	}
+	if refreshCalls != 0 {
+		t.Fatalf("refreshCalls = %d, want 0", refreshCalls)
+	}
+	if credentials.accessToken != "opaque-access-token" {
+		t.Fatalf("accessToken = %q, want original opaque-access-token", credentials.accessToken)
+	}
+	if credentials.accountID != "acct-123" {
+		t.Fatalf("accountID = %q, want acct-123", credentials.accountID)
+	}
+	if !credentials.fedRAMP {
+		t.Fatal("expected fedRAMP true")
+	}
+}
+
+func TestOpenAICodexAuthCredentialsRejectsNonChatGPTAuth(t *testing.T) {
+	t.Parallel()
+
+	codexHome := t.TempDir()
+	authPath := filepath.Join(codexHome, "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"auth_mode":"apikey","tokens":null}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := (&openAICodexAuth{path: authPath}).credentials(context.Background(), nil)
+	if err == nil {
+		t.Fatal("credentials() error = nil, want auth_mode error")
+	}
+}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -18,9 +18,11 @@ type providerType string
 const (
 	providerTypeCopilot     providerType = "copilot"
 	providerTypeAzureOpenAI providerType = "azure-openai"
+	providerTypeOpenAICodex providerType = "openai-codex"
 )
 
 var defaultStaticProviderEndpoints = []string{"/chat/completions", "/responses"}
+var openAICodexProviderEndpoints = []string{"/responses"}
 
 // ProvidersConfig configures optional non-Copilot upstream providers.
 // When empty, the proxy keeps its legacy zero-config Copilot behavior.
@@ -33,6 +35,7 @@ type ProviderConfig struct {
 	ID            string                `json:"id"`
 	Type          string                `json:"type"`
 	Default       bool                  `json:"default,omitempty"`
+	IncludeModels []string              `json:"include_models,omitempty"`
 	ExcludeModels []string              `json:"exclude_models,omitempty"`
 	BaseURL       string                `json:"base_url,omitempty"`
 	APIKey        string                `json:"api_key,omitempty"`
@@ -63,10 +66,12 @@ type providerRuntime struct {
 	baseURL       string
 	apiKey        string
 	apiVersion    string
+	includeModels map[string]struct{}
 	excludeModels map[string]struct{}
 	staticModels  map[string]providerModel
 	staticConfigs map[string]ProviderModelConfig
 	staticOrder   []string
+	codexAuth     *openAICodexAuth
 }
 
 type providerModel struct {
@@ -91,6 +96,30 @@ type providerModelsFetchResult struct {
 	models      []providerModel
 	etag        string
 	notModified bool
+}
+
+type openAICodexReasoningPreset struct {
+	Effort string `json:"effort"`
+}
+
+type openAICodexModelPayload struct {
+	Slug                        string                       `json:"slug"`
+	DisplayName                 string                       `json:"display_name"`
+	Description                 string                       `json:"description"`
+	Visibility                  string                       `json:"visibility"`
+	SupportedInAPI              bool                         `json:"supported_in_api"`
+	Priority                    int                          `json:"priority"`
+	SupportedReasoningLevels    []openAICodexReasoningPreset `json:"supported_reasoning_levels"`
+	SupportsParallelToolCalls   bool                         `json:"supports_parallel_tool_calls"`
+	SupportsImageDetailOriginal bool                         `json:"supports_image_detail_original"`
+	SupportsReasoningSummaries  bool                         `json:"supports_reasoning_summaries"`
+	SupportVerbosity            bool                         `json:"support_verbosity"`
+	ContextWindow               int64                        `json:"context_window"`
+	InputModalities             []string                     `json:"input_modalities"`
+	ExperimentalSupportedTools  []string                     `json:"experimental_supported_tools"`
+	BaseInstructions            string                       `json:"base_instructions"`
+	ShellType                   string                       `json:"shell_type"`
+	DefaultReasoningLevel       string                       `json:"default_reasoning_level"`
 }
 
 type providerRequestError struct {
@@ -158,6 +187,7 @@ func defaultProviderSetup(h *ProxyHandler) *providerSetup {
 				kind:          providerTypeCopilot,
 				isDefault:     true,
 				baseURL:       strings.TrimRight(h.copilotURL, "/"),
+				includeModels: map[string]struct{}{},
 				excludeModels: map[string]struct{}{},
 				staticModels:  map[string]providerModel{},
 			},
@@ -217,13 +247,29 @@ func (ps *providerSetup) replaceProviderModels(providerID string, models []provi
 
 	for _, model := range models {
 		if existing, exists := next[model.publicID]; exists && existing.providerID != model.providerID {
-			return fmt.Errorf("model %q is exposed by both provider %q and provider %q", model.publicID, existing.providerID, model.providerID)
+			return providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
 		}
 		next[model.publicID] = model
 	}
 
 	ps.models = next
 	return nil
+}
+
+func (ps *providerSetup) modelsForProvider(providerID string) []providerModel {
+	if ps == nil {
+		return nil
+	}
+	ps.modelsMu.RLock()
+	defer ps.modelsMu.RUnlock()
+
+	models := make([]providerModel, 0)
+	for _, model := range ps.models {
+		if model.providerID == providerID {
+			models = append(models, model)
+		}
+	}
+	return models
 }
 
 func (h *ProxyHandler) initializeProviders() error {
@@ -253,17 +299,17 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 		hasConfiguredState: true,
 	}
 
-	needsDynamicModelValidation := false
-	for _, provider := range providers {
-		if provider.kind == providerTypeCopilot && len(providers) > 1 {
-			needsDynamicModelValidation = true
-			break
-		}
-	}
+	needsDynamicModelValidation := len(providers) > 1 && hasDynamicProvider(providers)
 
 	if !needsDynamicModelValidation {
 		for _, provider := range providers {
 			for publicID, model := range provider.staticModels {
+				if existing, exists := setup.models[publicID]; exists {
+					if existing.providerID == model.providerID {
+						continue
+					}
+					return nil, providerModelCollisionError(publicID, existing.providerID, model.providerID)
+				}
 				setup.models[publicID] = model
 			}
 		}
@@ -279,10 +325,10 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 
 	for _, providerID := range providerOrder {
 		provider := providers[providerID]
-		if provider.kind != providerTypeCopilot {
+		if !providerUsesDynamicModels(provider) {
 			for publicID, model := range provider.staticModels {
 				if existing, exists := setup.models[publicID]; exists {
-					return nil, fmt.Errorf("model %q is exposed by both provider %q and provider %q", publicID, existing.providerID, model.providerID)
+					return nil, providerModelCollisionError(publicID, existing.providerID, model.providerID)
 				}
 				setup.models[publicID] = model
 			}
@@ -298,7 +344,7 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 				if existing.providerID == model.providerID {
 					continue
 				}
-				return nil, fmt.Errorf("model %q is exposed by both provider %q and provider %q", model.publicID, existing.providerID, model.providerID)
+				return nil, providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
 			}
 			setup.models[model.publicID] = model
 		}
@@ -374,8 +420,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 
 	kind := providerType(strings.TrimSpace(cfg.Type))
 	switch kind {
-	case providerTypeCopilot:
-	case providerTypeAzureOpenAI:
+	case providerTypeCopilot, providerTypeAzureOpenAI, providerTypeOpenAICodex:
 	default:
 		return nil, fmt.Errorf("provider %q has unsupported type %q", id, cfg.Type)
 	}
@@ -384,9 +429,17 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 		id:            id,
 		kind:          kind,
 		isDefault:     cfg.Default,
+		includeModels: make(map[string]struct{}, len(cfg.IncludeModels)),
 		excludeModels: make(map[string]struct{}, len(cfg.ExcludeModels)),
 		staticModels:  make(map[string]providerModel, len(cfg.Models)),
 		staticConfigs: make(map[string]ProviderModelConfig, len(cfg.Models)),
+	}
+
+	for _, included := range cfg.IncludeModels {
+		included = strings.TrimSpace(included)
+		if included != "" {
+			runtime.includeModels[included] = struct{}{}
+		}
 	}
 
 	for _, excluded := range cfg.ExcludeModels {
@@ -428,7 +481,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 			if err != nil {
 				return nil, err
 			}
-			if _, excluded := runtime.excludeModels[model.publicID]; excluded {
+			if !runtime.allowsModel(model.publicID) {
 				continue
 			}
 			if _, exists := runtime.staticModels[model.publicID]; exists {
@@ -438,9 +491,67 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 			runtime.staticConfigs[model.publicID] = normalizeProviderModelConfig(modelCfg)
 			runtime.staticOrder = append(runtime.staticOrder, model.publicID)
 		}
+	case providerTypeOpenAICodex:
+		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+		if baseURL == "" {
+			baseURL = defaultOpenAICodexBaseURL
+		}
+		if err := validateGenericProviderBaseURL(id, "OpenAI Codex", baseURL); err != nil {
+			return nil, err
+		}
+		codexAuth, err := newOpenAICodexAuth()
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", id, err)
+		}
+		runtime.baseURL = baseURL
+		runtime.codexAuth = codexAuth
 	}
 
 	return runtime, nil
+}
+
+func hasDynamicProvider(providers map[string]*providerRuntime) bool {
+	for _, provider := range providers {
+		if providerUsesDynamicModels(provider) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerUsesDynamicModels(provider *providerRuntime) bool {
+	if provider == nil {
+		return false
+	}
+	return provider.kind == providerTypeCopilot || provider.kind == providerTypeOpenAICodex
+}
+
+func (p *providerRuntime) allowsModel(model string) bool {
+	if p == nil {
+		return true
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	if len(p.includeModels) > 0 {
+		if _, included := p.includeModels[model]; !included {
+			return false
+		}
+	}
+	if _, excluded := p.excludeModels[model]; excluded {
+		return false
+	}
+	return true
+}
+
+func providerModelCollisionError(publicID, existingProviderID, incomingProviderID string) error {
+	return fmt.Errorf(
+		"model %q is exposed by both provider %q and provider %q; resolve by adding include_models to the dynamic provider or exclude_models to one provider",
+		publicID,
+		existingProviderID,
+		incomingProviderID,
+	)
 }
 
 func buildStaticProviderModel(providerID string, cfg ProviderModelConfig) (providerModel, error) {
@@ -673,6 +784,18 @@ func classifyAzureBaseURL(baseURL string) azureBaseURLKind {
 	}
 }
 
+func validateGenericProviderBaseURL(providerID, label, baseURL string) error {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("provider %q has unsupported %s base_url %q: expected an absolute URL with no query string or fragment", providerID, label, baseURL)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Contains(trimmed, "#") {
+		return fmt.Errorf("provider %q has unsupported %s base_url %q: expected an absolute URL with no query string or fragment", providerID, label, baseURL)
+	}
+	return nil
+}
+
 func appendQuery(parts ...string) string {
 	combined := ""
 	for _, part := range parts {
@@ -715,6 +838,22 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 		h.setCopilotHeaders(req, token)
 	case providerTypeAzureOpenAI:
 		req.Header.Set("api-key", provider.apiKey)
+		req.Header.Set("Content-Type", "application/json")
+	case providerTypeOpenAICodex:
+		if provider.codexAuth == nil {
+			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no OpenAI Codex auth configured", provider.id)}
+		}
+		credentials, err := provider.codexAuth.credentials(req.Context(), h.client)
+		if err != nil {
+			return &providerRequestError{statusCode: http.StatusInternalServerError, err: err}
+		}
+		req.Header.Set("Authorization", "Bearer "+credentials.accessToken)
+		if credentials.accountID != "" {
+			req.Header.Set("ChatGPT-Account-ID", credentials.accountID)
+		}
+		if credentials.fedRAMP {
+			req.Header.Set("X-OpenAI-Fedramp", "true")
+		}
 		req.Header.Set("Content-Type", "application/json")
 	default:
 		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("unsupported provider type %q", provider.kind)}
@@ -774,7 +913,7 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 			return providerModelsFetchResult{models: models}, nil
 		}
 
-		overlayModels, err := decodeProviderModelsFromBody(provider.id, body, provider.excludeModels)
+		overlayModels, err := decodeProviderModelsFromBody(provider, body)
 		if err != nil {
 			return providerModelsFetchResult{models: models}, nil
 		}
@@ -830,7 +969,48 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 			return providerModelsFetchResult{}, err
 		}
 
-		models, err := decodeProviderModelsFromBody(provider.id, body, provider.excludeModels)
+		models, err := decodeProviderModelsFromBody(provider, body)
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+		result.models = models
+		return result, nil
+	case providerTypeOpenAICodex:
+		modelsQuery := openAICodexModelsRawQuery(rawQuery)
+		resp, err := h.doWithRetry(func() (*http.Request, error) {
+			req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, modelsQuery)
+			if err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(ifNoneMatch) != "" {
+				req.Header.Set("If-None-Match", ifNoneMatch)
+			}
+			return req, nil
+		})
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		result := providerModelsFetchResult{etag: resp.Header.Get("ETag")}
+		if resp.StatusCode == http.StatusNotModified {
+			result.notModified = true
+			return result, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			return providerModelsFetchResult{}, &providerRequestError{
+				statusCode: resp.StatusCode,
+				err:        fmt.Errorf("unexpected /models status %d: %s", resp.StatusCode, string(body)),
+			}
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+
+		models, err := decodeOpenAICodexModelsFromBody(provider, body)
 		if err != nil {
 			return providerModelsFetchResult{}, err
 		}
@@ -1025,7 +1205,11 @@ func copyRawField(dst, src map[string]json.RawMessage, field string) {
 	dst[field] = append(json.RawMessage(nil), value...)
 }
 
-func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[string]struct{}) ([]providerModel, error) {
+func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]providerModel, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is required")
+	}
+
 	var upstream struct {
 		Data []json.RawMessage `json:"data"`
 	}
@@ -1050,7 +1234,7 @@ func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[s
 		if publicID == "" {
 			continue
 		}
-		if _, skip := excluded[publicID]; skip {
+		if !provider.allowsModel(publicID) {
 			continue
 		}
 
@@ -1073,7 +1257,7 @@ func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[s
 		models = append(models, providerModel{
 			publicID:           publicID,
 			upstreamModel:      publicID,
-			providerID:         providerID,
+			providerID:         provider.id,
 			supportedEndpoints: supportedEndpoints,
 			disabled:           disabled,
 			raw:                mergeProviderModelRaw(raw, supportedEndpoints),
@@ -1081,6 +1265,154 @@ func decodeProviderModelsFromBody(providerID string, body []byte, excluded map[s
 	}
 
 	return models, nil
+}
+
+func decodeOpenAICodexModelsFromBody(provider *providerRuntime, body []byte) ([]providerModel, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is required")
+	}
+
+	var upstream struct {
+		Models []json.RawMessage `json:"models"`
+	}
+	if err := json.Unmarshal(body, &upstream); err != nil {
+		return nil, err
+	}
+
+	models := make([]providerModel, 0, len(upstream.Models))
+	seen := make(map[string]struct{}, len(upstream.Models))
+	for _, raw := range upstream.Models {
+		var parsed openAICodexModelPayload
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			continue
+		}
+
+		publicID := strings.TrimSpace(parsed.Slug)
+		if publicID == "" {
+			continue
+		}
+		if _, duplicate := seen[publicID]; duplicate {
+			continue
+		}
+		visibilityList := strings.EqualFold(strings.TrimSpace(parsed.Visibility), "list")
+		if !parsed.SupportedInAPI || !visibilityList {
+			continue
+		}
+		if !provider.allowsModel(publicID) {
+			continue
+		}
+
+		modelRaw, err := synthesizeOpenAICodexModelRaw(provider.id, parsed)
+		if err != nil {
+			return nil, err
+		}
+
+		seen[publicID] = struct{}{}
+		models = append(models, providerModel{
+			publicID:           publicID,
+			upstreamModel:      publicID,
+			providerID:         provider.id,
+			supportedEndpoints: append([]string(nil), openAICodexProviderEndpoints...),
+			raw:                modelRaw,
+		})
+	}
+
+	return models, nil
+}
+
+func synthesizeOpenAICodexModelRaw(providerID string, parsed openAICodexModelPayload) (json.RawMessage, error) {
+	reasoningEffort := make([]string, 0, len(parsed.SupportedReasoningLevels))
+	for _, level := range parsed.SupportedReasoningLevels {
+		effort := strings.TrimSpace(level.Effort)
+		if effort != "" {
+			reasoningEffort = append(reasoningEffort, effort)
+		}
+	}
+
+	name := strings.TrimSpace(parsed.DisplayName)
+	if name == "" {
+		name = strings.TrimSpace(parsed.Slug)
+	}
+
+	vision := parsed.SupportsImageDetailOriginal
+	for _, modality := range parsed.InputModalities {
+		if strings.EqualFold(strings.TrimSpace(modality), "image") {
+			vision = true
+			break
+		}
+	}
+
+	modelPickerCategory := "versatile"
+	switch {
+	case parsed.Priority <= 0:
+		modelPickerCategory = "powerful"
+	case parsed.Priority >= 8:
+		modelPickerCategory = "lightweight"
+	}
+
+	payload := map[string]interface{}{
+		"id":                    parsed.Slug,
+		"object":                "model",
+		"created":               0,
+		"owned_by":              providerID,
+		"name":                  name,
+		"supported_endpoints":   openAICodexProviderEndpoints,
+		"model_picker_enabled":  parsed.SupportedInAPI && strings.EqualFold(strings.TrimSpace(parsed.Visibility), "list"),
+		"model_picker_category": modelPickerCategory,
+		"capabilities": map[string]interface{}{
+			"limits": map[string]interface{}{
+				"max_context_window_tokens": parsed.ContextWindow,
+			},
+			"supports": map[string]interface{}{
+				"parallel_tool_calls": parsed.SupportsParallelToolCalls,
+				"reasoning_effort":    reasoningEffort,
+				"vision":              vision,
+			},
+		},
+		"slug":                           parsed.Slug,
+		"display_name":                   name,
+		"description":                    parsed.Description,
+		"visibility":                     parsed.Visibility,
+		"supported_in_api":               parsed.SupportedInAPI,
+		"priority":                       parsed.Priority,
+		"supports_reasoning_summaries":   parsed.SupportsReasoningSummaries,
+		"support_verbosity":              parsed.SupportVerbosity,
+		"supports_parallel_tool_calls":   parsed.SupportsParallelToolCalls,
+		"supports_image_detail_original": parsed.SupportsImageDetailOriginal,
+		"context_window":                 parsed.ContextWindow,
+		"input_modalities":               parsed.InputModalities,
+		"experimental_supported_tools":   parsed.ExperimentalSupportedTools,
+		"base_instructions":              parsed.BaseInstructions,
+		"shell_type":                     parsed.ShellType,
+		"default_reasoning_level":        strings.TrimSpace(parsed.DefaultReasoningLevel),
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal OpenAI Codex model %q for provider %q: %w", parsed.Slug, providerID, err)
+	}
+	return raw, nil
+}
+
+func openAICodexModelsRawQuery(rawQuery string) string {
+	rawQuery = strings.TrimSpace(strings.TrimPrefix(rawQuery, "?"))
+	if rawQueryHasParam(rawQuery, "client_version") {
+		return rawQuery
+	}
+	return appendQuery(rawQuery, "client_version="+url.QueryEscape(defaultOpenAICodexClientVersion))
+}
+
+func rawQueryHasParam(rawQuery, name string) bool {
+	rawQuery = strings.TrimSpace(strings.TrimPrefix(rawQuery, "?"))
+	if rawQuery == "" {
+		return false
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return strings.Contains(rawQuery, url.QueryEscape(name)+"=") || strings.Contains(rawQuery, name+"=")
+	}
+	_, ok := values[name]
+	return ok
 }
 
 func normalizeDynamicProviderEndpoints(endpoints []string) []string {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -159,6 +160,98 @@ func TestBuildProvidersAzureLegacyBaseURLAccepted(t *testing.T) {
 	}
 	if provider.baseURL != "https://example.openai.azure.com/openai" {
 		t.Fatalf("provider.baseURL = %q, want Azure /openai endpoint", provider.baseURL)
+	}
+}
+
+func TestBuildConfiguredProviderSetupRejectsStaticModelCollision(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	_, err := handler.buildConfiguredProviderSetup(context.Background(), ProvidersConfig{
+		Providers: []ProviderConfig{
+			{
+				ID:      "azure-a",
+				Type:    "azure-openai",
+				Default: true,
+				BaseURL: "https://a.openai.azure.com/openai/v1",
+				APIKey:  "test-key-a",
+				Models: []ProviderModelConfig{{
+					PublicID: "gpt-5.4",
+				}},
+			},
+			{
+				ID:      "azure-b",
+				Type:    "azure-openai",
+				BaseURL: "https://b.openai.azure.com/openai/v1",
+				APIKey:  "test-key-b",
+				Models: []ProviderModelConfig{{
+					PublicID: "gpt-5.4",
+				}},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("buildConfiguredProviderSetup() error = nil, want model collision")
+	}
+	if !strings.Contains(err.Error(), "gpt-5.4") || !strings.Contains(err.Error(), "azure-a") || !strings.Contains(err.Error(), "azure-b") {
+		t.Fatalf("expected static collision details, got %v", err)
+	}
+}
+
+func TestBuildProvidersOpenAICodexDefaultBaseURLAndFilters(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	providers, _, defaultProviderID, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:            "codex",
+			Type:          "openai-codex",
+			Default:       true,
+			IncludeModels: []string{"gpt-5.5"},
+			ExcludeModels: []string{"gpt-5.4"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	if defaultProviderID != "codex" {
+		t.Fatalf("default provider = %q, want codex", defaultProviderID)
+	}
+
+	provider := providers["codex"]
+	if provider == nil {
+		t.Fatal("expected codex provider to be built")
+	}
+	if provider.baseURL != defaultOpenAICodexBaseURL {
+		t.Fatalf("provider.baseURL = %q, want %q", provider.baseURL, defaultOpenAICodexBaseURL)
+	}
+	if !provider.allowsModel("gpt-5.5") {
+		t.Fatal("expected include_models to allow gpt-5.5")
+	}
+	if provider.allowsModel("gpt-5.4") {
+		t.Fatal("expected exclude_models to block gpt-5.4")
+	}
+	if provider.allowsModel("gpt-other") {
+		t.Fatal("expected include_models to block gpt-other")
+	}
+}
+
+func TestBuildProvidersOpenAICodexMalformedBaseURLRejected(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	_, _, _, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:      "codex",
+			Type:    "openai-codex",
+			BaseURL: "https://chatgpt.com/backend-api/codex?client_version=1.0.0",
+		}},
+	})
+	if err == nil {
+		t.Fatal("buildProviders() error = nil, want malformed OpenAI Codex base_url error")
+	}
+	if !strings.Contains(err.Error(), "no query string or fragment") {
+		t.Fatalf("buildProviders() error = %v, want query/fragment guidance", err)
 	}
 }
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -15,7 +15,17 @@ import (
 func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 	var headers http.Header
 
-	for _, name := range []string{"X-OpenAI-Subagent", "OpenAI-Beta", "session_id", "X-Client-Request-Id"} {
+	for _, name := range []string{
+		"X-OpenAI-Subagent",
+		"OpenAI-Beta",
+		"session_id",
+		"X-Client-Request-Id",
+		"X-Codex-Beta-Features",
+		"X-Codex-Turn-State",
+		"X-Codex-Turn-Metadata",
+		"X-Codex-Parent-Thread-Id",
+		"X-Codex-Window-Id",
+	} {
 		for _, value := range r.Header.Values(name) {
 			if trimmed := strings.TrimSpace(value); trimmed != "" {
 				if headers == nil {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -123,6 +123,12 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 	if provider == nil {
 		return nil, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
 	}
+	if !providerSupportsEndpoint(provider, endpoint) {
+		return nil, nil, &providerRequestError{
+			statusCode: http.StatusBadRequest,
+			err:        fmt.Errorf("provider %q does not support %s", provider.id, endpoint),
+		}
+	}
 	if known && !providerModelSupportsEndpoint(owner, endpoint) {
 		return nil, nil, &providerRequestError{
 			statusCode: http.StatusBadRequest,
@@ -135,6 +141,16 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 		return nil, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 	}
 	return provider, rewrittenBody, nil
+}
+
+func providerSupportsEndpoint(provider *providerRuntime, endpoint string) bool {
+	if provider == nil {
+		return false
+	}
+	if provider.kind == providerTypeOpenAICodex {
+		return supportsEndpoint(openAICodexProviderEndpoints, endpoint)
+	}
+	return true
 }
 
 func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body []byte) (*http.Response, error) {

--- a/scripts/live-cli-smoke.sh
+++ b/scripts/live-cli-smoke.sh
@@ -241,6 +241,7 @@ EOF
     GOOGLE_GEMINI_BASE_URL="${PROXY_BASE_URL}" \
     GOOGLE_GENAI_API_VERSION=v1beta \
     GEMINI_CLI_NO_RELAUNCH=true \
+    GEMINI_CLI_TRUST_WORKSPACE=true \
     gemini \
       -m "${GEMINI_MODEL}" \
       -p "${PROMPT}" \


### PR DESCRIPTION
## Summary
- add an OpenAI Codex provider that loads auth from `~/.codex/auth.json`, refreshes access tokens, and forwards Codex requests with the expected headers
- route Codex models through `/responses`, improve dynamic `/models` discovery plus `include_models` filtering/collision errors, and add coverage for the new provider paths
- update README/docs to position vekil as a multi-provider proxy and document Codex setup and client usage

## Testing
- `go test ./...`