### PR TITLE
Add YAML provider config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Vekil.app/
 .build/
 .DS_Store
 providers.json
+providers.yaml
+providers.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,12 @@ Documentation update rules:
 
 | Package | Purpose |
 |---------|---------|
-| `main.go` | CLI entry, flags (including providers config), signal handling |
+| `main.go` | CLI entry, flags (including JSON/YAML providers config), signal handling |
 | `auth/` | GitHub OAuth device code flow and Copilot token caching/refresh (`sync.RWMutex` + double-check) |
 | `proxy/chat_handlers.go` | Anthropic and OpenAI chat handlers, including forced-streaming aggregation for tool calls |
 | `proxy/responses_handler.go` | OpenAI Responses passthrough plus Codex compatibility endpoints (`/v1/responses/compact`, `/v1/memories/trace_summarize`) |
 | `proxy/handler.go` | Shared proxy plumbing: health/ready/models handlers, request-body decoding, provider-aware model catalogs, provider headers, caches |
-| `proxy/providers.go` | Provider config loading, model ownership, Azure metadata overlay, endpoint allowlists, and routing state |
+| `proxy/providers.go` | JSON/YAML provider config loading, model ownership, Azure metadata overlay, endpoint allowlists, and routing state |
 | `proxy/upstream_http.go` | Provider selection, public→upstream model rewriting, and provider-specific upstream HTTP dispatch |
 | `proxy/openai_codex_auth.go` | OpenAI Codex CLI auth.json loading, refresh, and request credentials |
 | `proxy/gemini_handler.go` | Gemini-native HTTP handlers and countTokens probe flow |
@@ -69,7 +69,7 @@ Documentation update rules:
 ## Key Design Decisions
 
 - **No frameworks**: Pure `net/http` with Go 1.22+ `ServeMux` method routing. Do not add web frameworks.
-- **Vekil is a multi-provider proxy**: zero-config startup currently targets GitHub Copilot, but explicit provider configs can extend or replace that default behind the same public API surface.
+- **Vekil is a multi-provider proxy**: zero-config startup currently targets GitHub Copilot, but explicit JSON/YAML provider configs can extend or replace that default behind the same public API surface.
 - **Public model IDs are global across providers**: Model ownership is explicit and startup must fail on collisions rather than silently shadowing one provider with another.
 - **Forced streaming for reliable parallel tool calls**: Non-streaming requests with tools may be force-streamed upstream then aggregated back before returning to the client. This behavior started as an upstream compatibility workaround and still applies to provider-backed OpenAI chat handling.
 - **Gemini is a translation layer**: Gemini endpoints are implemented like Anthropic, not as zero-copy passthrough. Keep Gemini-specific protocol logic in `proxy/gemini*.go`.
@@ -79,7 +79,7 @@ Documentation update rules:
 - **Azure support is OpenAI-compatible provider routing, not a separate public surface**: Azure deployment names stay internal to provider config, and Azure `/models` probing is only a best-effort metadata overlay for configured models.
 - **OpenAI Codex support is file-auth-backed provider routing**: Codex models use the CLI ChatGPT auth file, dynamic `/models` discovery, and `/responses`-only routing.
 - **Proxy websocket bridging is not upstream realtime**: `GET /v1/responses` remains a proxy-owned websocket transport over upstream HTTP `/responses`. Do not describe it as native Azure websocket or `/realtime` support.
-- **Minimal dependencies**: Keep third-party deps minimal. Current non-stdlib dependencies used in production code are `systray`, `uuid`, and `klauspost/compress`.
+- **Minimal dependencies**: Keep third-party deps minimal. Current direct non-stdlib dependencies used in production code include `github.com/pkg/browser`, `fyne.io/systray`, `github.com/godbus/dbus/v5`, `github.com/google/uuid`, `github.com/gorilla/websocket`, `github.com/klauspost/compress`, and `gopkg.in/yaml.v3`.
 - **Distroless container**: Single static binary, `CGO_ENABLED=0`.
 
 ## Code Conventions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/vekil:latest
 ```
 
-For explicit provider routing, start the proxy with `--providers-config /path/to/providers.json`.
+For explicit provider routing, start the proxy with `--providers-config /path/to/providers.json` or `--providers-config /path/to/providers.yaml`.
 
 On Apple Silicon Macs, you can also use the native macOS tray app.
 

--- a/cmd/menubar/dialog_darwin.go
+++ b/cmd/menubar/dialog_darwin.go
@@ -36,7 +36,7 @@ func showErrorDialog(title, message string) {
 }
 
 func chooseProvidersConfigPath() (string, error) {
-	script := `POSIX path of (choose file with prompt "Choose a providers config JSON file")`
+	script := `POSIX path of (choose file with prompt "Choose a providers config JSON or YAML file")`
 	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
 	if err != nil {
 		if isOsascriptCancel(err, out) {

--- a/cmd/menubar/dialog_linux.go
+++ b/cmd/menubar/dialog_linux.go
@@ -112,7 +112,7 @@ func chooseProvidersConfigPath() (string, error) {
 		output, runErr := execCommand(zenity,
 			"--file-selection",
 			"--title=Choose Providers Config",
-			"--file-filter=JSON files | *.json",
+			"--file-filter=Provider config files | *.json *.yaml *.yml",
 			"--file-filter=All files | *",
 		).CombinedOutput()
 		if runErr == nil {
@@ -131,7 +131,7 @@ func chooseProvidersConfigPath() (string, error) {
 		output, runErr := execCommand(kdialog,
 			"--getopenfilename",
 			"",
-			"*.json|JSON files",
+			"*.json *.yaml *.yml|Provider config files",
 		).CombinedOutput()
 		if runErr == nil {
 			path := strings.TrimSpace(string(output))

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -66,7 +66,7 @@ func onReady() {
 
 	mProvidersStatus = systray.AddMenuItem("Providers: Copilot default", "")
 	mProvidersStatus.Disable()
-	mProvidersChoose = systray.AddMenuItem("Choose Providers Config…", "Select a providers JSON file")
+	mProvidersChoose = systray.AddMenuItem("Choose Providers Config…", "Select a providers JSON or YAML file")
 	mProvidersClear = systray.AddMenuItem("Use Default Copilot Routing", "Clear custom providers config")
 	systray.AddSeparator()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Vekil supports two runtime patterns:
 | `--port` | `PORT` | `1337` | Listen port |
 | `--host` | `HOST` | `0.0.0.0` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
-| `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON provider configuration for explicit provider routing |
+| `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
@@ -47,7 +47,7 @@ Azure OpenAI credentials are configured in the provider entry, using either `api
 
 ## Provider Routing
 
-Use `--providers-config` when you want explicit ownership of public model IDs across providers such as GitHub Copilot, Azure OpenAI, and OpenAI Codex.
+Use `--providers-config` when you want explicit ownership of public model IDs across providers such as GitHub Copilot, Azure OpenAI, and OpenAI Codex. Provider config files can be JSON (`.json`) or YAML (`.yaml`/`.yml`).
 
 You can run Azure-only or Codex-only configs, or mix those providers with Copilot behind the same local endpoint.
 
@@ -73,6 +73,23 @@ You can run Azure-only or Codex-only configs, or mix those providers with Copilo
     }
   ]
 }
+```
+
+The same config can be written as YAML:
+
+```yaml
+providers:
+  - id: azure-openai
+    type: azure-openai
+    default: true
+    base_url: https://myresource.cognitiveservices.azure.com/openai/v1
+    api_key_env: AZURE_OPENAI_API_KEY
+    models:
+      - public_id: gpt-5.4-pro
+        deployment: gpt-5.4-pro
+        endpoints:
+          - /responses
+        name: GPT-5.4 Pro
 ```
 
 ### Copilot + Azure Example
@@ -123,6 +140,19 @@ You can run Azure-only or Codex-only configs, or mix those providers with Copilo
 }
 ```
 
+The same Codex config can be written as YAML:
+
+```yaml
+providers:
+  - id: copilot
+    type: copilot
+    default: true
+  - id: openai-codex
+    type: openai-codex
+    include_models:
+      - gpt-5.5
+```
+
 Routing rules:
 
 - Clients keep using plain model IDs such as `gpt-5.4-pro`.
@@ -145,7 +175,7 @@ Routing rules:
 - Explicit `models[]` metadata overrides Azure `/models` overlay metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails or returns a sparse payload.
 - The example Azure `gpt-5.4-pro` model shown above is `/responses`-only. Do not advertise `/chat/completions` for that model unless you have verified native support.
 
-Use the JSON examples above as a starting point for your local providers config file.
+Use the examples above as a starting point for your local providers config file. JSON and YAML use the same snake_case field names.
 
 ## WebSocket Session Tuning
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/vekil:latest
 ```
 
-If you use explicit provider routing, mount your config file and pass `--providers-config`:
+If you use explicit provider routing, mount your JSON or YAML config file and pass `--providers-config`:
 
 ```bash
 docker run -p 1337:1337 \
@@ -114,7 +114,7 @@ If `HTTP_PROXY` or `HTTPS_PROXY` points at a local loopback proxy that is not ru
 
 ### Azure OpenAI
 
-Azure OpenAI credentials are configured per provider entry, usually with `api_key` or `api_key_env` in the providers JSON file. There is no separate interactive login flow in the proxy.
+Azure OpenAI credentials are configured per provider entry, usually with `api_key` or `api_key_env` in the providers config file. There is no separate interactive login flow in the proxy.
 
 ### OpenAI Codex
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -43,14 +43,14 @@ open "Vekil.app"
 - start/stop toggle from the tray menu
 - status icon: white robot when running, gray when stopped
 - current app version shown in the menu
-- choose and persist a `providers-config` JSON file from the menu
+- choose and persist a `providers-config` JSON or YAML file from the menu
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
 - `Check for Updates…` in packaged macOS app builds
 
 ## Providers Config
 
-Use `Choose Providers Config…` from the tray menu to select the same JSON file you would pass to the CLI with `--providers-config`.
+Use `Choose Providers Config…` from the tray menu to select the same JSON or YAML file you would pass to the CLI with `--providers-config`.
 
 - The app saves the selected path in its local app config so it is reused on the next launch and when started at login.
 - `Use Default Copilot Routing` clears the saved path and returns to zero-config startup, which currently uses the built-in Copilot provider.

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.18.4
+	gopkg.in/yaml.v3 v3.0.1
 )
+
 require golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,3 +13,7 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func runServe() {
 	port := flag.String("port", getEnv("PORT", "1337"), "Listen port")
 	host := flag.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
 	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	providersConfigPath := flag.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON provider configuration")
+	providersConfigPath := flag.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration")
 	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
 	streamingUpstreamTimeout := flag.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
 	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -171,6 +171,10 @@ func LoadProvidersConfigFile(path string) (ProvidersConfig, error) {
 }
 
 func decodeProvidersConfigFile(path string, body []byte, cfg *ProvidersConfig) error {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return fmt.Errorf("providers config %q is empty", path)
+	}
+
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".yaml", ".yml":
 		if err := yaml.Unmarshal(body, cfg); err != nil {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -9,8 +9,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+
+	"gopkg.in/yaml.v3"
 )
 
 type providerType string
@@ -27,36 +30,36 @@ var openAICodexProviderEndpoints = []string{"/responses"}
 // ProvidersConfig configures optional non-Copilot upstream providers.
 // When empty, the proxy keeps its legacy zero-config Copilot behavior.
 type ProvidersConfig struct {
-	Providers []ProviderConfig `json:"providers"`
+	Providers []ProviderConfig `json:"providers" yaml:"providers"`
 }
 
 // ProviderConfig configures one upstream provider instance.
 type ProviderConfig struct {
-	ID            string                `json:"id"`
-	Type          string                `json:"type"`
-	Default       bool                  `json:"default,omitempty"`
-	IncludeModels []string              `json:"include_models,omitempty"`
-	ExcludeModels []string              `json:"exclude_models,omitempty"`
-	BaseURL       string                `json:"base_url,omitempty"`
-	APIKey        string                `json:"api_key,omitempty"`
-	APIKeyEnv     string                `json:"api_key_env,omitempty"`
-	APIVersion    string                `json:"api_version,omitempty"`
-	Models        []ProviderModelConfig `json:"models,omitempty"`
+	ID            string                `json:"id" yaml:"id"`
+	Type          string                `json:"type" yaml:"type"`
+	Default       bool                  `json:"default,omitempty" yaml:"default,omitempty"`
+	IncludeModels []string              `json:"include_models,omitempty" yaml:"include_models,omitempty"`
+	ExcludeModels []string              `json:"exclude_models,omitempty" yaml:"exclude_models,omitempty"`
+	BaseURL       string                `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	APIKey        string                `json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	APIKeyEnv     string                `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
+	APIVersion    string                `json:"api_version,omitempty" yaml:"api_version,omitempty"`
+	Models        []ProviderModelConfig `json:"models,omitempty" yaml:"models,omitempty"`
 }
 
 // ProviderModelConfig maps a public model ID exposed by this proxy to the
 // upstream model or deployment name used by the provider.
 type ProviderModelConfig struct {
-	PublicID            string   `json:"public_id"`
-	Deployment          string   `json:"deployment,omitempty"`
-	Name                string   `json:"name,omitempty"`
-	Endpoints           []string `json:"endpoints,omitempty"`
-	ModelPickerEnabled  *bool    `json:"model_picker_enabled,omitempty"`
-	ModelPickerCategory string   `json:"model_picker_category,omitempty"`
-	ReasoningEffort     []string `json:"reasoning_effort,omitempty"`
-	Vision              *bool    `json:"vision,omitempty"`
-	ParallelToolCalls   *bool    `json:"parallel_tool_calls,omitempty"`
-	ContextWindow       *int64   `json:"context_window,omitempty"`
+	PublicID            string   `json:"public_id" yaml:"public_id"`
+	Deployment          string   `json:"deployment,omitempty" yaml:"deployment,omitempty"`
+	Name                string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Endpoints           []string `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
+	ModelPickerEnabled  *bool    `json:"model_picker_enabled,omitempty" yaml:"model_picker_enabled,omitempty"`
+	ModelPickerCategory string   `json:"model_picker_category,omitempty" yaml:"model_picker_category,omitempty"`
+	ReasoningEffort     []string `json:"reasoning_effort,omitempty" yaml:"reasoning_effort,omitempty"`
+	Vision              *bool    `json:"vision,omitempty" yaml:"vision,omitempty"`
+	ParallelToolCalls   *bool    `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
+	ContextWindow       *int64   `json:"context_window,omitempty" yaml:"context_window,omitempty"`
 }
 
 type providerRuntime struct {
@@ -161,10 +164,24 @@ func LoadProvidersConfigFile(path string) (ProvidersConfig, error) {
 	if err != nil {
 		return cfg, fmt.Errorf("read providers config %q: %w", path, err)
 	}
-	if err := json.Unmarshal(body, &cfg); err != nil {
-		return cfg, fmt.Errorf("decode providers config %q: %w", path, err)
+	if err := decodeProvidersConfigFile(path, body, &cfg); err != nil {
+		return cfg, err
 	}
 	return cfg, nil
+}
+
+func decodeProvidersConfigFile(path string, body []byte, cfg *ProvidersConfig) error {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(body, cfg); err != nil {
+			return fmt.Errorf("decode providers config %q as YAML: %w", path, err)
+		}
+	default:
+		if err := json.Unmarshal(body, cfg); err != nil {
+			return fmt.Errorf("decode providers config %q as JSON: %w", path, err)
+		}
+	}
+	return nil
 }
 
 func (c ProvidersConfig) UsesCopilot() bool {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -249,6 +249,73 @@ func TestLoadProvidersConfigFileYAML(t *testing.T) {
 	}
 }
 
+func TestLoadProvidersConfigFileRejectsEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		ext  string
+		body string
+	}{
+		{name: "empty JSON", ext: ".json", body: ""},
+		{name: "empty YAML", ext: ".yaml", body: ""},
+		{name: "whitespace YAML", ext: ".yml", body: " \n\t \n"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			providersPath := filepath.Join(t.TempDir(), "providers"+tc.ext)
+			if err := os.WriteFile(providersPath, []byte(tc.body), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			_, err := LoadProvidersConfigFile(providersPath)
+			if err == nil {
+				t.Fatal("LoadProvidersConfigFile() error = nil, want empty config error")
+			}
+			if !strings.Contains(err.Error(), "empty") {
+				t.Fatalf("LoadProvidersConfigFile() error = %v, want empty config error", err)
+			}
+		})
+	}
+}
+
+func TestLoadProvidersConfigFileAllowsExplicitEmptyProviders(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		ext  string
+		body string
+	}{
+		{name: "JSON", ext: ".json", body: `{"providers": []}`},
+		{name: "YAML", ext: ".yaml", body: "providers: []\n"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			providersPath := filepath.Join(t.TempDir(), "providers"+tc.ext)
+			if err := os.WriteFile(providersPath, []byte(tc.body), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			cfg, err := LoadProvidersConfigFile(providersPath)
+			if err != nil {
+				t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+			}
+			if len(cfg.Providers) != 0 {
+				t.Fatalf("providers count = %d, want 0", len(cfg.Providers))
+			}
+		})
+	}
+}
+
 func TestProviderRequestURLAzureLegacyBaseURLAppendsAPIVersion(t *testing.T) {
 	t.Parallel()
 

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -114,6 +114,141 @@ func TestLoadProvidersConfigFileAzureV1BaseURLAndModelMetadata(t *testing.T) {
 	}
 }
 
+func TestLoadProvidersConfigFileYAML(t *testing.T) {
+	t.Parallel()
+
+	for _, ext := range []string{".yaml", ".yml"} {
+		ext := ext
+		t.Run(ext, func(t *testing.T) {
+			t.Parallel()
+
+			providersPath := filepath.Join(t.TempDir(), "providers"+ext)
+			body := []byte(`providers:
+  - id: copilot
+    type: copilot
+    default: true
+    exclude_models:
+      - gpt-5.4-pro
+  - id: azure-openai
+    type: azure-openai
+    base_url: https://example.openai.azure.com/openai/v1
+    api_key: test-key
+    api_version: 2025-04-01-preview
+    models:
+      - public_id: gpt-5.4-pro
+        deployment: gpt-5.4-pro
+        endpoints:
+          - /responses
+        name: GPT-5.4 Pro
+        model_picker_enabled: false
+        model_picker_category: powerful
+        reasoning_effort:
+          - low
+          - medium
+          - high
+        vision: true
+        parallel_tool_calls: true
+        context_window: 400000
+  - id: openai-codex
+    type: openai-codex
+    include_models:
+      - gpt-5.5
+`)
+			if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			cfg, err := LoadProvidersConfigFile(providersPath)
+			if err != nil {
+				t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+			}
+
+			if len(cfg.Providers) != 3 {
+				t.Fatalf("providers count = %d, want 3", len(cfg.Providers))
+			}
+			if !cfg.Providers[0].Default {
+				t.Fatal("copilot default = false, want true")
+			}
+			if !reflect.DeepEqual(cfg.Providers[0].ExcludeModels, []string{"gpt-5.4-pro"}) {
+				t.Fatalf("exclude_models = %v, want [gpt-5.4-pro]", cfg.Providers[0].ExcludeModels)
+			}
+
+			provider := cfg.Providers[1]
+			if provider.ID != "azure-openai" || provider.Type != "azure-openai" {
+				t.Fatalf("provider = %#v, want azure-openai", provider)
+			}
+			if provider.BaseURL != "https://example.openai.azure.com/openai/v1" {
+				t.Fatalf("base_url = %q", provider.BaseURL)
+			}
+			if provider.APIKey != "test-key" {
+				t.Fatalf("api_key = %q, want test-key", provider.APIKey)
+			}
+			if provider.APIVersion != "2025-04-01-preview" {
+				t.Fatalf("api_version = %q, want 2025-04-01-preview", provider.APIVersion)
+			}
+			if len(provider.Models) != 1 {
+				t.Fatalf("models count = %d, want 1", len(provider.Models))
+			}
+
+			model := provider.Models[0]
+			if model.PublicID != "gpt-5.4-pro" || model.Deployment != "gpt-5.4-pro" {
+				t.Fatalf("model IDs = (%q, %q), want gpt-5.4-pro", model.PublicID, model.Deployment)
+			}
+			if !reflect.DeepEqual(model.Endpoints, []string{"/responses"}) {
+				t.Fatalf("endpoints = %v, want [/responses]", model.Endpoints)
+			}
+			if model.ModelPickerEnabled == nil || *model.ModelPickerEnabled {
+				t.Fatalf("model_picker_enabled = %v, want false", model.ModelPickerEnabled)
+			}
+			if model.ModelPickerCategory != "powerful" {
+				t.Fatalf("model_picker_category = %q, want powerful", model.ModelPickerCategory)
+			}
+			if !reflect.DeepEqual(model.ReasoningEffort, []string{"low", "medium", "high"}) {
+				t.Fatalf("reasoning_effort = %v, want [low medium high]", model.ReasoningEffort)
+			}
+			if model.Vision == nil || !*model.Vision {
+				t.Fatalf("vision = %v, want true", model.Vision)
+			}
+			if model.ParallelToolCalls == nil || !*model.ParallelToolCalls {
+				t.Fatalf("parallel_tool_calls = %v, want true", model.ParallelToolCalls)
+			}
+			if model.ContextWindow == nil || *model.ContextWindow != 400000 {
+				t.Fatalf("context_window = %v, want 400000", model.ContextWindow)
+			}
+
+			codexProvider := cfg.Providers[2]
+			if codexProvider.ID != "openai-codex" || codexProvider.Type != "openai-codex" {
+				t.Fatalf("codex provider = %#v, want openai-codex", codexProvider)
+			}
+			if !reflect.DeepEqual(codexProvider.IncludeModels, []string{"gpt-5.5"}) {
+				t.Fatalf("codex include_models = %v, want [gpt-5.5]", codexProvider.IncludeModels)
+			}
+
+			handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+			providers, _, defaultProviderID, err := handler.buildProviders(cfg)
+			if err != nil {
+				t.Fatalf("buildProviders() error = %v", err)
+			}
+			if defaultProviderID != "copilot" {
+				t.Fatalf("default provider = %q, want copilot", defaultProviderID)
+			}
+			codexRuntime := providers["openai-codex"]
+			if codexRuntime == nil {
+				t.Fatal("expected openai-codex provider to be built")
+			}
+			if codexRuntime.baseURL != defaultOpenAICodexBaseURL {
+				t.Fatalf("codex baseURL = %q, want %q", codexRuntime.baseURL, defaultOpenAICodexBaseURL)
+			}
+			if !codexRuntime.allowsModel("gpt-5.5") {
+				t.Fatal("expected YAML include_models to allow gpt-5.5")
+			}
+			if codexRuntime.allowsModel("gpt-5.4") {
+				t.Fatal("expected YAML include_models to block gpt-5.4")
+			}
+		})
+	}
+}
+
 func TestProviderRequestURLAzureLegacyBaseURLAppendsAPIVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add YAML provider config parsing for `.yaml` and `.yml` files while preserving JSON support
- add YAML struct tags, picker/help text updates, and YAML docs/examples
- add test coverage for YAML provider configs, Azure metadata, Codex defaults, and include-model filtering

## Tests
- go test ./... -count=1