### PR TITLE
fix: strip unsupported image_generation tools for Azure responses

### DIFF
--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -385,7 +385,10 @@ func extractResponsesOutputText(body []byte) (string, error) {
 }
 
 func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint string, injectResumePrompt bool) []byte {
-	if rewrittenBody, strippedFields := stripUnsupportedResponsesRequestFields(bodyBytes); len(strippedFields) > 0 {
+	requestedModel := extractResponsesRequestModel(bodyBytes)
+	provider, _, _ := h.resolveProviderModel(requestedModel, "/responses")
+
+	if rewrittenBody, strippedFields := stripUnsupportedResponsesRequestFields(bodyBytes, provider); len(strippedFields) > 0 {
 		bodyBytes = rewrittenBody
 		h.log.Debug("stripped unsupported responses request fields",
 			logger.F("endpoint", endpoint),
@@ -416,8 +419,110 @@ func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint st
 	return bodyBytes
 }
 
-func stripUnsupportedResponsesRequestFields(bodyBytes []byte) ([]byte, []string) {
-	return bodyBytes, nil
+func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *providerRuntime) ([]byte, []string) {
+	if provider == nil {
+		return bodyBytes, nil
+	}
+
+	unsupportedToolTypes := unsupportedResponsesToolTypes(provider)
+	if len(unsupportedToolTypes) == 0 {
+		return bodyBytes, nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+		return bodyBytes, nil
+	}
+
+	rawTools, ok := payload["tools"]
+	if !ok {
+		return bodyBytes, nil
+	}
+
+	var tools []json.RawMessage
+	if err := json.Unmarshal(rawTools, &tools); err != nil {
+		return bodyBytes, nil
+	}
+
+	filteredTools := make([]json.RawMessage, 0, len(tools))
+	strippedFields := make([]string, 0, len(tools)+1)
+	strippedToolTypes := make(map[string]struct{})
+	for i, rawTool := range tools {
+		toolType := responsesToolType(rawTool)
+		if _, unsupported := unsupportedToolTypes[toolType]; unsupported {
+			strippedFields = append(strippedFields, fmt.Sprintf("tools[%d]", i))
+			strippedToolTypes[toolType] = struct{}{}
+			continue
+		}
+		filteredTools = append(filteredTools, rawTool)
+	}
+
+	if len(strippedFields) == 0 {
+		return bodyBytes, nil
+	}
+
+	rewrittenTools, err := json.Marshal(filteredTools)
+	if err != nil {
+		return bodyBytes, nil
+	}
+	payload["tools"] = rewrittenTools
+
+	if rawToolChoice, ok := payload["tool_choice"]; ok {
+		if _, stripped := stripUnsupportedResponsesToolChoice(rawToolChoice, len(filteredTools) == 0, strippedToolTypes); stripped {
+			delete(payload, "tool_choice")
+			strippedFields = append(strippedFields, "tool_choice")
+		}
+	}
+
+	rewrittenBody, err := json.Marshal(payload)
+	if err != nil {
+		return bodyBytes, nil
+	}
+
+	return rewrittenBody, strippedFields
+}
+
+func unsupportedResponsesToolTypes(provider *providerRuntime) map[string]struct{} {
+	if provider == nil {
+		return nil
+	}
+
+	switch provider.kind {
+	case providerTypeCopilot, providerTypeAzureOpenAI:
+		return map[string]struct{}{
+			"image_generation": {},
+		}
+	default:
+		return nil
+	}
+}
+
+func responsesToolType(rawTool json.RawMessage) string {
+	var tool struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(rawTool, &tool); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(tool.Type)
+}
+
+func stripUnsupportedResponsesToolChoice(rawToolChoice json.RawMessage, noRemainingTools bool, strippedToolTypes map[string]struct{}) (json.RawMessage, bool) {
+	if noRemainingTools {
+		return nil, true
+	}
+
+	var toolChoiceString string
+	if err := json.Unmarshal(rawToolChoice, &toolChoiceString); err == nil {
+		return rawToolChoice, false
+	}
+
+	toolType := responsesToolType(rawToolChoice)
+	if _, unsupported := strippedToolTypes[toolType]; unsupported {
+		return nil, true
+	}
+
+	return rawToolChoice, false
 }
 
 func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, bodyBytes []byte, extraHeaders http.Header) (*http.Response, error) {

--- a/proxy/upstream_http_test.go
+++ b/proxy/upstream_http_test.go
@@ -135,6 +135,141 @@ func TestResolveProviderRequest_RejectsKnownModelWithoutEndpointSupport(t *testi
 	}
 }
 
+func TestResponsesRequestRewriting_StripsUnsupportedImageGenerationToolForAzure(t *testing.T) {
+	handler := newProviderRoutingTestHandler(t, []string{"/responses"})
+	originalBody := []byte(`{"model":"gpt-5-public","input":"hello","tools":[{"type":"function","name":"lookup_weather","description":"Lookup the weather","parameters":{"type":"object","properties":{}}},{"type":"image_generation"}],"tool_choice":"auto"}`)
+
+	rewrittenForResponses := handler.rewriteResponsesRequestBody(originalBody, "responses", true)
+	provider, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
+	if err != nil {
+		t.Fatalf("resolveProviderRequest() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("resolveProviderRequest() provider = nil, want azure provider")
+	}
+	if provider.kind != providerTypeAzureOpenAI {
+		t.Fatalf("resolveProviderRequest() provider.kind = %q, want %q", provider.kind, providerTypeAzureOpenAI)
+	}
+	if got := extractResponsesRequestModel(rewrittenBody); got != "gpt-5-4-prod" {
+		t.Fatalf("rewritten model = %q, want gpt-5-4-prod", got)
+	}
+
+	payload := decodeResponsesRequestPayload(t, rewrittenBody)
+	tools := decodeResponsesRequestTools(t, payload)
+	if len(tools) != 1 {
+		t.Fatalf("len(tools) = %d, want 1 after stripping unsupported tools", len(tools))
+	}
+	if tools[0].Type != "function" {
+		t.Fatalf("tools[0].Type = %q, want function", tools[0].Type)
+	}
+	if tools[0].Name != "lookup_weather" {
+		t.Fatalf("tools[0].Name = %q, want lookup_weather", tools[0].Name)
+	}
+
+	rawToolChoice, ok := payload["tool_choice"]
+	if !ok {
+		t.Fatal("rewritten payload missing tool_choice")
+	}
+	var toolChoice string
+	if err := json.Unmarshal(rawToolChoice, &toolChoice); err != nil {
+		t.Fatalf("json.Unmarshal(tool_choice) error = %v", err)
+	}
+	if toolChoice != "auto" {
+		t.Fatalf("tool_choice = %q, want auto", toolChoice)
+	}
+}
+
+func TestResponsesRequestRewriting_StripsUnsupportedImageGenerationToolForDefaultCopilot(t *testing.T) {
+	handler := newTestProxyHandler(t, func(http.ResponseWriter, *http.Request) {})
+	originalBody := []byte(`{"model":"gpt-5.4","input":"hello","tools":[{"type":"image_generation"}],"tool_choice":"required"}`)
+
+	rewrittenForResponses := handler.rewriteResponsesRequestBody(originalBody, "responses", true)
+	provider, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
+	if err != nil {
+		t.Fatalf("resolveProviderRequest() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("resolveProviderRequest() provider = nil, want default copilot provider")
+	}
+	if provider.kind != providerTypeCopilot {
+		t.Fatalf("resolveProviderRequest() provider.kind = %q, want %q", provider.kind, providerTypeCopilot)
+	}
+	if provider.id != "copilot" {
+		t.Fatalf("resolveProviderRequest() provider.id = %q, want copilot", provider.id)
+	}
+	if got := extractResponsesRequestModel(rewrittenBody); got != "gpt-5.4" {
+		t.Fatalf("rewritten model = %q, want gpt-5.4", got)
+	}
+
+	payload := decodeResponsesRequestPayload(t, rewrittenBody)
+	tools := decodeResponsesRequestTools(t, payload)
+	if len(tools) != 0 {
+		t.Fatalf("len(tools) = %d, want 0 after stripping unsupported tools", len(tools))
+	}
+	if _, ok := payload["tool_choice"]; ok {
+		t.Fatalf("rewritten payload unexpectedly retained tool_choice: %s", payload["tool_choice"])
+	}
+}
+
+func TestResponsesRequestRewriting_StripsUnsupportedImageGenerationToolChoiceForAzure(t *testing.T) {
+	handler := newProviderRoutingTestHandler(t, []string{"/responses"})
+	originalBody := []byte(`{"model":"gpt-5-public","input":"hello","tools":[{"type":"function","name":"lookup_weather","description":"Lookup the weather","parameters":{"type":"object","properties":{}}},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
+
+	rewrittenForResponses := handler.rewriteResponsesRequestBody(originalBody, "responses", true)
+	provider, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
+	if err != nil {
+		t.Fatalf("resolveProviderRequest() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("resolveProviderRequest() provider = nil, want azure provider")
+	}
+	if provider.kind != providerTypeAzureOpenAI {
+		t.Fatalf("resolveProviderRequest() provider.kind = %q, want %q", provider.kind, providerTypeAzureOpenAI)
+	}
+
+	payload := decodeResponsesRequestPayload(t, rewrittenBody)
+	tools := decodeResponsesRequestTools(t, payload)
+	if len(tools) != 1 {
+		t.Fatalf("len(tools) = %d, want 1 after stripping unsupported tools", len(tools))
+	}
+	if tools[0].Type != "function" {
+		t.Fatalf("tools[0].Type = %q, want function", tools[0].Type)
+	}
+	if _, ok := payload["tool_choice"]; ok {
+		t.Fatalf("rewritten payload unexpectedly retained tool_choice: %s", payload["tool_choice"])
+	}
+}
+
+type responsesRequestTool struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+func decodeResponsesRequestPayload(t *testing.T, body []byte) map[string]json.RawMessage {
+	t.Helper()
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(body) error = %v", err)
+	}
+	return payload
+}
+
+func decodeResponsesRequestTools(t *testing.T, payload map[string]json.RawMessage) []responsesRequestTool {
+	t.Helper()
+
+	rawTools, ok := payload["tools"]
+	if !ok {
+		return nil
+	}
+
+	var tools []responsesRequestTool
+	if err := json.Unmarshal(rawTools, &tools); err != nil {
+		t.Fatalf("json.Unmarshal(tools) error = %v", err)
+	}
+	return tools
+}
+
 func TestRewriteRequestModelForProvider_RewritesGenericJSONModelAndNoopsWhenUnchanged(t *testing.T) {
 	originalBody := []byte(`{"model":"gpt-5-public","messages":[{"role":"user","content":"hello"}]}`)
 


### PR DESCRIPTION
## Summary
- strip unsupported `image_generation` tools from `/responses` requests for Azure OpenAI the same way Copilot already does
- remove `tool_choice` when it references a stripped `image_generation` tool or when no tools remain after stripping
- add Azure coverage for tool stripping and `tool_choice` cleanup

## Testing
- `go test ./proxy -run 'TestResponsesRequestRewriting|TestResolveProviderRequest|TestRewriteRequestModelForProvider'`\n- `go test ./...`\n- live end-to-end validation against a local mock Azure `/openai/v1/responses` upstream and built proxy