### PR TITLE
Reuse GitHub CLI token for Copilot auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For explicit provider routing, start the proxy with `--providers-config /path/to
 
 **First-run auth** depends on your providers:
 
-- **Copilot** — kicks off GitHub's device code flow on first run.
+- **Copilot** — `vekil login` uses Vekil-managed GitHub device-code sign-in; first proxy startup starts the same flow when needed. To use your current GitHub CLI account instead, opt in with `vekil login --github-cli` (or `--gh`). `vekil logout` clears cached auth and disables future silent `gh` reuse until you opt in again. `COPILOT_GITHUB_TOKEN` remains the explicit non-interactive override.
 - **OpenAI Codex** — requires `codex login` so `~/.codex/auth.json` exists. In Docker, mount your Codex home into `CODEX_HOME` (default `/home/nonroot/.codex`).
 
 For full configuration and routing details, see [Getting Started](docs/getting-started.md) and [Configuration](docs/configuration.md).

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -421,7 +421,7 @@ func (a *Authenticator) RequestDeviceCode(ctx context.Context) (*DeviceCodeRespo
 	if err != nil {
 		return nil, fmt.Errorf("requesting device code: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var dcResp DeviceCodeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&dcResp); err != nil {
@@ -474,7 +474,7 @@ func (a *Authenticator) pollForAuthorization(ctx context.Context, dcResp *Device
 
 		var atResp AccessTokenResponse
 		respBody, _ := io.ReadAll(tokenResp.Body)
-		tokenResp.Body.Close()
+		_ = tokenResp.Body.Close()
 		if err := json.Unmarshal(respBody, &atResp); err != nil {
 			return fmt.Errorf("decoding access token response: %w (body: %s)", err, string(respBody))
 		}
@@ -514,7 +514,7 @@ func (a *Authenticator) deviceCodeFlow(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
+	_, _ = fmt.Fprintf(os.Stderr, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
 
 	return a.pollForAuthorization(ctx, dcResp)
 }
@@ -628,7 +628,7 @@ func (a *Authenticator) validateGitHubCLIToken(ctx context.Context, accessToken 
 	if err != nil {
 		return fmt.Errorf("validating github cli copilot access: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		detail := readGitHubAPIErrorDetail(resp.Body)
@@ -685,7 +685,7 @@ func (a *Authenticator) exchangeForCopilotToken(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("requesting copilot token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var ctResp CopilotTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ctResp); err != nil {

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -24,8 +24,10 @@ const (
 	deviceCodeURL         = "https://github.com/login/device/code"
 	accessTokenURL        = "https://github.com/login/oauth/access_token"
 	copilotTokenURL       = "https://api.github.com/copilot_internal/v2/token"
+	copilotUserURL        = "https://api.github.com/copilot_internal/user"
 	defaultTokenDir       = "~/.config/vekil"
 	githubCLITokenTimeout = 5 * time.Second
+	githubCLITokenTTL     = 15 * time.Minute
 	signedOutMarkerFile   = "signed-out"
 	authPreferencesFile   = "auth-preferences.json"
 )
@@ -93,6 +95,19 @@ type AccessTokenResponse struct {
 type CopilotTokenResponse struct {
 	Token        string `json:"token"`
 	ExpiresAt    int64  `json:"expires_at"`
+	ErrorDetails string `json:"error_details,omitempty"`
+}
+
+// CopilotUserResponse is the response from the Copilot user endpoint used to
+// validate GitHub CLI tokens. Only the fields needed for validation are modeled.
+type CopilotUserResponse struct {
+	Login       string `json:"login,omitempty"`
+	ChatEnabled *bool  `json:"chat_enabled,omitempty"`
+}
+
+type githubAPIErrorResponse struct {
+	Message      string `json:"message,omitempty"`
+	Status       string `json:"status,omitempty"`
 	ErrorDetails string `json:"error_details,omitempty"`
 }
 
@@ -366,15 +381,9 @@ func (a *Authenticator) refreshToken(ctx context.Context, allowDeviceFlow bool) 
 	// should be surfaced as-is.
 	if refreshErr == nil || IsInteractiveLoginRequired(refreshErr) {
 		if !a.hasSignedOutMarker() && a.isGitHubCLIAutoSignInEnabled() {
-			previousAccessToken := a.accessToken
-			if err := a.loadGitHubCLIAccessToken(ctx); err == nil {
-				if err := a.exchangeForCopilotToken(ctx); err == nil {
-					return nil
-				} else {
-					a.accessToken = previousAccessToken
-					refreshErr = err
-				}
-			} else if !errors.Is(err, ErrNotAuthenticated) && refreshErr == nil {
+			if err := a.useGitHubCLICopilotToken(ctx); err == nil {
+				return nil
+			} else if !errors.Is(err, ErrNotAuthenticated) || refreshErr == nil {
 				refreshErr = err
 			}
 		}
@@ -539,33 +548,26 @@ func (a *Authenticator) SignOut() error {
 }
 
 // SignInWithGitHubCLI explicitly signs in using the currently authenticated
-// GitHub CLI account. The GitHub CLI token is used only for the Copilot token
-// exchange and is never persisted as Vekil's access-token cache.
+// GitHub CLI account. The GitHub CLI token is kept only in memory as a
+// short-lived Copilot bearer token and is never persisted by Vekil.
 func (a *Authenticator) SignInWithGitHubCLI(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-
-	accessToken, err := a.gitHubCLIAccessToken(ctx)
-	if err != nil {
-		return err
-	}
 
 	previousAccessToken := a.accessToken
 	previousCopilotToken := a.copilotToken
 	previousTokenExpiry := a.tokenExpiry
 
-	a.accessToken = accessToken
-	a.copilotToken = ""
-	a.tokenExpiry = time.Time{}
-
-	if err := a.exchangeForCopilotToken(ctx); err != nil {
+	if err := a.useGitHubCLICopilotToken(ctx); err != nil {
 		a.accessToken = previousAccessToken
 		a.copilotToken = previousCopilotToken
 		a.tokenExpiry = previousTokenExpiry
 		return err
 	}
-	if err := os.Remove(filepath.Join(a.tokenDir, "access-token")); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing stale access token: %w", err)
+	for _, name := range []string{"access-token", "api-key.json"} {
+		if err := os.Remove(filepath.Join(a.tokenDir, name)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing stale %s: %w", name, err)
+		}
 	}
 	if err := a.clearSignedOutMarker(); err != nil {
 		return fmt.Errorf("clearing signed-out marker: %w", err)
@@ -582,6 +584,92 @@ func (a *Authenticator) getCopilotTokenURL() string {
 		return a.copilotBaseURL + "/copilot_internal/v2/token"
 	}
 	return copilotTokenURL
+}
+
+func (a *Authenticator) getCopilotUserURL() string {
+	if a.copilotBaseURL != "" {
+		return a.copilotBaseURL + "/copilot_internal/user"
+	}
+	return copilotUserURL
+}
+
+func (a *Authenticator) useGitHubCLICopilotToken(ctx context.Context) error {
+	accessToken, err := a.gitHubCLIAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := a.validateGitHubCLIToken(ctx, accessToken); err != nil {
+		return err
+	}
+
+	// GitHub CLI OAuth tokens are accepted directly by the Copilot API as bearer
+	// tokens. Keep them in memory only: do not persist them as Vekil-managed
+	// GitHub access tokens, do not write them to the Copilot token cache, and do
+	// not feed them through the legacy Copilot token exchange endpoint. Some
+	// GitHub CLI OAuth tokens can validate against Copilot but return 404 from
+	// that exchange.
+	a.accessToken = ""
+	a.copilotToken = accessToken
+	a.tokenExpiry = time.Now().Add(githubCLITokenTTL)
+	return nil
+}
+
+func (a *Authenticator) validateGitHubCLIToken(ctx context.Context, accessToken string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.getCopilotUserURL(), nil)
+	if err != nil {
+		return fmt.Errorf("creating copilot user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "GitHubCopilotChat/0.26.7")
+
+	resp, err := a.do(req)
+	if err != nil {
+		return fmt.Errorf("validating github cli copilot access: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		detail := readGitHubAPIErrorDetail(resp.Body)
+		if detail != "" {
+			detail = ": " + detail
+		}
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("%w: github cli token cannot access Copilot (status %d%s)", ErrInvalidAccessToken, resp.StatusCode, detail)
+		}
+		return fmt.Errorf("github cli copilot validation failed with status %d%s", resp.StatusCode, detail)
+	}
+
+	var user CopilotUserResponse
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return fmt.Errorf("decoding copilot user response: %w", err)
+	}
+	if user.ChatEnabled != nil && !*user.ChatEnabled {
+		return fmt.Errorf("%w: github cli account does not have Copilot Chat enabled", ErrInvalidAccessToken)
+	}
+	return nil
+}
+
+func readGitHubAPIErrorDetail(body io.Reader) string {
+	data, err := io.ReadAll(io.LimitReader(body, 4096))
+	if err != nil {
+		return ""
+	}
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return ""
+	}
+
+	var apiErr githubAPIErrorResponse
+	if err := json.Unmarshal(data, &apiErr); err == nil {
+		for _, detail := range []string{apiErr.ErrorDetails, apiErr.Message, apiErr.Status} {
+			if strings.TrimSpace(detail) != "" {
+				return strings.TrimSpace(detail)
+			}
+		}
+	}
+	return text
 }
 
 func (a *Authenticator) exchangeForCopilotToken(ctx context.Context) error {
@@ -843,15 +931,6 @@ func (a *Authenticator) clearSignedOutMarker() error {
 	if err := os.Remove(a.signedOutMarkerPath()); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	return nil
-}
-
-func (a *Authenticator) loadGitHubCLIAccessToken(ctx context.Context) error {
-	token, err := a.gitHubCLIAccessToken(ctx)
-	if err != nil {
-		return err
-	}
-	a.accessToken = token
 	return nil
 }
 

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -26,6 +26,8 @@ const (
 	copilotTokenURL       = "https://api.github.com/copilot_internal/v2/token"
 	defaultTokenDir       = "~/.config/vekil"
 	githubCLITokenTimeout = 5 * time.Second
+	signedOutMarkerFile   = "signed-out"
+	authPreferencesFile   = "auth-preferences.json"
 )
 
 var accessTokenEnvVars = []string{
@@ -94,6 +96,34 @@ type CopilotTokenResponse struct {
 	ErrorDetails string `json:"error_details,omitempty"`
 }
 
+// AuthPreferences stores explicit authentication preferences shared by the
+// CLI and menubar app.
+type AuthPreferences struct {
+	GitHubCLIAutoSignIn bool `json:"github_cli_auto_sign_in,omitempty"`
+}
+
+// AuthSource identifies the source of the currently usable authentication
+// state.
+type AuthSource string
+
+const (
+	AuthSourceNone      AuthSource = "none"
+	AuthSourceEnv       AuthSource = "env"
+	AuthSourceVekil     AuthSource = "vekil"
+	AuthSourceGitHubCLI AuthSource = "github-cli"
+)
+
+// AuthStatus is a fast snapshot of local authentication state. It never shells
+// out to external tools such as gh.
+type AuthStatus struct {
+	SignedIn             bool
+	Source               AuthSource
+	GitHubCLIAutoSignIn  bool
+	SignedOut            bool
+	HasValidCopilotCache bool
+	HasVekilAccessToken  bool
+}
+
 // NewAuthenticator creates an Authenticator that stores tokens in tokenDir.
 // If tokenDir is empty, it defaults to ~/.config/vekil.
 func NewAuthenticator(tokenDir string) (*Authenticator, error) {
@@ -117,22 +147,67 @@ func NewAuthenticator(tokenDir string) (*Authenticator, error) {
 	}, nil
 }
 
-// IsSignedIn reports whether the authenticator has a GitHub access token
-// either in memory or persisted on disk.
+// IsSignedIn reports whether the authenticator has a usable or explicitly
+// configured local authentication source.
 func (a *Authenticator) IsSignedIn() bool {
-	if token, _ := lookupAccessTokenFromEnv(); token != "" {
-		return true
+	return a.Status().SignedIn
+}
+
+// Status returns a fast snapshot of local authentication state without making
+// network requests or invoking external commands.
+func (a *Authenticator) Status() AuthStatus {
+	status := AuthStatus{
+		Source:              AuthSourceNone,
+		GitHubCLIAutoSignIn: a.isGitHubCLIAutoSignInEnabled(),
+		SignedOut:           a.hasSignedOutMarker(),
 	}
 
+	status.HasVekilAccessToken = a.hasAccessTokenOnDisk()
+	status.HasValidCopilotCache = a.hasValidCopilotTokenOnDisk()
+
 	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if a.accessToken != "" {
-		return true
+	memoryAccessToken := strings.TrimSpace(a.accessToken) != ""
+	memoryCopilotToken := a.copilotToken != "" && time.Now().Before(a.tokenExpiry)
+	a.mu.RUnlock()
+
+	if token, _ := lookupAccessTokenFromEnv(); token != "" {
+		status.SignedIn = true
+		status.Source = AuthSourceEnv
+		return status
 	}
-	if a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
-		return true
+
+	if status.HasVekilAccessToken {
+		status.SignedIn = true
+		status.Source = AuthSourceVekil
+		return status
 	}
-	return a.hasAccessTokenOnDisk() || a.hasValidCopilotTokenOnDisk()
+
+	if memoryAccessToken {
+		status.SignedIn = true
+		if status.GitHubCLIAutoSignIn && (memoryCopilotToken || status.HasValidCopilotCache) {
+			status.Source = AuthSourceGitHubCLI
+		} else {
+			status.Source = AuthSourceVekil
+		}
+		return status
+	}
+
+	if memoryCopilotToken || status.HasValidCopilotCache {
+		status.SignedIn = true
+		if status.GitHubCLIAutoSignIn {
+			status.Source = AuthSourceGitHubCLI
+		} else {
+			status.Source = AuthSourceVekil
+		}
+		return status
+	}
+
+	if status.GitHubCLIAutoSignIn && !status.SignedOut {
+		status.SignedIn = true
+		status.Source = AuthSourceGitHubCLI
+	}
+
+	return status
 }
 
 // hasAccessTokenOnDisk returns true when the access-token file exists and is
@@ -287,16 +362,21 @@ func (a *Authenticator) refreshToken(ctx context.Context, allowDeviceFlow bool) 
 	// If there is no Vekil-managed GitHub token, or the existing token is no
 	// longer usable, try borrowing the active GitHub CLI token before falling
 	// back to the interactive device-code flow. Do not do this after transient
-	// Copilot exchange failures; those should be surfaced as-is.
+	// Copilot exchange failures, or after an explicit Vekil sign-out; those
+	// should be surfaced as-is.
 	if refreshErr == nil || IsInteractiveLoginRequired(refreshErr) {
-		if err := a.loadGitHubCLIAccessToken(ctx); err == nil {
-			if err := a.exchangeForCopilotToken(ctx); err == nil {
-				return nil
-			} else {
+		if !a.hasSignedOutMarker() && a.isGitHubCLIAutoSignInEnabled() {
+			previousAccessToken := a.accessToken
+			if err := a.loadGitHubCLIAccessToken(ctx); err == nil {
+				if err := a.exchangeForCopilotToken(ctx); err == nil {
+					return nil
+				} else {
+					a.accessToken = previousAccessToken
+					refreshErr = err
+				}
+			} else if !errors.Is(err, ErrNotAuthenticated) && refreshErr == nil {
 				refreshErr = err
 			}
-		} else if !errors.Is(err, ErrNotAuthenticated) && refreshErr == nil {
-			refreshErr = err
 		}
 	}
 
@@ -396,7 +476,16 @@ func (a *Authenticator) pollForAuthorization(ctx context.Context, dcResp *Device
 			if err := a.saveAccessToken(); err != nil {
 				return fmt.Errorf("saving access token: %w", err)
 			}
-			return a.exchangeForCopilotToken(ctx)
+			if err := a.exchangeForCopilotToken(ctx); err != nil {
+				return err
+			}
+			if err := a.clearSignedOutMarker(); err != nil {
+				return fmt.Errorf("clearing signed-out marker: %w", err)
+			}
+			if err := a.setGitHubCLIAutoSignIn(false); err != nil {
+				return fmt.Errorf("saving auth preferences: %w", err)
+			}
+			return nil
 		case "authorization_pending":
 			continue
 		case "slow_down":
@@ -434,12 +523,57 @@ func (a *Authenticator) SignOut() error {
 	var errs []error
 	for _, name := range []string{"access-token", "api-key.json"} {
 		if err := os.Remove(filepath.Join(a.tokenDir, name)); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("remove %s: %w", name, err))
 		}
 	}
-	if len(errs) > 0 {
-		return fmt.Errorf("sign out cleanup: %v", errs)
+	if err := a.setGitHubCLIAutoSignIn(false); err != nil {
+		errs = append(errs, fmt.Errorf("writing auth preferences: %w", err))
 	}
+	if err := a.markSignedOut(); err != nil {
+		errs = append(errs, fmt.Errorf("writing signed-out marker: %w", err))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("sign out cleanup: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// SignInWithGitHubCLI explicitly signs in using the currently authenticated
+// GitHub CLI account. The GitHub CLI token is used only for the Copilot token
+// exchange and is never persisted as Vekil's access-token cache.
+func (a *Authenticator) SignInWithGitHubCLI(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	accessToken, err := a.gitHubCLIAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	previousAccessToken := a.accessToken
+	previousCopilotToken := a.copilotToken
+	previousTokenExpiry := a.tokenExpiry
+
+	a.accessToken = accessToken
+	a.copilotToken = ""
+	a.tokenExpiry = time.Time{}
+
+	if err := a.exchangeForCopilotToken(ctx); err != nil {
+		a.accessToken = previousAccessToken
+		a.copilotToken = previousCopilotToken
+		a.tokenExpiry = previousTokenExpiry
+		return err
+	}
+	if err := os.Remove(filepath.Join(a.tokenDir, "access-token")); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale access token: %w", err)
+	}
+	if err := a.clearSignedOutMarker(); err != nil {
+		return fmt.Errorf("clearing signed-out marker: %w", err)
+	}
+	if err := a.setGitHubCLIAutoSignIn(true); err != nil {
+		return fmt.Errorf("saving auth preferences: %w", err)
+	}
+
 	return nil
 }
 
@@ -636,6 +770,78 @@ func (a *Authenticator) loadAccessToken() error {
 	a.accessToken = strings.TrimSpace(string(data))
 	if a.accessToken == "" {
 		return ErrNotAuthenticated
+	}
+	return nil
+}
+
+func (a *Authenticator) signedOutMarkerPath() string {
+	return filepath.Join(a.tokenDir, signedOutMarkerFile)
+}
+
+func (a *Authenticator) authPreferencesPath() string {
+	return filepath.Join(a.tokenDir, authPreferencesFile)
+}
+
+func (a *Authenticator) loadAuthPreferences() (AuthPreferences, error) {
+	data, err := os.ReadFile(a.authPreferencesPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return AuthPreferences{}, nil
+		}
+		return AuthPreferences{}, err
+	}
+
+	var prefs AuthPreferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		return AuthPreferences{}, err
+	}
+	return prefs, nil
+}
+
+func (a *Authenticator) saveAuthPreferences(prefs AuthPreferences) error {
+	data, err := json.MarshalIndent(prefs, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return atomicWriteFile(a.authPreferencesPath(), data, 0o600)
+}
+
+func (a *Authenticator) isGitHubCLIAutoSignInEnabled() bool {
+	prefs, err := a.loadAuthPreferences()
+	if err != nil {
+		return false
+	}
+	return prefs.GitHubCLIAutoSignIn
+}
+
+func (a *Authenticator) setGitHubCLIAutoSignIn(enabled bool) error {
+	prefs, err := a.loadAuthPreferences()
+	if err != nil {
+		prefs = AuthPreferences{}
+	}
+	prefs.GitHubCLIAutoSignIn = enabled
+	return a.saveAuthPreferences(prefs)
+}
+
+// GitHubCLIAutoSignInEnabled reports whether the user has explicitly opted in
+// to automatic GitHub CLI sign-in. Malformed preferences are treated as false.
+func (a *Authenticator) GitHubCLIAutoSignInEnabled() bool {
+	return a.isGitHubCLIAutoSignInEnabled()
+}
+
+func (a *Authenticator) hasSignedOutMarker() bool {
+	_, err := os.Stat(a.signedOutMarkerPath())
+	return err == nil || !os.IsNotExist(err)
+}
+
+func (a *Authenticator) markSignedOut() error {
+	return atomicWriteFile(a.signedOutMarkerPath(), []byte("signed out\n"), 0o600)
+}
+
+func (a *Authenticator) clearSignedOutMarker() error {
+	if err := os.Remove(a.signedOutMarkerPath()); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -19,11 +20,12 @@ import (
 )
 
 const (
-	githubClientID  = "Iv1.b507a08c87ecfe98"
-	deviceCodeURL   = "https://github.com/login/device/code"
-	accessTokenURL  = "https://github.com/login/oauth/access_token"
-	copilotTokenURL = "https://api.github.com/copilot_internal/v2/token"
-	defaultTokenDir = "~/.config/vekil"
+	githubClientID        = "Iv1.b507a08c87ecfe98"
+	deviceCodeURL         = "https://github.com/login/device/code"
+	accessTokenURL        = "https://github.com/login/oauth/access_token"
+	copilotTokenURL       = "https://api.github.com/copilot_internal/v2/token"
+	defaultTokenDir       = "~/.config/vekil"
+	githubCLITokenTimeout = 5 * time.Second
 )
 
 var accessTokenEnvVars = []string{
@@ -31,6 +33,12 @@ var accessTokenEnvVars = []string{
 }
 
 var (
+	githubCLICommonPaths = []string{
+		"/opt/homebrew/bin/gh",
+		"/usr/local/bin/gh",
+		"/usr/bin/gh",
+	}
+
 	// ErrNotAuthenticated indicates that no reusable GitHub access token was
 	// available for a token refresh attempt.
 	ErrNotAuthenticated = errors.New("not authenticated")
@@ -52,6 +60,7 @@ type Authenticator struct {
 	client         *http.Client
 	directClient   *http.Client
 	copilotBaseURL string // overridable for tests; defaults to https://api.github.com
+	githubCLIPath  string // optional override for tests; defaults to gh lookup/common paths
 
 	// DisableAutoDeviceFlow prevents refreshToken from falling through to the
 	// interactive device-code flow. When true, callers (e.g. the menubar app)
@@ -273,6 +282,22 @@ func (a *Authenticator) refreshToken(ctx context.Context, allowDeviceFlow bool) 
 		}
 	} else if refreshErr == nil && !os.IsNotExist(err) {
 		refreshErr = fmt.Errorf("loading access token: %w", err)
+	}
+
+	// If there is no Vekil-managed GitHub token, or the existing token is no
+	// longer usable, try borrowing the active GitHub CLI token before falling
+	// back to the interactive device-code flow. Do not do this after transient
+	// Copilot exchange failures; those should be surfaced as-is.
+	if refreshErr == nil || IsInteractiveLoginRequired(refreshErr) {
+		if err := a.loadGitHubCLIAccessToken(ctx); err == nil {
+			if err := a.exchangeForCopilotToken(ctx); err == nil {
+				return nil
+			} else {
+				refreshErr = err
+			}
+		} else if !errors.Is(err, ErrNotAuthenticated) && refreshErr == nil {
+			refreshErr = err
+		}
 	}
 
 	if refreshErr == nil {
@@ -609,7 +634,88 @@ func (a *Authenticator) loadAccessToken() error {
 		return err
 	}
 	a.accessToken = strings.TrimSpace(string(data))
+	if a.accessToken == "" {
+		return ErrNotAuthenticated
+	}
 	return nil
+}
+
+func (a *Authenticator) loadGitHubCLIAccessToken(ctx context.Context) error {
+	token, err := a.gitHubCLIAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+	a.accessToken = token
+	return nil
+}
+
+func (a *Authenticator) gitHubCLIAccessToken(ctx context.Context) (string, error) {
+	ghPath, err := a.gitHubCLIExecutable()
+	if err != nil {
+		return "", err
+	}
+
+	cmdCtx, cancel := context.WithTimeout(ctx, githubCLITokenTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, ghPath, "auth", "token", "--hostname", "github.com")
+	cmd.Env = githubCLIEnvironment()
+
+	output, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		return "", fmt.Errorf("%w: github cli auth token unavailable", ErrNotAuthenticated)
+	}
+
+	token := strings.TrimSpace(string(output))
+	if token == "" {
+		return "", fmt.Errorf("%w: github cli returned an empty token", ErrNotAuthenticated)
+	}
+	return token, nil
+}
+
+func (a *Authenticator) gitHubCLIExecutable() (string, error) {
+	if strings.TrimSpace(a.githubCLIPath) != "" {
+		return a.githubCLIPath, nil
+	}
+
+	if path, err := exec.LookPath("gh"); err == nil {
+		return path, nil
+	}
+
+	for _, path := range githubCLICommonPaths {
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if info.Mode()&0o111 != 0 {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: gh executable not found", ErrNotAuthenticated)
+}
+
+func githubCLIEnvironment() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env)+1)
+
+	for _, kv := range env {
+		name, _, _ := strings.Cut(kv, "=")
+		switch name {
+		case "GH_TOKEN", "GITHUB_TOKEN", "GH_PROMPT_DISABLED":
+			continue
+		default:
+			filtered = append(filtered, kv)
+		}
+	}
+
+	// Ensure gh never opens an interactive prompt when Vekil is only probing for
+	// an existing CLI login.
+	filtered = append(filtered, "GH_PROMPT_DISABLED=1")
+	return filtered
 }
 
 func (a *Authenticator) saveAccessToken() error {

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -20,16 +20,15 @@ import (
 )
 
 const (
-	githubClientID        = "Iv1.b507a08c87ecfe98"
-	deviceCodeURL         = "https://github.com/login/device/code"
-	accessTokenURL        = "https://github.com/login/oauth/access_token"
-	copilotTokenURL       = "https://api.github.com/copilot_internal/v2/token"
-	copilotUserURL        = "https://api.github.com/copilot_internal/user"
-	defaultTokenDir       = "~/.config/vekil"
-	githubCLITokenTimeout = 5 * time.Second
-	githubCLITokenTTL     = 15 * time.Minute
-	signedOutMarkerFile   = "signed-out"
-	authPreferencesFile   = "auth-preferences.json"
+	githubClientID      = "Iv1.b507a08c87ecfe98"
+	deviceCodeURL       = "https://github.com/login/device/code"
+	accessTokenURL      = "https://github.com/login/oauth/access_token"
+	copilotTokenURL     = "https://api.github.com/copilot_internal/v2/token"
+	copilotUserURL      = "https://api.github.com/copilot_internal/user"
+	defaultTokenDir     = "~/.config/vekil"
+	githubCLITokenTTL   = 15 * time.Minute
+	signedOutMarkerFile = "signed-out"
+	authPreferencesFile = "auth-preferences.json"
 )
 
 var accessTokenEnvVars = []string{
@@ -37,6 +36,8 @@ var accessTokenEnvVars = []string{
 }
 
 var (
+	githubCLITokenTimeout = 5 * time.Second
+
 	githubCLICommonPaths = []string{
 		"/opt/homebrew/bin/gh",
 		"/usr/local/bin/gh",
@@ -948,8 +949,8 @@ func (a *Authenticator) gitHubCLIAccessToken(ctx context.Context) (string, error
 
 	output, err := cmd.Output()
 	if err != nil {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
+		if cmdCtx.Err() != nil {
+			return "", cmdCtx.Err()
 		}
 		return "", fmt.Errorf("%w: github cli auth token unavailable", ErrNotAuthenticated)
 	}

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -450,6 +450,7 @@ func TestSignOut_ClearsTokens(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "api-key.json"), []byte(`{"token":"tok"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	writeAuthPreferencesForTest(t, dir, true)
 
 	a := &Authenticator{
 		tokenDir:     dir,
@@ -480,13 +481,26 @@ func TestSignOut_ClearsTokens(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "api-key.json")); !os.IsNotExist(err) {
 		t.Error("api-key.json file still exists")
 	}
+	if _, err := os.Stat(filepath.Join(dir, signedOutMarkerFile)); err != nil {
+		t.Fatalf("signed-out marker was not written: %v", err)
+	}
+	if prefs := readAuthPreferencesForTest(t, dir); prefs.GitHubCLIAutoSignIn {
+		t.Fatal("expected sign out to disable GitHub CLI auto sign-in")
+	}
 }
 
 func TestSignOut_Idempotent(t *testing.T) {
-	a := &Authenticator{tokenDir: t.TempDir()}
+	dir := t.TempDir()
+	a := &Authenticator{tokenDir: dir}
 	// Calling SignOut when no files exist should not error
 	if err := a.SignOut(); err != nil {
 		t.Fatalf("SignOut on empty dir should not error: %v", err)
+	}
+	if err := a.SignOut(); err != nil {
+		t.Fatalf("second SignOut should not error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, signedOutMarkerFile)); err != nil {
+		t.Fatalf("signed-out marker was not written: %v", err)
 	}
 }
 
@@ -624,6 +638,156 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func writeAuthPreferencesForTest(t *testing.T, dir string, enabled bool) {
+	t.Helper()
+	data, err := json.Marshal(AuthPreferences{GitHubCLIAutoSignIn: enabled})
+	if err != nil {
+		t.Fatalf("marshal auth preferences: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, authPreferencesFile), data, 0o600); err != nil {
+		t.Fatalf("write auth preferences: %v", err)
+	}
+}
+
+func readAuthPreferencesForTest(t *testing.T, dir string) AuthPreferences {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, authPreferencesFile))
+	if err != nil {
+		t.Fatalf("read auth preferences: %v", err)
+	}
+	var prefs AuthPreferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		t.Fatalf("decode auth preferences: %v", err)
+	}
+	return prefs
+}
+
+func writeValidCopilotCacheForTest(t *testing.T, dir, token string) {
+	t.Helper()
+	data, err := json.Marshal(CopilotTokenResponse{
+		Token:     token,
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal copilot token cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "api-key.json"), data, 0o600); err != nil {
+		t.Fatalf("write copilot token cache: %v", err)
+	}
+}
+
+func TestGitHubCLIAutoSignInPreference_DefaultFalse(t *testing.T) {
+	dir := t.TempDir()
+	a := &Authenticator{tokenDir: dir}
+
+	if a.GitHubCLIAutoSignInEnabled() {
+		t.Fatal("expected missing auth preferences to disable GitHub CLI auto sign-in")
+	}
+	if _, err := os.Stat(filepath.Join(dir, authPreferencesFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected missing preferences file to remain missing, got err=%v", err)
+	}
+}
+
+func TestGitHubCLIAutoSignInPreference_SaveLoadTrue(t *testing.T) {
+	dir := t.TempDir()
+	a := &Authenticator{tokenDir: dir}
+
+	if err := a.setGitHubCLIAutoSignIn(true); err != nil {
+		t.Fatalf("set GitHub CLI preference: %v", err)
+	}
+
+	reloaded := &Authenticator{tokenDir: dir}
+	if !reloaded.GitHubCLIAutoSignInEnabled() {
+		t.Fatal("expected saved preference to enable GitHub CLI auto sign-in")
+	}
+}
+
+func TestGitHubCLIAutoSignInPreference_MalformedDisablesAutoSignIn(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, authPreferencesFile), []byte(`{not json`), 0o600); err != nil {
+		t.Fatalf("write malformed preferences: %v", err)
+	}
+
+	a := &Authenticator{tokenDir: dir}
+	if a.GitHubCLIAutoSignInEnabled() {
+		t.Fatal("expected malformed auth preferences to disable GitHub CLI auto sign-in")
+	}
+}
+
+func TestStatus_ReportsAuthSources(t *testing.T) {
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("COPILOT_GITHUB_TOKEN", "env-token")
+		t.Setenv("GITHUB_COPILOT_TOKEN", "")
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "access-token"), []byte("persisted-token"), 0o600); err != nil {
+			t.Fatalf("write access token: %v", err)
+		}
+		writeValidCopilotCacheForTest(t, dir, "cached-token")
+
+		status := (&Authenticator{tokenDir: dir}).Status()
+		if !status.SignedIn || status.Source != AuthSourceEnv {
+			t.Fatalf("expected env sign-in status, got %+v", status)
+		}
+		if !status.HasVekilAccessToken || !status.HasValidCopilotCache {
+			t.Fatalf("expected status to report local token files, got %+v", status)
+		}
+	})
+
+	t.Run("vekil", func(t *testing.T) {
+		t.Setenv("COPILOT_GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_COPILOT_TOKEN", "")
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "access-token"), []byte("persisted-token"), 0o600); err != nil {
+			t.Fatalf("write access token: %v", err)
+		}
+
+		status := (&Authenticator{tokenDir: dir}).Status()
+		if !status.SignedIn || status.Source != AuthSourceVekil || !status.HasVekilAccessToken {
+			t.Fatalf("expected Vekil sign-in status, got %+v", status)
+		}
+	})
+
+	t.Run("github-cli", func(t *testing.T) {
+		t.Setenv("COPILOT_GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_COPILOT_TOKEN", "")
+		dir := t.TempDir()
+		writeAuthPreferencesForTest(t, dir, true)
+		writeValidCopilotCacheForTest(t, dir, "cached-token")
+
+		status := (&Authenticator{tokenDir: dir}).Status()
+		if !status.SignedIn || status.Source != AuthSourceGitHubCLI || !status.GitHubCLIAutoSignIn {
+			t.Fatalf("expected GitHub CLI sign-in status, got %+v", status)
+		}
+	})
+
+	t.Run("github-cli configured without cache", func(t *testing.T) {
+		t.Setenv("COPILOT_GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_COPILOT_TOKEN", "")
+		dir := t.TempDir()
+		writeAuthPreferencesForTest(t, dir, true)
+
+		status := (&Authenticator{tokenDir: dir}).Status()
+		if !status.SignedIn || status.Source != AuthSourceGitHubCLI || !status.GitHubCLIAutoSignIn {
+			t.Fatalf("expected configured GitHub CLI sign-in status, got %+v", status)
+		}
+	})
+
+	t.Run("signed-out", func(t *testing.T) {
+		t.Setenv("COPILOT_GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_COPILOT_TOKEN", "")
+		dir := t.TempDir()
+		writeAuthPreferencesForTest(t, dir, true)
+		if err := os.WriteFile(filepath.Join(dir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
+			t.Fatalf("write signed-out marker: %v", err)
+		}
+
+		status := (&Authenticator{tokenDir: dir}).Status()
+		if status.SignedIn || status.Source != AuthSourceNone || !status.SignedOut {
+			t.Fatalf("expected signed-out status, got %+v", status)
+		}
+	})
+}
+
 func TestPollForAuthorization_Success(t *testing.T) {
 	call := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -653,6 +817,9 @@ func TestPollForAuthorization_Success(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
+		t.Fatalf("write signed-out marker: %v", err)
+	}
 	a := &Authenticator{
 		client:         server.Client(),
 		copilotBaseURL: server.URL,
@@ -687,6 +854,12 @@ func TestPollForAuthorization_Success(t *testing.T) {
 	}
 	if string(data) != "ghu_success" {
 		t.Errorf("expected ghu_success on disk, got %q", string(data))
+	}
+	if _, err := os.Stat(filepath.Join(dir, signedOutMarkerFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected signed-out marker to be cleared, got err=%v", err)
+	}
+	if prefs := readAuthPreferencesForTest(t, dir); prefs.GitHubCLIAutoSignIn {
+		t.Fatal("expected device-code authorization to disable GitHub CLI auto sign-in")
 	}
 }
 
@@ -746,6 +919,9 @@ func TestRefreshToken_UsesEnvAccessTokenWithoutSavingAccessToken(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
+		t.Fatalf("write signed-out marker: %v", err)
+	}
 	a := &Authenticator{
 		tokenDir:       dir,
 		client:         server.Client(),
@@ -760,6 +936,40 @@ func TestRefreshToken_UsesEnvAccessTokenWithoutSavingAccessToken(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "access-token")); !os.IsNotExist(err) {
 		t.Fatalf("expected no access-token file to be written, got err=%v", err)
+	}
+}
+
+func TestRefreshTokenNonInteractive_MissingPreferenceSkipsGitHubCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script test is Unix-only")
+	}
+
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	calledPath := filepath.Join(dir, "gh-called")
+	script := `#!/bin/sh
+printf 'called\n' > "$CALLED_FILE"
+printf 'gh-cli-access-token\n'
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("CALLED_FILE", calledPath)
+
+	tokenDir := t.TempDir()
+	a := &Authenticator{
+		tokenDir:      tokenDir,
+		githubCLIPath: ghPath,
+		client:        &http.Client{Timeout: 5 * time.Second},
+	}
+
+	if _, err := a.RefreshTokenNonInteractive(context.Background()); err == nil {
+		t.Fatal("expected missing credentials to require explicit login")
+	} else if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("expected ErrNotAuthenticated, got %v", err)
+	}
+	if _, err := os.Stat(calledPath); !os.IsNotExist(err) {
+		t.Fatalf("expected gh not to be invoked, got err=%v", err)
 	}
 }
 
@@ -801,6 +1011,7 @@ printf 'gh-cli-access-token\n'
 	defer server.Close()
 
 	tokenDir := t.TempDir()
+	writeAuthPreferencesForTest(t, tokenDir, true)
 	a := &Authenticator{
 		tokenDir:       tokenDir,
 		githubCLIPath:  ghPath,
@@ -835,6 +1046,134 @@ printf 'gh-cli-access-token\n'
 	}
 }
 
+func TestSignInWithGitHubCLI_ClearsSignedOutMarkerWritesPreferenceAndDoesNotSaveAccessToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script test is Unix-only")
+	}
+
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	calledPath := filepath.Join(dir, "gh-called")
+	script := `#!/bin/sh
+if [ "$1" != "auth" ] || [ "$2" != "token" ] || [ "$3" != "--hostname" ] || [ "$4" != "github.com" ]; then
+  exit 2
+fi
+if [ -n "$GH_TOKEN" ] || [ -n "$GITHUB_TOKEN" ]; then
+  exit 3
+fi
+if [ "$GH_PROMPT_DISABLED" != "1" ]; then
+  exit 4
+fi
+printf 'called\n' > "$CALLED_FILE"
+printf 'gh-cli-access-token\n'
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("CALLED_FILE", calledPath)
+	t.Setenv("GH_TOKEN", "generic-gh-token")
+	t.Setenv("GITHUB_TOKEN", "generic-github-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token gh-cli-access-token" {
+			t.Errorf("expected 'token gh-cli-access-token', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
+			Token:     "explicit-gh-cli-copilot-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		})
+	}))
+	defer server.Close()
+
+	tokenDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tokenDir, "access-token"), []byte("stale-access-token"), 0o600); err != nil {
+		t.Fatalf("write stale access token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tokenDir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
+		t.Fatalf("write signed-out marker: %v", err)
+	}
+	writeAuthPreferencesForTest(t, tokenDir, false)
+
+	a := &Authenticator{
+		tokenDir:       tokenDir,
+		githubCLIPath:  ghPath,
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+	}
+
+	if err := a.SignInWithGitHubCLI(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(calledPath); err != nil {
+		t.Fatalf("expected gh to be invoked: %v", err)
+	}
+	if a.accessToken != "gh-cli-access-token" {
+		t.Fatalf("expected GitHub CLI access token in memory, got %q", a.accessToken)
+	}
+	if a.copilotToken != "explicit-gh-cli-copilot-token" {
+		t.Fatalf("expected copilot token in memory, got %q", a.copilotToken)
+	}
+	if _, err := os.Stat(filepath.Join(tokenDir, signedOutMarkerFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected signed-out marker to be cleared, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tokenDir, "access-token")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale access-token file to be removed, got err=%v", err)
+	}
+	if prefs := readAuthPreferencesForTest(t, tokenDir); !prefs.GitHubCLIAutoSignIn {
+		t.Fatal("expected explicit GitHub CLI sign-in to enable auto sign-in preference")
+	}
+
+	data, err := os.ReadFile(filepath.Join(tokenDir, "api-key.json"))
+	if err != nil {
+		t.Fatalf("expected copilot token cache to be saved: %v", err)
+	}
+	var saved CopilotTokenResponse
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("decode saved copilot token: %v", err)
+	}
+	if saved.Token != "explicit-gh-cli-copilot-token" {
+		t.Fatalf("expected saved copilot token, got %q", saved.Token)
+	}
+}
+
+func TestRefreshTokenNonInteractive_SignedOutMarkerSkipsGitHubCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script test is Unix-only")
+	}
+
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	calledPath := filepath.Join(dir, "gh-called")
+	script := `#!/bin/sh
+printf 'called\n' > "$CALLED_FILE"
+exit 7
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("CALLED_FILE", calledPath)
+
+	tokenDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tokenDir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
+		t.Fatalf("write signed-out marker: %v", err)
+	}
+	writeAuthPreferencesForTest(t, tokenDir, true)
+	a := &Authenticator{
+		tokenDir:      tokenDir,
+		githubCLIPath: ghPath,
+		client:        &http.Client{Timeout: 5 * time.Second},
+	}
+
+	if _, err := a.RefreshTokenNonInteractive(context.Background()); err == nil {
+		t.Fatal("expected signed-out state to require explicit login")
+	} else if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("expected ErrNotAuthenticated, got %v", err)
+	}
+	if _, err := os.Stat(calledPath); !os.IsNotExist(err) {
+		t.Fatalf("expected gh not to be invoked, got err=%v", err)
+	}
+}
+
 func TestRefreshTokenNonInteractive_UsesPersistedAccessToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "token valid-access-token" {
@@ -850,6 +1189,9 @@ func TestRefreshTokenNonInteractive_UsesPersistedAccessToken(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "access-token"), []byte("valid-access-token"), 0o600); err != nil {
 		t.Fatalf("write access token: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
+		t.Fatalf("write signed-out marker: %v", err)
 	}
 
 	a := &Authenticator{

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -791,8 +791,8 @@ func TestStatus_ReportsAuthSources(t *testing.T) {
 func TestPollForAuthorization_Success(t *testing.T) {
 	call := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/login/oauth/access_token":
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
 			call++
 			if call == 1 {
 				// First call: authorization_pending
@@ -805,7 +805,7 @@ func TestPollForAuthorization_Success(t *testing.T) {
 					AccessToken: "ghu_success",
 				})
 			}
-		case r.URL.Path == "/copilot_internal/v2/token":
+		case "/copilot_internal/v2/token":
 			_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
 				Token:     "copilot-tok-poll",
 				ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -1042,6 +1042,39 @@ printf 'gh-cli-access-token\n'
 	}
 }
 
+func TestGitHubCLIAccessToken_ReturnsCommandContextTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script test is Unix-only")
+	}
+
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+exec sleep 1
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+
+	previousTimeout := githubCLITokenTimeout
+	githubCLITokenTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		githubCLITokenTimeout = previousTimeout
+	})
+
+	a := &Authenticator{githubCLIPath: ghPath}
+	_, err := a.gitHubCLIAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+	if errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("expected timeout not to be classified as unauthenticated, got %v", err)
+	}
+}
+
 func TestSignInWithGitHubCLI_ClearsSignedOutMarkerWritesPreferenceAndDoesNotPersistToken(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake gh shell script test is Unix-only")

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -973,7 +973,7 @@ printf 'gh-cli-access-token\n'
 	}
 }
 
-func TestRefreshTokenNonInteractive_UsesGitHubCLITokenWithoutSavingAccessToken(t *testing.T) {
+func TestRefreshTokenNonInteractive_UsesGitHubCLITokenWithoutPersistingToken(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake gh shell script test is Unix-only")
 	}
@@ -999,13 +999,17 @@ printf 'gh-cli-access-token\n'
 	t.Setenv("GH_TOKEN", "generic-gh-token")
 	t.Setenv("GITHUB_TOKEN", "generic-github-token")
 
+	chatEnabled := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "token gh-cli-access-token" {
-			t.Errorf("expected 'token gh-cli-access-token', got %q", got)
+		if r.URL.Path != "/copilot_internal/user" {
+			t.Errorf("expected copilot user validation request, got %s", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
-			Token:     "gh-cli-copilot-token",
-			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		if got := r.Header.Get("Authorization"); got != "Bearer gh-cli-access-token" {
+			t.Errorf("expected 'Bearer gh-cli-access-token', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(CopilotUserResponse{
+			Login:       "test-user",
+			ChatEnabled: &chatEnabled,
 		})
 	}))
 	defer server.Close()
@@ -1023,30 +1027,22 @@ printf 'gh-cli-access-token\n'
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if token != "gh-cli-copilot-token" {
-		t.Fatalf("expected gh-cli-copilot-token, got %q", token)
+	if token != "gh-cli-access-token" {
+		t.Fatalf("expected gh-cli-access-token, got %q", token)
 	}
-	if a.accessToken != "gh-cli-access-token" {
-		t.Fatalf("expected access token to be loaded from gh, got %q", a.accessToken)
+	if a.accessToken != "" {
+		t.Fatalf("expected GitHub CLI token not to be stored as access token, got %q", a.accessToken)
 	}
 	if _, err := os.Stat(filepath.Join(tokenDir, "access-token")); !os.IsNotExist(err) {
 		t.Fatalf("expected gh access token not to be persisted, got err=%v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(tokenDir, "api-key.json"))
-	if err != nil {
-		t.Fatalf("expected copilot token cache to be saved: %v", err)
-	}
-	var saved CopilotTokenResponse
-	if err := json.Unmarshal(data, &saved); err != nil {
-		t.Fatalf("decode saved copilot token: %v", err)
-	}
-	if saved.Token != "gh-cli-copilot-token" {
-		t.Fatalf("expected saved copilot token, got %q", saved.Token)
+	if _, err := os.Stat(filepath.Join(tokenDir, "api-key.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected gh token not to be persisted in copilot token cache, got err=%v", err)
 	}
 }
 
-func TestSignInWithGitHubCLI_ClearsSignedOutMarkerWritesPreferenceAndDoesNotSaveAccessToken(t *testing.T) {
+func TestSignInWithGitHubCLI_ClearsSignedOutMarkerWritesPreferenceAndDoesNotPersistToken(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake gh shell script test is Unix-only")
 	}
@@ -1074,13 +1070,17 @@ printf 'gh-cli-access-token\n'
 	t.Setenv("GH_TOKEN", "generic-gh-token")
 	t.Setenv("GITHUB_TOKEN", "generic-github-token")
 
+	chatEnabled := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "token gh-cli-access-token" {
-			t.Errorf("expected 'token gh-cli-access-token', got %q", got)
+		if r.URL.Path != "/copilot_internal/user" {
+			t.Errorf("expected copilot user validation request, got %s", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
-			Token:     "explicit-gh-cli-copilot-token",
-			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		if got := r.Header.Get("Authorization"); got != "Bearer gh-cli-access-token" {
+			t.Errorf("expected 'Bearer gh-cli-access-token', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(CopilotUserResponse{
+			Login:       "test-user",
+			ChatEnabled: &chatEnabled,
 		})
 	}))
 	defer server.Close()
@@ -1088,6 +1088,16 @@ printf 'gh-cli-access-token\n'
 	tokenDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tokenDir, "access-token"), []byte("stale-access-token"), 0o600); err != nil {
 		t.Fatalf("write stale access token: %v", err)
+	}
+	staleCopilotCache, err := json.Marshal(CopilotTokenResponse{
+		Token:     "stale-copilot-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal stale copilot cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tokenDir, "api-key.json"), staleCopilotCache, 0o600); err != nil {
+		t.Fatalf("write stale copilot cache: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(tokenDir, signedOutMarkerFile), []byte("signed out\n"), 0o600); err != nil {
 		t.Fatalf("write signed-out marker: %v", err)
@@ -1107,11 +1117,11 @@ printf 'gh-cli-access-token\n'
 	if _, err := os.Stat(calledPath); err != nil {
 		t.Fatalf("expected gh to be invoked: %v", err)
 	}
-	if a.accessToken != "gh-cli-access-token" {
-		t.Fatalf("expected GitHub CLI access token in memory, got %q", a.accessToken)
+	if a.accessToken != "" {
+		t.Fatalf("expected GitHub CLI token not to be stored as access token, got %q", a.accessToken)
 	}
-	if a.copilotToken != "explicit-gh-cli-copilot-token" {
-		t.Fatalf("expected copilot token in memory, got %q", a.copilotToken)
+	if a.copilotToken != "gh-cli-access-token" {
+		t.Fatalf("expected GitHub CLI bearer token in memory, got %q", a.copilotToken)
 	}
 	if _, err := os.Stat(filepath.Join(tokenDir, signedOutMarkerFile)); !os.IsNotExist(err) {
 		t.Fatalf("expected signed-out marker to be cleared, got err=%v", err)
@@ -1123,16 +1133,61 @@ printf 'gh-cli-access-token\n'
 		t.Fatal("expected explicit GitHub CLI sign-in to enable auto sign-in preference")
 	}
 
-	data, err := os.ReadFile(filepath.Join(tokenDir, "api-key.json"))
-	if err != nil {
-		t.Fatalf("expected copilot token cache to be saved: %v", err)
+	if _, err := os.Stat(filepath.Join(tokenDir, "api-key.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale copilot token cache to be removed, got err=%v", err)
 	}
-	var saved CopilotTokenResponse
-	if err := json.Unmarshal(data, &saved); err != nil {
-		t.Fatalf("decode saved copilot token: %v", err)
+}
+
+func TestSignInWithGitHubCLI_ValidationFailureRestoresPreviousState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script test is Unix-only")
 	}
-	if saved.Token != "explicit-gh-cli-copilot-token" {
-		t.Fatalf("expected saved copilot token, got %q", saved.Token)
+
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+printf 'gh-cli-access-token\n'
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/copilot_internal/user" {
+			t.Errorf("expected copilot user validation request, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(githubAPIErrorResponse{Message: "Not Found", Status: "404"})
+	}))
+	defer server.Close()
+
+	tokenDir := t.TempDir()
+	writeAuthPreferencesForTest(t, tokenDir, false)
+	a := &Authenticator{
+		tokenDir:       tokenDir,
+		githubCLIPath:  ghPath,
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+		accessToken:    "previous-access-token",
+		copilotToken:   "previous-copilot-token",
+		tokenExpiry:    time.Now().Add(1 * time.Hour),
+	}
+
+	err := a.SignInWithGitHubCLI(context.Background())
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !errors.Is(err, ErrInvalidAccessToken) {
+		t.Fatalf("expected ErrInvalidAccessToken, got %v", err)
+	}
+	if a.accessToken != "previous-access-token" {
+		t.Fatalf("expected access token to be restored, got %q", a.accessToken)
+	}
+	if a.copilotToken != "previous-copilot-token" {
+		t.Fatalf("expected copilot token to be restored, got %q", a.copilotToken)
+	}
+	if prefs := readAuthPreferencesForTest(t, tokenDir); prefs.GitHubCLIAutoSignIn {
+		t.Fatal("expected failed GitHub CLI sign-in not to enable auto sign-in preference")
 	}
 }
 

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -363,6 +364,11 @@ func TestIsSignedIn_WithEnvToken(t *testing.T) {
 	}
 }
 
+func missingGitHubCLIPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "missing-gh")
+}
+
 func TestGetToken_IgnoresGenericGitHubEnvVars(t *testing.T) {
 	t.Setenv("GH_TOKEN", "generic-gh-token")
 	t.Setenv("GITHUB_TOKEN", "generic-github-token")
@@ -388,6 +394,7 @@ func TestGetToken_IgnoresGenericGitHubEnvVars(t *testing.T) {
 
 	a := &Authenticator{
 		tokenDir:       dir,
+		githubCLIPath:  missingGitHubCLIPath(t),
 		client:         server.Client(),
 		copilotBaseURL: server.URL,
 	}
@@ -711,6 +718,7 @@ func TestRefreshToken_DisableAutoDeviceFlow(t *testing.T) {
 	a := &Authenticator{
 		tokenDir:              t.TempDir(),
 		client:                &http.Client{Timeout: 5 * time.Second},
+		githubCLIPath:         missingGitHubCLIPath(t),
 		DisableAutoDeviceFlow: true,
 	}
 
@@ -752,6 +760,78 @@ func TestRefreshToken_UsesEnvAccessTokenWithoutSavingAccessToken(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "access-token")); !os.IsNotExist(err) {
 		t.Fatalf("expected no access-token file to be written, got err=%v", err)
+	}
+}
+
+func TestRefreshTokenNonInteractive_UsesGitHubCLITokenWithoutSavingAccessToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script test is Unix-only")
+	}
+
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+if [ "$1" != "auth" ] || [ "$2" != "token" ] || [ "$3" != "--hostname" ] || [ "$4" != "github.com" ]; then
+  exit 2
+fi
+if [ -n "$GH_TOKEN" ] || [ -n "$GITHUB_TOKEN" ]; then
+  exit 3
+fi
+if [ "$GH_PROMPT_DISABLED" != "1" ]; then
+  exit 4
+fi
+printf 'gh-cli-access-token\n'
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+
+	t.Setenv("GH_TOKEN", "generic-gh-token")
+	t.Setenv("GITHUB_TOKEN", "generic-github-token")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "token gh-cli-access-token" {
+			t.Errorf("expected 'token gh-cli-access-token', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(CopilotTokenResponse{
+			Token:     "gh-cli-copilot-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+		})
+	}))
+	defer server.Close()
+
+	tokenDir := t.TempDir()
+	a := &Authenticator{
+		tokenDir:       tokenDir,
+		githubCLIPath:  ghPath,
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+	}
+
+	token, err := a.RefreshTokenNonInteractive(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "gh-cli-copilot-token" {
+		t.Fatalf("expected gh-cli-copilot-token, got %q", token)
+	}
+	if a.accessToken != "gh-cli-access-token" {
+		t.Fatalf("expected access token to be loaded from gh, got %q", a.accessToken)
+	}
+	if _, err := os.Stat(filepath.Join(tokenDir, "access-token")); !os.IsNotExist(err) {
+		t.Fatalf("expected gh access token not to be persisted, got err=%v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tokenDir, "api-key.json"))
+	if err != nil {
+		t.Fatalf("expected copilot token cache to be saved: %v", err)
+	}
+	var saved CopilotTokenResponse
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("decode saved copilot token: %v", err)
+	}
+	if saved.Token != "gh-cli-copilot-token" {
+		t.Fatalf("expected saved copilot token, got %q", saved.Token)
 	}
 }
 
@@ -818,6 +898,7 @@ func TestRefreshTokenNonInteractive_DetectsRevokedAccessTokenDespiteCachedCopilo
 	a := &Authenticator{
 		tokenDir:       dir,
 		client:         server.Client(),
+		githubCLIPath:  missingGitHubCLIPath(t),
 		copilotBaseURL: server.URL,
 	}
 
@@ -845,8 +926,9 @@ func TestRefreshTokenNonInteractive_RequiresGitHubAccessToken(t *testing.T) {
 	}
 
 	a := &Authenticator{
-		tokenDir: dir,
-		client:   &http.Client{Timeout: 5 * time.Second},
+		tokenDir:      dir,
+		client:        &http.Client{Timeout: 5 * time.Second},
+		githubCLIPath: missingGitHubCLIPath(t),
 	}
 
 	if _, err := a.RefreshTokenNonInteractive(context.Background()); err == nil {

--- a/cmd/menubar/config_test.go
+++ b/cmd/menubar/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/proxy"
 )
 
@@ -173,6 +174,58 @@ func TestProvidersConfigErrorPresentation(t *testing.T) {
 	providersConfigErr = providersErr
 	if got := providersMenuTitle(); got != "Providers: Invalid (providers.json)" {
 		t.Fatalf("providersMenuTitle() with providers error = %q, want %q", got, "Providers: Invalid (providers.json)")
+	}
+}
+
+func TestAuthMenuTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status auth.AuthStatus
+		want   string
+	}{
+		{
+			name:   "not signed in",
+			status: auth.AuthStatus{Source: auth.AuthSourceNone},
+			want:   "GitHub Auth: Not Signed In",
+		},
+		{
+			name:   "signed out",
+			status: auth.AuthStatus{Source: auth.AuthSourceNone, SignedOut: true},
+			want:   "GitHub Auth: Signed Out",
+		},
+		{
+			name:   "environment token",
+			status: auth.AuthStatus{SignedIn: true, Source: auth.AuthSourceEnv},
+			want:   "GitHub Auth: Environment Token",
+		},
+		{
+			name:   "vekil managed",
+			status: auth.AuthStatus{SignedIn: true, Source: auth.AuthSourceVekil},
+			want:   "GitHub Auth: Signed in with GitHub",
+		},
+		{
+			name:   "github cli",
+			status: auth.AuthStatus{SignedIn: true, Source: auth.AuthSourceGitHubCLI},
+			want:   "GitHub Auth: Using GitHub CLI Account",
+		},
+		{
+			name:   "unknown signed in source",
+			status: auth.AuthStatus{SignedIn: true, Source: auth.AuthSourceNone},
+			want:   "GitHub Auth: Signed In",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := authMenuTitle(tt.status); got != tt.want {
+				t.Fatalf("authMenuTitle() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -309,7 +309,7 @@ func signInWithGitHubCLI() {
 	if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
 		log.Error("github cli sign-in failed", logger.Err(err))
 		if ctx.Err() == nil {
-			showErrorDialog("GitHub CLI Sign In Failed", fmt.Sprintf("Could not sign in with GitHub CLI. Make sure gh is installed and already authenticated with GitHub.\n\n%v", err))
+			showErrorDialog("GitHub CLI Sign In Failed", fmt.Sprintf("Could not sign in with GitHub CLI. Make sure gh is installed, authenticated with GitHub, and using an account with Copilot access.\n\n%v", err))
 		}
 		refreshSessionUI()
 		setAuthActionsEnabled(true)

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -22,9 +22,11 @@ var (
 	authenticator *auth.Authenticator
 
 	// Menu items kept at package level so helpers can update them.
-	mStatus          *systray.MenuItem
+	mAuthStatus      *systray.MenuItem
 	mToggle          *systray.MenuItem
-	mAuth            *systray.MenuItem
+	mSignInGitHub    *systray.MenuItem
+	mUseGitHubCLI    *systray.MenuItem
+	mSignOut         *systray.MenuItem
 	mProvidersStatus *systray.MenuItem
 	mProvidersChoose *systray.MenuItem
 	mProvidersClear  *systray.MenuItem
@@ -58,8 +60,8 @@ func onReady() {
 	systray.SetIcon(iconOff)
 	systray.SetTooltip("Vekil - Stopped")
 
-	mStatus = systray.AddMenuItem("○ Not signed in", "")
-	mStatus.Disable()
+	mAuthStatus = systray.AddMenuItem("○ Not signed in", "")
+	mAuthStatus.Disable()
 	mVersion := systray.AddMenuItem(versionMenuTitle(), "Current app version")
 	mVersion.Disable()
 	systray.AddSeparator()
@@ -81,7 +83,9 @@ func onReady() {
 		mLaunch.Check()
 	}
 
-	mAuth = systray.AddMenuItem("Sign In", "Sign in or out of GitHub")
+	mSignInGitHub = systray.AddMenuItem("Sign In with GitHub", "Sign in with GitHub using a browser code")
+	mUseGitHubCLI = systray.AddMenuItem("Use GitHub CLI", "Use the currently authenticated GitHub CLI account")
+	mSignOut = systray.AddMenuItem("Sign Out", "Clear Vekil authentication")
 	systray.AddSeparator()
 
 	var mCheckUpdates *systray.MenuItem
@@ -134,12 +138,12 @@ func onReady() {
 						mLaunch.Check()
 					}
 				}
-			case <-mAuth.ClickedCh:
-				if authenticator.IsSignedIn() {
-					signOut()
-				} else {
-					go signIn()
-				}
+			case <-mSignInGitHub.ClickedCh:
+				go signInWithGitHub()
+			case <-mUseGitHubCLI.ClickedCh:
+				go signInWithGitHubCLI()
+			case <-mSignOut.ClickedCh:
+				signOut()
 			case <-mCheckUpdatesClicked:
 				if err := checkForUpdates(); err != nil {
 					log.Error("failed to check for updates", logger.Err(err))
@@ -166,9 +170,11 @@ func startProxy() {
 	if providersRequireGitHubAuth(providersCfg, providersConfigErr) {
 		if _, err := authenticator.GetToken(context.Background()); err != nil {
 			log.Error("auth failed", logger.Err(err))
-			// Token refresh failed — force re-authentication.
-			_ = authenticator.SignOut()
-			go signIn()
+			showErrorDialog(
+				"GitHub Sign In Required",
+				fmt.Sprintf("The active providers config uses GitHub Copilot, but Vekil could not refresh authentication.\n\nChoose ‘Sign In with GitHub’ or ‘Use GitHub CLI’ from the Vekil menu, then start Vekil again.\n\n%v", err),
+			)
+			refreshSessionUI()
 			return
 		}
 	}
@@ -212,9 +218,9 @@ func stopProxy() {
 	log.Info("proxy stopped")
 }
 
-// signIn drives the interactive GitHub device-code flow via native macOS
+// signInWithGitHub drives the interactive GitHub device-code flow via native macOS
 // dialogs. It is expected to be called in its own goroutine.
-func signIn() {
+func signInWithGitHub() {
 	// Guard against double sign-in.
 	signInMu.Lock()
 	if signInCancel != nil {
@@ -231,15 +237,15 @@ func signIn() {
 		signInMu.Unlock()
 	}()
 
-	mAuth.Disable()
-	mStatus.SetTitle("⟳ Signing in…")
+	setAuthActionsEnabled(false)
+	mAuthStatus.SetTitle("⟳ Signing in with GitHub…")
 
 	dcResp, err := authenticator.RequestDeviceCode(ctx)
 	if err != nil {
 		log.Error("device code request failed", logger.Err(err))
 		showErrorDialog("Sign In Failed", fmt.Sprintf("Could not start sign-in: %v", err))
 		refreshSessionUI()
-		mAuth.Enable()
+		setAuthActionsEnabled(true)
 		return
 	}
 
@@ -255,12 +261,12 @@ func signIn() {
 	if button == "Cancel" {
 		cancel()
 		refreshSessionUI()
-		mAuth.Enable()
+		setAuthActionsEnabled(true)
 		return
 	}
 
 	openURL(dcResp.VerificationURI)
-	mStatus.SetTitle("⟳ Waiting for authorization…")
+	mAuthStatus.SetTitle("⟳ Waiting for authorization…")
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
 		log.Error("authorization failed", logger.Err(err))
@@ -269,7 +275,7 @@ func signIn() {
 			showErrorDialog("Sign In Failed", fmt.Sprintf("Authorization failed: %v", err))
 		}
 		refreshSessionUI()
-		mAuth.Enable()
+		setAuthActionsEnabled(true)
 		return
 	}
 
@@ -278,7 +284,45 @@ func signIn() {
 	log.Info("sign-in complete")
 }
 
-// signOut stops the proxy (if running) and clears all credentials.
+// signInWithGitHubCLI signs in using the currently authenticated GitHub CLI account.
+// It is expected to be called in its own goroutine.
+func signInWithGitHubCLI() {
+	// Guard against double sign-in.
+	signInMu.Lock()
+	if signInCancel != nil {
+		signInMu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	signInCancel = cancel
+	signInMu.Unlock()
+
+	defer func() {
+		signInMu.Lock()
+		signInCancel = nil
+		signInMu.Unlock()
+	}()
+
+	setAuthActionsEnabled(false)
+	mAuthStatus.SetTitle("⟳ Signing in with GitHub CLI…")
+
+	if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
+		log.Error("github cli sign-in failed", logger.Err(err))
+		if ctx.Err() == nil {
+			showErrorDialog("GitHub CLI Sign In Failed", fmt.Sprintf("Could not sign in with GitHub CLI. Make sure gh is installed and already authenticated with GitHub.\n\n%v", err))
+		}
+		refreshSessionUI()
+		setAuthActionsEnabled(true)
+		return
+	}
+
+	refreshSessionUI()
+	showNotification("Vekil", "Successfully signed in with GitHub CLI.")
+	log.Info("github cli sign-in complete")
+}
+
+// signOut clears Vekil credentials and stops the proxy only when active
+// providers require GitHub Copilot authentication.
 func signOut() {
 	// Cancel any in-progress sign-in.
 	signInMu.Lock()
@@ -287,7 +331,7 @@ func signOut() {
 	}
 	signInMu.Unlock()
 
-	if srv != nil && srv.IsRunning() {
+	if providersRequireGitHubAuth(providersCfg, providersConfigErr) && srv != nil && srv.IsRunning() {
 		stopProxy()
 	}
 
@@ -351,50 +395,105 @@ func applyProvidersConfigPath(path string) error {
 	return nil
 }
 
-// setSignedInUI updates the menu to reflect an authenticated state.
-func setSignedInUI() {
-	mStatus.SetTitle("● Signed in to GitHub")
-	mAuth.SetTitle("Sign Out")
-	mAuth.Enable()
-	mToggle.Enable()
-}
-
-// setSignedOutUI updates the menu to reflect an unauthenticated state.
-func setSignedOutUI() {
-	mStatus.SetTitle("○ Not signed in")
-	mAuth.SetTitle("Sign In")
-	mAuth.Enable()
-	mToggle.Disable()
-	systray.SetIcon(iconOff)
-	systray.SetTooltip("Vekil - Stopped")
-}
-
 func refreshSessionUI() {
 	refreshProvidersMenu()
 
+	status := auth.AuthStatus{Source: auth.AuthSourceNone}
+	if authenticator != nil {
+		status = authenticator.Status()
+	}
+	refreshAuthMenu(status)
+
+	running := srv != nil && srv.IsRunning()
 	switch {
 	case providersConfigErr != nil:
-		mStatus.SetTitle(providersConfigStatusTitle(providersConfigErr))
-		mAuth.SetTitle(authMenuTitle())
-		mAuth.Enable()
 		mToggle.Disable()
-		systray.SetIcon(iconOff)
-		systray.SetTooltip("Vekil - Stopped")
-	case !providersRequireGitHubAuth(providersCfg, providersConfigErr):
-		mStatus.SetTitle("● Provider-only mode")
-		mAuth.SetTitle(authMenuTitle())
-		mAuth.Enable()
-		mToggle.Enable()
-		if srv == nil || !srv.IsRunning() {
+		if !running {
 			mToggle.SetTitle("Start Vekil")
 			systray.SetIcon(iconOff)
 			systray.SetTooltip("Vekil - Stopped")
 		}
-	case authenticator.IsSignedIn():
-		setSignedInUI()
+	case !providersRequireGitHubAuth(providersCfg, providersConfigErr):
+		mToggle.Enable()
+		if !running {
+			mToggle.SetTitle("Start Vekil")
+			systray.SetIcon(iconOff)
+			systray.SetTooltip("Vekil - Stopped")
+		}
+	case status.SignedIn:
+		mToggle.Enable()
+		if !running {
+			mToggle.SetTitle("Start Vekil")
+			systray.SetIcon(iconOff)
+			systray.SetTooltip("Vekil - Stopped")
+		}
 	default:
-		setSignedOutUI()
+		mToggle.Disable()
+		if !running {
+			mToggle.SetTitle("Start Vekil")
+			systray.SetIcon(iconOff)
+			systray.SetTooltip("Vekil - Stopped")
+		}
 	}
+}
+
+func refreshAuthMenu(status auth.AuthStatus) {
+	if mAuthStatus != nil {
+		mAuthStatus.SetTitle(authStatusTitle(status))
+	}
+	if mSignInGitHub != nil {
+		mSignInGitHub.Enable()
+	}
+	if mUseGitHubCLI != nil {
+		mUseGitHubCLI.Enable()
+	}
+	if mSignOut != nil {
+		if status.SignedIn {
+			mSignOut.Enable()
+		} else {
+			mSignOut.Disable()
+		}
+	}
+}
+
+func authStatusTitle(status auth.AuthStatus) string {
+	if status.SignedIn {
+		switch status.Source {
+		case auth.AuthSourceEnv:
+			return "● Signed in with environment token"
+		case auth.AuthSourceVekil:
+			return "● Signed in with GitHub"
+		case auth.AuthSourceGitHubCLI:
+			return "● Using GitHub CLI"
+		default:
+			return "● Signed in"
+		}
+	}
+	if status.SignedOut {
+		return "○ Signed out"
+	}
+	return "○ Not signed in"
+}
+
+func setAuthActionsEnabled(enabled bool) {
+	if !enabled {
+		if mSignInGitHub != nil {
+			mSignInGitHub.Disable()
+		}
+		if mUseGitHubCLI != nil {
+			mUseGitHubCLI.Disable()
+		}
+		if mSignOut != nil {
+			mSignOut.Disable()
+		}
+		return
+	}
+
+	status := auth.AuthStatus{Source: auth.AuthSourceNone}
+	if authenticator != nil {
+		status = authenticator.Status()
+	}
+	refreshAuthMenu(status)
 }
 
 func refreshProvidersMenu() {
@@ -419,13 +518,6 @@ func providersMenuTitle() string {
 	default:
 		return fmt.Sprintf("Providers: %s", filepath.Base(menubarCfg.ProvidersConfigPath))
 	}
-}
-
-func authMenuTitle() string {
-	if authenticator != nil && authenticator.IsSignedIn() {
-		return "Sign Out"
-	}
-	return "Sign In"
 }
 
 func logProvidersConfigLoadError(err error) {

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -22,7 +22,7 @@ var (
 	authenticator *auth.Authenticator
 
 	// Menu items kept at package level so helpers can update them.
-	mAuthStatus      *systray.MenuItem
+	mAuthMenu        *systray.MenuItem
 	mToggle          *systray.MenuItem
 	mSignInGitHub    *systray.MenuItem
 	mUseGitHubCLI    *systray.MenuItem
@@ -60,8 +60,12 @@ func onReady() {
 	systray.SetIcon(iconOff)
 	systray.SetTooltip("Vekil - Stopped")
 
-	mAuthStatus = systray.AddMenuItem("○ Not signed in", "")
-	mAuthStatus.Disable()
+	mAuthMenu = systray.AddMenuItem("GitHub Auth: Not Signed In", "GitHub authentication")
+	mSignInGitHub = mAuthMenu.AddSubMenuItem("Sign In with GitHub", "Sign in through GitHub in your browser and let Vekil manage the token")
+	mUseGitHubCLI = mAuthMenu.AddSubMenuItem("Use GitHub CLI Account", "Use the account already authenticated with gh auth login")
+	mAuthMenu.AddSeparator()
+	mSignOut = mAuthMenu.AddSubMenuItem("Sign Out", "Clear Vekil authentication")
+
 	mVersion := systray.AddMenuItem(versionMenuTitle(), "Current app version")
 	mVersion.Disable()
 	systray.AddSeparator()
@@ -82,11 +86,6 @@ func onReady() {
 		}
 		mLaunch.Check()
 	}
-
-	mSignInGitHub = systray.AddMenuItem("Sign In with GitHub", "Sign in with GitHub using a browser code")
-	mUseGitHubCLI = systray.AddMenuItem("Use GitHub CLI", "Use the currently authenticated GitHub CLI account")
-	mSignOut = systray.AddMenuItem("Sign Out", "Clear Vekil authentication")
-	systray.AddSeparator()
 
 	var mCheckUpdates *systray.MenuItem
 	if updaterSupported() {
@@ -172,7 +171,7 @@ func startProxy() {
 			log.Error("auth failed", logger.Err(err))
 			showErrorDialog(
 				"GitHub Sign In Required",
-				fmt.Sprintf("The active providers config uses GitHub Copilot, but Vekil could not refresh authentication.\n\nChoose ‘Sign In with GitHub’ or ‘Use GitHub CLI’ from the Vekil menu, then start Vekil again.\n\n%v", err),
+				fmt.Sprintf("The active providers config uses GitHub Copilot, but Vekil could not refresh authentication.\n\nOpen ‘GitHub Auth’ and choose ‘Sign In with GitHub’ or ‘Use GitHub CLI Account’, then start Vekil again.\n\n%v", err),
 			)
 			refreshSessionUI()
 			return
@@ -238,7 +237,7 @@ func signInWithGitHub() {
 	}()
 
 	setAuthActionsEnabled(false)
-	mAuthStatus.SetTitle("⟳ Signing in with GitHub…")
+	mAuthMenu.SetTitle("GitHub Auth: Signing in with GitHub…")
 
 	dcResp, err := authenticator.RequestDeviceCode(ctx)
 	if err != nil {
@@ -266,7 +265,7 @@ func signInWithGitHub() {
 	}
 
 	openURL(dcResp.VerificationURI)
-	mAuthStatus.SetTitle("⟳ Waiting for authorization…")
+	mAuthMenu.SetTitle("GitHub Auth: Waiting for authorization…")
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
 		log.Error("authorization failed", logger.Err(err))
@@ -304,7 +303,7 @@ func signInWithGitHubCLI() {
 	}()
 
 	setAuthActionsEnabled(false)
-	mAuthStatus.SetTitle("⟳ Signing in with GitHub CLI…")
+	mAuthMenu.SetTitle("GitHub Auth: Signing in with GitHub CLI…")
 
 	if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
 		log.Error("github cli sign-in failed", logger.Err(err))
@@ -438,8 +437,8 @@ func refreshSessionUI() {
 }
 
 func refreshAuthMenu(status auth.AuthStatus) {
-	if mAuthStatus != nil {
-		mAuthStatus.SetTitle(authStatusTitle(status))
+	if mAuthMenu != nil {
+		mAuthMenu.SetTitle(authMenuTitle(status))
 	}
 	if mSignInGitHub != nil {
 		mSignInGitHub.Enable()
@@ -456,23 +455,23 @@ func refreshAuthMenu(status auth.AuthStatus) {
 	}
 }
 
-func authStatusTitle(status auth.AuthStatus) string {
+func authMenuTitle(status auth.AuthStatus) string {
 	if status.SignedIn {
 		switch status.Source {
 		case auth.AuthSourceEnv:
-			return "● Signed in with environment token"
+			return "GitHub Auth: Environment Token"
 		case auth.AuthSourceVekil:
-			return "● Signed in with GitHub"
+			return "GitHub Auth: Signed in with GitHub"
 		case auth.AuthSourceGitHubCLI:
-			return "● Using GitHub CLI"
+			return "GitHub Auth: Using GitHub CLI Account"
 		default:
-			return "● Signed in"
+			return "GitHub Auth: Signed In"
 		}
 	}
 	if status.SignedOut {
-		return "○ Signed out"
+		return "GitHub Auth: Signed Out"
 	}
-	return "○ Not signed in"
+	return "GitHub Auth: Not Signed In"
 }
 
 func setAuthActionsEnabled(enabled bool) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,11 @@ These overrides only affect Copilot-backed upstream requests.
 
 For CI or other non-interactive environments, set `COPILOT_GITHUB_TOKEN` to a GitHub token for a user with GitHub Copilot access. This is the only GitHub token environment variable Vekil consumes directly; it overrides cached Vekil login state and is exchanged for a short-lived Copilot token at startup.
 
-Vekil intentionally ignores generic GitHub token variables such as `GH_TOKEN` and `GITHUB_TOKEN`. If `COPILOT_GITHUB_TOKEN` and Vekil's own cached GitHub token are unavailable, Vekil probes an authenticated GitHub CLI by running `gh auth token --hostname github.com` and uses that token without copying it into Vekil's `access-token` cache.
+Vekil intentionally ignores generic GitHub token variables such as `GH_TOKEN` and `GITHUB_TOKEN`. If you want Vekil to use an authenticated GitHub CLI account, opt in explicitly with `vekil login --github-cli` or `vekil login --gh`; Vekil then runs `gh auth token --hostname github.com` for Copilot token refreshes without copying that token into Vekil's `access-token` cache.
+
+Plain `vekil login` refreshes an existing Vekil-managed login when possible, otherwise starts GitHub's device-code flow. Use `vekil login --force` to force a new device-code flow even if an existing login can still refresh. A device-code sign-in disables GitHub CLI auto sign-in because the active account is then managed by Vekil rather than by `gh`.
+
+After `vekil logout` or menubar Sign Out, Vekil clears its cached credentials, disables GitHub CLI auto sign-in, and suppresses automatic GitHub CLI reuse until you explicitly opt back in with `vekil login --github-cli` or `vekil login --gh`. `COPILOT_GITHUB_TOKEN` remains an explicit override and still works while signed out.
 
 ### OpenAI Codex
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,9 +31,9 @@ These overrides only affect Copilot-backed upstream requests.
 
 ### GitHub Copilot
 
-For CI or other non-interactive environments, the proxy accepts a GitHub token from `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`.
+For CI or other non-interactive environments, set `COPILOT_GITHUB_TOKEN` to a GitHub token for a user with GitHub Copilot access. This is the only GitHub token environment variable Vekil consumes directly; it overrides cached Vekil login state and is exchanged for a short-lived Copilot token at startup.
 
-If one of these is set, it overrides any cached login state and is exchanged for a short-lived Copilot token at startup.
+Vekil intentionally ignores generic GitHub token variables such as `GH_TOKEN` and `GITHUB_TOKEN`. If `COPILOT_GITHUB_TOKEN` and Vekil's own cached GitHub token are unavailable, Vekil probes an authenticated GitHub CLI by running `gh auth token --hostname github.com` and uses that token without copying it into Vekil's `access-token` cache.
 
 ### OpenAI Codex
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ These overrides only affect Copilot-backed upstream requests.
 
 For CI or other non-interactive environments, set `COPILOT_GITHUB_TOKEN` to a GitHub token for a user with GitHub Copilot access. This is the only GitHub token environment variable Vekil consumes directly; it overrides cached Vekil login state and is exchanged for a short-lived Copilot token at startup.
 
-Vekil intentionally ignores generic GitHub token variables such as `GH_TOKEN` and `GITHUB_TOKEN`. If you want Vekil to use an authenticated GitHub CLI account, opt in explicitly with `vekil login --github-cli` or `vekil login --gh`; Vekil then runs `gh auth token --hostname github.com` for Copilot token refreshes without copying that token into Vekil's `access-token` cache.
+Vekil intentionally ignores generic GitHub token variables such as `GH_TOKEN` and `GITHUB_TOKEN`. If you want Vekil to use an authenticated GitHub CLI account, opt in explicitly with `vekil login --github-cli` or `vekil login --gh`; Vekil then runs `gh auth token --hostname github.com` for Copilot access and keeps that token in memory only, without copying it into Vekil's `access-token` or `api-key.json` caches.
 
 Plain `vekil login` refreshes an existing Vekil-managed login when possible, otherwise starts GitHub's device-code flow. Use `vekil login --force` to force a new device-code flow even if an existing login can still refresh. A device-code sign-in disables GitHub CLI auto sign-in because the active account is then managed by Vekil rather than by `gh`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,13 +103,19 @@ Startup behavior depends on the providers that are active in your deployment.
 
 ### GitHub Copilot
 
-If you are using zero-config startup or an explicit `type: "copilot"` provider, the proxy starts GitHub's device code flow on first run:
+If you are using zero-config startup or an explicit `type: "copilot"` provider, the proxy first looks for GitHub authentication in this order:
+
+1. `COPILOT_GITHUB_TOKEN` when set explicitly for CI or another non-interactive environment.
+2. Vekil's cached GitHub access token in `~/.config/vekil/`.
+3. An authenticated GitHub CLI via `gh auth token --hostname github.com`.
+
+If none of those sources is available, Vekil starts GitHub's device code flow on first run:
 
 1. Visit the URL shown in the terminal.
 2. Enter the one-time code.
 3. Authorize the application.
 
-Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry.
+Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry. Tokens borrowed from the GitHub CLI are used for the Copilot exchange but are not copied into Vekil's `access-token` cache.
 If `HTTP_PROXY` or `HTTPS_PROXY` points at a local loopback proxy that is not running, the auth flow automatically retries GitHub requests directly.
 
 ### Azure OpenAI

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,9 +117,9 @@ If none of those sources is available, Vekil starts GitHub's device-code flow on
 
 You can also run `vekil login` ahead of time to start the same device-code flow. If an existing Vekil login is still refreshable, `vekil login` reuses it and prints `Already logged in.`; use `vekil login --force` to skip that refresh check and force a new device-code sign-in.
 
-To use the account that is already authenticated with the GitHub CLI, run `vekil login --github-cli` or the shorter `vekil login --gh`. This records an explicit preference to use `gh` for future Copilot token refreshes, but the GitHub CLI token itself is not copied into Vekil's `access-token` cache.
+To use the account that is already authenticated with the GitHub CLI, run `vekil login --github-cli` or the shorter `vekil login --gh`. This records an explicit preference to use `gh` for future Copilot access. Vekil uses the GitHub CLI token in memory only and does not copy it into Vekil's `access-token` or `api-key.json` caches.
 
-Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry. GitHub CLI-backed sign-in caches only the short-lived Copilot token and the explicit `gh` opt-in preference; it does not persist the GitHub CLI access token as a Vekil-managed token.
+Device-code sign-in caches Vekil-managed tokens in `~/.config/vekil/` and refreshes them automatically before expiry. GitHub CLI-backed sign-in records only the explicit `gh` opt-in preference on disk; each process asks `gh` for the token and keeps it in memory only.
 
 Signing out with `vekil logout` clears Vekil's cached credentials, disables GitHub CLI auto sign-in, and records a signed-out state so Vekil will not automatically borrow GitHub CLI credentials again. Run `vekil login --github-cli` to opt back into GitHub CLI auth, sign in with the device-code flow to use Vekil-managed OAuth, or set `COPILOT_GITHUB_TOKEN` explicitly for a non-interactive session.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,15 +107,22 @@ If you are using zero-config startup or an explicit `type: "copilot"` provider, 
 
 1. `COPILOT_GITHUB_TOKEN` when set explicitly for CI or another non-interactive environment.
 2. Vekil's cached GitHub access token in `~/.config/vekil/`.
-3. An authenticated GitHub CLI via `gh auth token --hostname github.com`.
+3. An authenticated GitHub CLI via `gh auth token --hostname github.com`, but only after you explicitly opt in with `vekil login --github-cli` or `vekil login --gh`.
 
-If none of those sources is available, Vekil starts GitHub's device code flow on first run:
+If none of those sources is available, Vekil starts GitHub's device-code flow on first run:
 
 1. Visit the URL shown in the terminal.
 2. Enter the one-time code.
 3. Authorize the application.
 
-Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry. Tokens borrowed from the GitHub CLI are used for the Copilot exchange but are not copied into Vekil's `access-token` cache.
+You can also run `vekil login` ahead of time to start the same device-code flow. If an existing Vekil login is still refreshable, `vekil login` reuses it and prints `Already logged in.`; use `vekil login --force` to skip that refresh check and force a new device-code sign-in.
+
+To use the account that is already authenticated with the GitHub CLI, run `vekil login --github-cli` or the shorter `vekil login --gh`. This records an explicit preference to use `gh` for future Copilot token refreshes, but the GitHub CLI token itself is not copied into Vekil's `access-token` cache.
+
+Tokens are cached in `~/.config/vekil/` and refreshed automatically before expiry. GitHub CLI-backed sign-in caches only the short-lived Copilot token and the explicit `gh` opt-in preference; it does not persist the GitHub CLI access token as a Vekil-managed token.
+
+Signing out with `vekil logout` clears Vekil's cached credentials, disables GitHub CLI auto sign-in, and records a signed-out state so Vekil will not automatically borrow GitHub CLI credentials again. Run `vekil login --github-cli` to opt back into GitHub CLI auth, sign in with the device-code flow to use Vekil-managed OAuth, or set `COPILOT_GITHUB_TOKEN` explicitly for a non-interactive session.
+
 If `HTTP_PROXY` or `HTTPS_PROXY` points at a local loopback proxy that is not running, the auth flow automatically retries GitHub requests directly.
 
 ### Azure OpenAI

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -54,7 +54,7 @@ open "Vekil.app"
 The tray menu shows a read-only GitHub auth status plus explicit actions:
 
 - `Sign In with GitHub` starts Vekil's browser/device-code flow and stores Vekil-managed credentials in `~/.config/vekil/`.
-- `Use GitHub CLI` opts in to the account already authenticated by `gh auth login`. Vekil uses `gh auth token --hostname github.com` for Copilot token refreshes, but it does not copy the GitHub CLI token into Vekil's `access-token` cache.
+- `Use GitHub CLI` opts in to the account already authenticated by `gh auth login`. Vekil uses `gh auth token --hostname github.com` for Copilot access and keeps that token in memory only; it does not copy the GitHub CLI token into Vekil's `access-token` or `api-key.json` caches.
 - `Sign Out` clears Vekil's cached credentials, disables GitHub CLI auto sign-in, and records a signed-out state. The app will not silently fall back to GitHub CLI again until you choose `Use GitHub CLI` or run `vekil login --github-cli` / `vekil login --gh`.
 
 When the active providers config uses Copilot, start-up needs one of those GitHub auth sources or an explicit `COPILOT_GITHUB_TOKEN`. If auth is missing or expired, the app asks you to choose `Sign In with GitHub` or `Use GitHub CLI` instead of starting a sign-in flow automatically.

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -44,9 +44,22 @@ open "Vekil.app"
 - status icon: white robot when running, gray when stopped
 - current app version shown in the menu
 - choose and persist a `providers-config` JSON or YAML file from the menu
+- separate authentication actions for `Sign In with GitHub`, `Use GitHub CLI`, and `Sign Out`
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
 - `Check for Updates…` in packaged macOS app builds
+
+## Authentication
+
+The tray menu shows a read-only GitHub auth status plus explicit actions:
+
+- `Sign In with GitHub` starts Vekil's browser/device-code flow and stores Vekil-managed credentials in `~/.config/vekil/`.
+- `Use GitHub CLI` opts in to the account already authenticated by `gh auth login`. Vekil uses `gh auth token --hostname github.com` for Copilot token refreshes, but it does not copy the GitHub CLI token into Vekil's `access-token` cache.
+- `Sign Out` clears Vekil's cached credentials, disables GitHub CLI auto sign-in, and records a signed-out state. The app will not silently fall back to GitHub CLI again until you choose `Use GitHub CLI` or run `vekil login --github-cli` / `vekil login --gh`.
+
+When the active providers config uses Copilot, start-up needs one of those GitHub auth sources or an explicit `COPILOT_GITHUB_TOKEN`. If auth is missing or expired, the app asks you to choose `Sign In with GitHub` or `Use GitHub CLI` instead of starting a sign-in flow automatically.
+
+Provider-only configs that omit Copilot do not require GitHub auth; the proxy can keep running after `Sign Out` in that mode.
 
 ## Providers Config
 

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -44,20 +44,20 @@ open "Vekil.app"
 - status icon: white robot when running, gray when stopped
 - current app version shown in the menu
 - choose and persist a `providers-config` JSON or YAML file from the menu
-- separate authentication actions for `Sign In with GitHub`, `Use GitHub CLI`, and `Sign Out`
+- `GitHub Auth` submenu with current status and actions for `Sign In with GitHub`, `Use GitHub CLI Account`, and `Sign Out`
 - optional LaunchAgent integration for launch at login
 - tooltip showing running/stopped state and port
 - `Check for Updates…` in packaged macOS app builds
 
 ## Authentication
 
-The tray menu shows a read-only GitHub auth status plus explicit actions:
+The tray menu shows a `GitHub Auth` parent item whose title reports the current auth state. Its submenu contains explicit actions:
 
 - `Sign In with GitHub` starts Vekil's browser/device-code flow and stores Vekil-managed credentials in `~/.config/vekil/`.
-- `Use GitHub CLI` opts in to the account already authenticated by `gh auth login`. Vekil uses `gh auth token --hostname github.com` for Copilot access and keeps that token in memory only; it does not copy the GitHub CLI token into Vekil's `access-token` or `api-key.json` caches.
-- `Sign Out` clears Vekil's cached credentials, disables GitHub CLI auto sign-in, and records a signed-out state. The app will not silently fall back to GitHub CLI again until you choose `Use GitHub CLI` or run `vekil login --github-cli` / `vekil login --gh`.
+- `Use GitHub CLI Account` opts in to the account already authenticated by `gh auth login`. Vekil uses `gh auth token --hostname github.com` for Copilot access and keeps that token in memory only; it does not copy the GitHub CLI token into Vekil's `access-token` or `api-key.json` caches.
+- `Sign Out` clears Vekil's cached credentials, disables GitHub CLI auto sign-in, and records a signed-out state. The app will not silently fall back to GitHub CLI again until you choose `Use GitHub CLI Account` or run `vekil login --github-cli` / `vekil login --gh`.
 
-When the active providers config uses Copilot, start-up needs one of those GitHub auth sources or an explicit `COPILOT_GITHUB_TOKEN`. If auth is missing or expired, the app asks you to choose `Sign In with GitHub` or `Use GitHub CLI` instead of starting a sign-in flow automatically.
+When the active providers config uses Copilot, start-up needs one of those GitHub auth sources or an explicit `COPILOT_GITHUB_TOKEN`. If auth is missing or expired, the app asks you to open `GitHub Auth` and choose `Sign In with GitHub` or `Use GitHub CLI Account` instead of starting a sign-in flow automatically.
 
 Provider-only configs that omit Copilot do not require GitHub auth; the proxy can keep running after `Sign Out` in that mode.
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strconv"
@@ -54,45 +55,140 @@ func commandFromArgs(args []string) cliCommand {
 	}
 }
 
-func runLogin(args []string) {
-	fs := flag.NewFlagSet("login", flag.ExitOnError)
-	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	fs.Parse(args) //nolint:errcheck
+type loginOptions struct {
+	tokenDir     string
+	useGitHubCLI bool
+	force        bool
+}
 
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
+var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
+
+type loginAuthenticator interface {
+	SignInWithGitHubCLI(context.Context) error
+	RefreshTokenNonInteractive(context.Context) (string, error)
+	RequestDeviceCode(context.Context) (*auth.DeviceCodeResponse, error)
+	PollForAuthorization(context.Context, *auth.DeviceCodeResponse) error
+}
+
+type loginDeps struct {
+	stderr           io.Writer
+	newAuthenticator func(string) (loginAuthenticator, error)
+	openURL          func(string) error
+}
+
+func runLogin(args []string) {
+	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+		os.Exit(code)
+	}
+}
+
+func defaultLoginDeps() loginDeps {
+	return loginDeps{
+		stderr: os.Stderr,
+		newAuthenticator: func(tokenDir string) (loginAuthenticator, error) {
+			return auth.NewAuthenticator(tokenDir)
+		},
+		openURL: browser.OpenURL,
+	}
+}
+
+func runLoginWithDeps(args []string, deps loginDeps) int {
+	deps = normalizeLoginDeps(deps)
+
+	opts, err := parseLoginOptions(args, deps.stderr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		if err == flag.ErrHelp {
+			return 0
+		}
+		if err == errConflictingLoginFlags {
+			fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		}
+		return 2
+	}
+
+	authenticator, err := deps.newAuthenticator(opts.tokenDir)
+	if err != nil {
+		fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
 	ctx := context.Background()
-	if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-		fmt.Fprintln(os.Stderr, "Already logged in.")
-		return
-	} else if !auth.IsInteractiveLoginRequired(err) {
-		fmt.Fprintf(os.Stderr, "error refreshing existing login: %v\n", err)
-		os.Exit(1)
+	if opts.useGitHubCLI {
+		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
+			fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(deps.stderr, "Login successful.")
+		return 0
+	}
+
+	if !opts.force {
+		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
+			fmt.Fprintln(deps.stderr, "Already logged in.")
+			return 0
+		} else if !auth.IsInteractiveLoginRequired(err) {
+			fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
+			return 1
+		}
 	}
 
 	dcResp, err := authenticator.RequestDeviceCode(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error requesting device code: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(deps.stderr, "error requesting device code: %v\n", err)
+		return 1
 	}
 
-	fmt.Fprintf(os.Stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	fmt.Fprintf(os.Stderr, "Enter code: %s\n", dcResp.UserCode)
+	fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+	fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
 
-	if err := browser.OpenURL(dcResp.VerificationURI); err != nil {
-		fmt.Fprintf(os.Stderr, "Could not open browser automatically, please visit the URL above.\n")
+	if err := deps.openURL(dcResp.VerificationURI); err != nil {
+		fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
-	fmt.Fprintln(os.Stderr, "Login successful.")
+	fmt.Fprintln(deps.stderr, "Login successful.")
+	return 0
+}
+
+func normalizeLoginDeps(deps loginDeps) loginDeps {
+	if deps.stderr == nil {
+		deps.stderr = io.Discard
+	}
+	if deps.newAuthenticator == nil {
+		deps.newAuthenticator = defaultLoginDeps().newAuthenticator
+	}
+	if deps.openURL == nil {
+		deps.openURL = func(string) error { return nil }
+	}
+	return deps
+}
+
+func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	opts := loginOptions{}
+	fs := flag.NewFlagSet("login", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
+	gh := fs.Bool("gh", false, "Alias for --github-cli")
+	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
+	}
+
+	opts.tokenDir = *tokenDir
+	opts.useGitHubCLI = *githubCLI || *gh
+	opts.force = *force
+	if opts.useGitHubCLI && opts.force {
+		return opts, errConflictingLoginFlags
+	}
+	return opts, nil
 }
 
 func runLogout(args []string) {
@@ -111,7 +207,7 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Fprintln(os.Stderr, "Logged out.")
+	fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 }
 
 func runServe() {

--- a/main.go
+++ b/main.go
@@ -101,56 +101,56 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			return 0
 		}
 		if err == errConflictingLoginFlags {
-			fmt.Fprintf(deps.stderr, "error: %v\n", err)
+			_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
 		}
 		return 2
 	}
 
 	authenticator, err := deps.newAuthenticator(opts.tokenDir)
 	if err != nil {
-		fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
 		return 1
 	}
 
 	ctx := context.Background()
 	if opts.useGitHubCLI {
 		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
-			fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
+			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
-			fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
+			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
 			return 1
 		}
 	}
 
 	dcResp, err := authenticator.RequestDeviceCode(ctx)
 	if err != nil {
-		fmt.Fprintf(deps.stderr, "error requesting device code: %v\n", err)
+		_, _ = fmt.Fprintf(deps.stderr, "error requesting device code: %v\n", err)
 		return 1
 	}
 
-	fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
-		fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
 		return 1
 	}
 
-	fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
 	return 0
 }
 
@@ -198,16 +198,16 @@ func runLogout(args []string) {
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
 	if err := authenticator.SignOut(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 }
 
 func runServe() {
@@ -306,7 +306,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -319,7 +319,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -332,7 +332,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/sozercan/vekil/auth"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -150,4 +154,183 @@ func TestCommandFromArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
+	for _, helpArg := range []string{"-h", "--help"} {
+		t.Run(helpArg, func(t *testing.T) {
+			var stderr bytes.Buffer
+			constructed := false
+
+			code := runLoginWithDeps([]string{helpArg}, loginDeps{
+				stderr: &stderr,
+				newAuthenticator: func(string) (loginAuthenticator, error) {
+					constructed = true
+					return &fakeLoginAuthenticator{}, nil
+				},
+			})
+
+			if code != 0 {
+				t.Fatalf("runLoginWithDeps(%q) code = %d, want 0", helpArg, code)
+			}
+			if constructed {
+				t.Fatalf("help constructed an authenticator")
+			}
+
+			output := stderr.String()
+			for _, want := range []string{"github-cli", "gh", "force"} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("help output missing %q:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
+	var stderr bytes.Buffer
+	constructed := false
+
+	code := runLoginWithDeps([]string{"--github-cli", "--force"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			constructed = true
+			return &fakeLoginAuthenticator{}, nil
+		},
+	})
+
+	if code != 2 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 2", code)
+	}
+	if constructed {
+		t.Fatalf("conflicting login flags constructed an authenticator")
+	}
+	if got := stderr.String(); !strings.Contains(got, "--github-cli/--gh cannot be used with --force") {
+		t.Fatalf("stderr missing conflict error, got %q", got)
+	}
+}
+
+func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{}
+	var gotTokenDir string
+
+	code := runLoginWithDeps([]string{"--gh", "--token-dir", "/tmp/vekil-test-tokens"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(tokenDir string) (loginAuthenticator, error) {
+			gotTokenDir = tokenDir
+			return fake, nil
+		},
+	})
+
+	if code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if gotTokenDir != "/tmp/vekil-test-tokens" {
+		t.Fatalf("newAuthenticator tokenDir = %q, want /tmp/vekil-test-tokens", gotTokenDir)
+	}
+	if fake.signInWithGitHubCLICalls != 1 {
+		t.Fatalf("SignInWithGitHubCLI calls = %d, want 1", fake.signInWithGitHubCLICalls)
+	}
+	if fake.refreshCalls != 0 || fake.requestDeviceCodeCalls != 0 || fake.pollForAuthorizationCalls != 0 {
+		t.Fatalf("unexpected auth flow calls: refresh=%d request=%d poll=%d", fake.refreshCalls, fake.requestDeviceCodeCalls, fake.pollForAuthorizationCalls)
+	}
+	if got := stderr.String(); !strings.Contains(got, "Login successful.") {
+		t.Fatalf("stderr missing success message, got %q", got)
+	}
+}
+
+func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{
+		deviceCodeResponse: &auth.DeviceCodeResponse{
+			DeviceCode:      "device-code",
+			UserCode:        "ABCD-EFGH",
+			VerificationURI: "https://github.com/login/device",
+			Interval:        1,
+		},
+	}
+	var openedURL string
+
+	code := runLoginWithDeps([]string{"--force"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+		openURL: func(url string) error {
+			openedURL = url
+			return nil
+		},
+	})
+
+	if code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if fake.refreshCalls != 0 {
+		t.Fatalf("RefreshTokenNonInteractive calls = %d, want 0", fake.refreshCalls)
+	}
+	if fake.requestDeviceCodeCalls != 1 {
+		t.Fatalf("RequestDeviceCode calls = %d, want 1", fake.requestDeviceCodeCalls)
+	}
+	if fake.pollForAuthorizationCalls != 1 {
+		t.Fatalf("PollForAuthorization calls = %d, want 1", fake.pollForAuthorizationCalls)
+	}
+	if fake.polledDeviceCode != fake.deviceCodeResponse {
+		t.Fatalf("PollForAuthorization received %#v, want %#v", fake.polledDeviceCode, fake.deviceCodeResponse)
+	}
+	if openedURL != fake.deviceCodeResponse.VerificationURI {
+		t.Fatalf("opened URL = %q, want %q", openedURL, fake.deviceCodeResponse.VerificationURI)
+	}
+	output := stderr.String()
+	for _, want := range []string{"Opening browser to https://github.com/login/device", "Enter code: ABCD-EFGH", "Login successful."} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("stderr missing %q, got %q", want, output)
+		}
+	}
+}
+
+type fakeLoginAuthenticator struct {
+	signInWithGitHubCLICalls int
+	signInWithGitHubCLIErr   error
+
+	refreshCalls int
+	refreshToken string
+	refreshErr   error
+
+	requestDeviceCodeCalls int
+	deviceCodeResponse     *auth.DeviceCodeResponse
+	requestDeviceCodeErr   error
+
+	pollForAuthorizationCalls int
+	polledDeviceCode          *auth.DeviceCodeResponse
+	pollForAuthorizationErr   error
+}
+
+func (f *fakeLoginAuthenticator) SignInWithGitHubCLI(context.Context) error {
+	f.signInWithGitHubCLICalls++
+	return f.signInWithGitHubCLIErr
+}
+
+func (f *fakeLoginAuthenticator) RefreshTokenNonInteractive(context.Context) (string, error) {
+	f.refreshCalls++
+	return f.refreshToken, f.refreshErr
+}
+
+func (f *fakeLoginAuthenticator) RequestDeviceCode(context.Context) (*auth.DeviceCodeResponse, error) {
+	f.requestDeviceCodeCalls++
+	if f.deviceCodeResponse == nil {
+		f.deviceCodeResponse = &auth.DeviceCodeResponse{
+			DeviceCode:      "device-code",
+			UserCode:        "USER-CODE",
+			VerificationURI: "https://github.com/login/device",
+			Interval:        1,
+		}
+	}
+	return f.deviceCodeResponse, f.requestDeviceCodeErr
+}
+
+func (f *fakeLoginAuthenticator) PollForAuthorization(_ context.Context, dcResp *auth.DeviceCodeResponse) error {
+	f.pollForAuthorizationCalls++
+	f.polledDeviceCode = dcResp
+	return f.pollForAuthorizationErr
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -381,7 +381,7 @@ func writeCachedModelsResponse(w http.ResponseWriter, entry cachedModelsResponse
 // HandleHealthz handles GET /healthz and returns {"status":"ok"}.
 func (h *ProxyHandler) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"ok"}`))
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
 // HandleReadyz validates that the proxy can obtain an auth token and reach the
@@ -834,7 +834,7 @@ func supportsEndpoint(supportedEndpoints []string, endpoint string) bool {
 func writeAnthropicError(w http.ResponseWriter, status int, errType, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(models.AnthropicError{
+	_ = json.NewEncoder(w).Encode(models.AnthropicError{
 		Type: "error",
 		Error: struct {
 			Type    string `json:"type"`
@@ -857,7 +857,7 @@ func writeOpenAIErrorWithRetryAfter(w http.ResponseWriter, status int, message, 
 		}
 	}
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"error": map[string]interface{}{
 			"message": message,
 			"type":    errType,

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -368,9 +368,9 @@ func TestHandleAnthropicMessages(t *testing.T) {
 		// Return SSE streaming response (since handler forces streaming)
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("data: {\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello from the backend!\"},\"finish_reason\":null}]}\n\n"))
-		w.Write([]byte("data: {\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n"))
-		w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello from the backend!\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	})
 
 	anthropicReq := `{
@@ -518,7 +518,7 @@ func TestHandleAnthropicMessagesInvalidJSON(t *testing.T) {
 func TestHandleAnthropicUpstreamError(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"error": "internal server error"}`))
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
 	})
 
 	anthropicReq := `{
@@ -559,7 +559,9 @@ func TestHandleOpenAIChatCompletions(t *testing.T) {
 		// Echo back the request body as a mock response
 		body, _ := io.ReadAll(r.Body)
 		var oaiReq models.OpenAIRequest
-		json.Unmarshal(body, &oaiReq)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("json.Unmarshal(upstream request) error = %v", err)
+		}
 
 		finishReason := "stop"
 		resp := models.OpenAIResponse{
@@ -579,7 +581,7 @@ func TestHandleOpenAIChatCompletions(t *testing.T) {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 
 	oaiReq := `{
@@ -634,7 +636,7 @@ func TestHandleResponses(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"id":"resp-123","object":"response","status":"completed"}`))
+		_, _ = w.Write([]byte(`{"id":"resp-123","object":"response","status":"completed"}`))
 	})
 
 	responsesReq := `{
@@ -2333,7 +2335,7 @@ func TestHandleOpenAIChatCompletionsUpstreamError(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(`{"error":{"message":"service unavailable","type":"server_error"}}`))
+		_, _ = w.Write([]byte(`{"error":{"message":"service unavailable","type":"server_error"}}`))
 	})
 
 	oaiReq := `{
@@ -3456,7 +3458,7 @@ func TestHandleModels(t *testing.T) {
 		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"error":"internal server error"}`))
+			_, _ = w.Write([]byte(`{"error":"internal server error"}`))
 		})
 		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
 		w := httptest.NewRecorder()
@@ -4357,13 +4359,17 @@ func TestOpenAIErrorResponseShape(t *testing.T) {
 
 	// Check values
 	var msg string
-	json.Unmarshal(errObj["message"], &msg)
+	if err := json.Unmarshal(errObj["message"], &msg); err != nil {
+		t.Fatalf("json.Unmarshal(message) error = %v", err)
+	}
 	if msg != "test error message" {
 		t.Errorf("message = %q, want %q", msg, "test error message")
 	}
 
 	var errType string
-	json.Unmarshal(errObj["type"], &errType)
+	if err := json.Unmarshal(errObj["type"], &errType); err != nil {
+		t.Fatalf("json.Unmarshal(type) error = %v", err)
+	}
 	if errType != "invalid_request_error" {
 		t.Errorf("type = %q, want %q", errType, "invalid_request_error")
 	}
@@ -4388,14 +4394,16 @@ func TestOpenAIChatCompletionsStreaming(t *testing.T) {
 			Stream *bool `json:"stream"`
 		}
 		body, _ := io.ReadAll(r.Body)
-		json.Unmarshal(body, &partial)
+		if err := json.Unmarshal(body, &partial); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
 		if partial.Stream == nil || !*partial.Stream {
 			t.Error("expected stream=true in upstream request")
 		}
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(sseBody))
+		_, _ = w.Write([]byte(sseBody))
 	})
 
 	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
@@ -4449,7 +4457,7 @@ func TestOpenAIResponsesStreaming(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(sseBody))
+		_, _ = w.Write([]byte(sseBody))
 	})
 
 	reqBody := `{"model":"gpt-4","input":"Hello","stream":true,"service_tier":"auto"}`
@@ -4516,7 +4524,7 @@ func TestOpenAIChatCompletionsUpstreamErrorPassthrough(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","param":"model","code":null}}`))
+		_, _ = w.Write([]byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","param":"model","code":null}}`))
 	})
 
 	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}`
@@ -4547,7 +4555,7 @@ func TestOpenAIChatCompletionsUpstreamErrorPassthrough(t *testing.T) {
 func TestOpenAIChatCompletionsResponseShape(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"id": "chatcmpl-test",
 			"object": "chat.completion",
 			"created": 1700000000,
@@ -4587,14 +4595,18 @@ func TestOpenAIChatCompletionsResponseShape(t *testing.T) {
 
 	// Verify object is "chat.completion"
 	var obj string
-	json.Unmarshal(raw["object"], &obj)
+	if err := json.Unmarshal(raw["object"], &obj); err != nil {
+		t.Fatalf("json.Unmarshal(object) error = %v", err)
+	}
 	if obj != "chat.completion" {
 		t.Errorf("object = %q, want chat.completion", obj)
 	}
 
 	// Verify choices structure
 	var choices []map[string]json.RawMessage
-	json.Unmarshal(raw["choices"], &choices)
+	if err := json.Unmarshal(raw["choices"], &choices); err != nil {
+		t.Fatalf("json.Unmarshal(choices) error = %v", err)
+	}
 	if len(choices) != 1 {
 		t.Fatalf("expected 1 choice, got %d", len(choices))
 	}
@@ -4615,7 +4627,7 @@ func TestOpenAIChatCompletionsResponseShape(t *testing.T) {
 func TestOpenAIResponsesResponseShape(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"id": "resp-test",
 			"object": "response",
 			"created_at": 1700000000,
@@ -4650,7 +4662,9 @@ func TestOpenAIResponsesResponseShape(t *testing.T) {
 	}
 
 	var obj string
-	json.Unmarshal(raw["object"], &obj)
+	if err := json.Unmarshal(raw["object"], &obj); err != nil {
+		t.Fatalf("json.Unmarshal(object) error = %v", err)
+	}
 	if obj != "response" {
 		t.Errorf("object = %q, want response", obj)
 	}
@@ -4694,7 +4708,9 @@ func TestHandleAnthropicMessages_ParallelToolCalls(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		var oaiReq models.OpenAIRequest
 		body, _ := io.ReadAll(r.Body)
-		json.Unmarshal(body, &oaiReq)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
 		if oaiReq.Stream == nil || !*oaiReq.Stream {
 			t.Error("expected stream=true (forced streaming)")
 		}
@@ -4716,9 +4732,9 @@ func TestHandleAnthropicMessages_ParallelToolCalls(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		for _, chunk := range chunks {
 			b, _ := json.Marshal(chunk)
-			w.Write([]byte("data: " + string(b) + "\n\n"))
+			_, _ = w.Write([]byte("data: " + string(b) + "\n\n"))
 		}
-		w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	})
 
 	anthropicReq := `{
@@ -4770,7 +4786,9 @@ func TestInjectParallelToolCalls(t *testing.T) {
 		input := `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"f"}}]}`
 		result := injectParallelToolCalls([]byte(input))
 		var m map[string]json.RawMessage
-		json.Unmarshal(result, &m)
+		if err := json.Unmarshal(result, &m); err != nil {
+			t.Fatalf("json.Unmarshal(result) error = %v", err)
+		}
 		if string(m["parallel_tool_calls"]) != "true" {
 			t.Errorf("parallel_tool_calls = %s, want true", m["parallel_tool_calls"])
 		}
@@ -4780,7 +4798,9 @@ func TestInjectParallelToolCalls(t *testing.T) {
 		input := `{"model":"gpt-4","tools":[{"type":"function"}],"parallel_tool_calls":false}`
 		result := injectParallelToolCalls([]byte(input))
 		var m map[string]json.RawMessage
-		json.Unmarshal(result, &m)
+		if err := json.Unmarshal(result, &m); err != nil {
+			t.Fatalf("json.Unmarshal(result) error = %v", err)
+		}
 		if string(m["parallel_tool_calls"]) != "false" {
 			t.Errorf("parallel_tool_calls = %s, want false (preserved)", m["parallel_tool_calls"])
 		}
@@ -4817,7 +4837,9 @@ func TestOpenAIChatCompletions_InjectsParallelToolCalls(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		var oaiReq models.OpenAIRequest
 		body, _ := io.ReadAll(r.Body)
-		json.Unmarshal(body, &oaiReq)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
 		if oaiReq.ParallelToolCalls == nil || !*oaiReq.ParallelToolCalls {
 			t.Error("expected parallel_tool_calls=true injected by proxy")
 		}
@@ -4828,9 +4850,9 @@ func TestOpenAIChatCompletions_InjectsParallelToolCalls(t *testing.T) {
 		// Return SSE since proxy forced streaming
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n"))
-		w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
-		w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	})
 
 	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"f","parameters":{}}}]}`

--- a/proxy/integration_test.go
+++ b/proxy/integration_test.go
@@ -1,70 +1,72 @@
 package proxy
 
 import (
-"encoding/json"
-"io"
-"net/http"
-"net/http/httptest"
-"strings"
-"testing"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-"github.com/sozercan/vekil/models"
+	"github.com/sozercan/vekil/models"
 )
 
 // TestBugReport_AnthropicSingleTool verifies single tool call works (Anthropic path).
 func TestBugReport_AnthropicSingleTool(t *testing.T) {
-handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
-w.Header().Set("Content-Type", "text/event-stream")
-w.WriteHeader(http.StatusOK)
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_single\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\"}\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":50,\"completion_tokens\":25,\"total_tokens\":75}}\n\n"))
-w.Write([]byte("data: [DONE]\n\n"))
-})
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_single\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\"}\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":50,\"completion_tokens\":25,\"total_tokens\":75}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
 
-req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
 "model": "claude-opus-4.6-fast", "max_tokens": 4096,
 "messages": [{"role": "user", "content": "Call delegate_task"}],
 "tools": [{"name": "delegate_task", "description": "d", "input_schema": {"type": "object"}}]
 }`))
-w := httptest.NewRecorder()
-handler.HandleAnthropicMessages(w, req)
+	w := httptest.NewRecorder()
+	handler.HandleAnthropicMessages(w, req)
 
-var resp models.AnthropicResponse
-body, _ := io.ReadAll(w.Result().Body)
-json.Unmarshal(body, &resp)
+	var resp models.AnthropicResponse
+	body, _ := io.ReadAll(w.Result().Body)
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("json.Unmarshal(response) error = %v", err)
+	}
 
-toolCount := 0
-for _, c := range resp.Content {
-if c.Type == "tool_use" {
-toolCount++
-}
-}
-t.Logf("LLM response: stop_reason=%v, tool_calls=%d, tools_sent=1", resp.StopReason, toolCount)
-if resp.StopReason == nil || *resp.StopReason != "tool_use" {
-t.Errorf("stop_reason = %v, want tool_use", resp.StopReason)
-}
-if toolCount != 1 {
-t.Fatalf("tool_calls = %d, want 1", toolCount)
-}
+	toolCount := 0
+	for _, c := range resp.Content {
+		if c.Type == "tool_use" {
+			toolCount++
+		}
+	}
+	t.Logf("LLM response: stop_reason=%v, tool_calls=%d, tools_sent=1", resp.StopReason, toolCount)
+	if resp.StopReason == nil || *resp.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %v, want tool_use", resp.StopReason)
+	}
+	if toolCount != 1 {
+		t.Fatalf("tool_calls = %d, want 1", toolCount)
+	}
 }
 
 // TestBugReport_AnthropicParallelTools verifies parallel tool calls work (Anthropic path).
 // This was the primary bug: parallel tool calls were dropped in non-streaming mode.
 func TestBugReport_AnthropicParallelTools(t *testing.T) {
-handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
-w.Header().Set("Content-Type", "text/event-stream")
-w.WriteHeader(http.StatusOK)
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"I'll delegate both research tasks in parallel...\"}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc1\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 pros of Go\\\"}\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc2\",\"index\":1,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 cons of Go\\\"}\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":50,\"total_tokens\":150}}\n\n"))
-w.Write([]byte("data: [DONE]\n\n"))
-})
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"I'll delegate both research tasks in parallel...\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc1\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 pros of Go\\\"}\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc2\",\"index\":1,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 cons of Go\\\"}\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":50,\"total_tokens\":150}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
 
-req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
 "model": "claude-opus-4.6-fast", "max_tokens": 4096,
 "messages": [{"role": "user", "content": "Call delegate_task for pros and cons of Go in parallel."}],
 "tools": [
@@ -72,93 +74,99 @@ req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
 {"name": "wait_for_tasks", "description": "Wait", "input_schema": {"type": "object"}}
 ]
 }`))
-w := httptest.NewRecorder()
-handler.HandleAnthropicMessages(w, req)
+	w := httptest.NewRecorder()
+	handler.HandleAnthropicMessages(w, req)
 
-var resp models.AnthropicResponse
-body, _ := io.ReadAll(w.Result().Body)
-json.Unmarshal(body, &resp)
+	var resp models.AnthropicResponse
+	body, _ := io.ReadAll(w.Result().Body)
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("json.Unmarshal(response) error = %v", err)
+	}
 
-toolCount := 0
-for _, c := range resp.Content {
-if c.Type == "tool_use" {
-toolCount++
-}
-}
-t.Logf("LLM response: stop_reason=%v, tool_calls=%d, content_blocks=%d", resp.StopReason, toolCount, len(resp.Content))
-if resp.StopReason == nil || *resp.StopReason != "tool_use" {
-t.Errorf("stop_reason = %v, want tool_use", resp.StopReason)
-}
-if toolCount != 2 {
-t.Fatalf("tool_calls = %d, want 2 ← THIS WAS THE BUG (was 0 before fix)", toolCount)
-}
-if resp.Content[1].ID != "call_abc1" || resp.Content[1].Name != "delegate_task" {
-t.Errorf("tool[0] = %+v, want call_abc1/delegate_task", resp.Content[1])
-}
-if resp.Content[2].ID != "call_abc2" || resp.Content[2].Name != "delegate_task" {
-t.Errorf("tool[1] = %+v, want call_abc2/delegate_task", resp.Content[2])
-}
+	toolCount := 0
+	for _, c := range resp.Content {
+		if c.Type == "tool_use" {
+			toolCount++
+		}
+	}
+	t.Logf("LLM response: stop_reason=%v, tool_calls=%d, content_blocks=%d", resp.StopReason, toolCount, len(resp.Content))
+	if resp.StopReason == nil || *resp.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %v, want tool_use", resp.StopReason)
+	}
+	if toolCount != 2 {
+		t.Fatalf("tool_calls = %d, want 2 ← THIS WAS THE BUG (was 0 before fix)", toolCount)
+	}
+	if resp.Content[1].ID != "call_abc1" || resp.Content[1].Name != "delegate_task" {
+		t.Errorf("tool[0] = %+v, want call_abc1/delegate_task", resp.Content[1])
+	}
+	if resp.Content[2].ID != "call_abc2" || resp.Content[2].Name != "delegate_task" {
+		t.Errorf("tool[1] = %+v, want call_abc2/delegate_task", resp.Content[2])
+	}
 }
 
 // TestBugReport_OpenAISingleTool verifies single tool call works (OpenAI path with forced streaming).
 func TestBugReport_OpenAISingleTool(t *testing.T) {
-handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
-w.Header().Set("Content-Type", "text/event-stream")
-w.WriteHeader(http.StatusOK)
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_single\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\"}\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":50,\"completion_tokens\":25,\"total_tokens\":75}}\n\n"))
-w.Write([]byte("data: [DONE]\n\n"))
-})
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_single\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\"}\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":50,\"completion_tokens\":25,\"total_tokens\":75}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
 
-req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
 "model": "claude-opus-4.6-fast",
 "messages": [{"role": "user", "content": "Call delegate_task"}],
 "tools": [{"type": "function", "function": {"name": "delegate_task", "parameters": {"type": "object"}}}]
 }`))
-w := httptest.NewRecorder()
-handler.HandleOpenAIChatCompletions(w, req)
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
 
-var resp models.OpenAIResponse
-body, _ := io.ReadAll(w.Result().Body)
-json.Unmarshal(body, &resp)
+	var resp models.OpenAIResponse
+	body, _ := io.ReadAll(w.Result().Body)
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("json.Unmarshal(response) error = %v", err)
+	}
 
-tc := len(resp.Choices[0].Message.ToolCalls)
-fr := ""
-if resp.Choices[0].FinishReason != nil {
-fr = *resp.Choices[0].FinishReason
-}
-t.Logf("LLM response: stop_reason=%s, tool_calls=%d, tools_sent=1", fr, tc)
-if fr != "tool_calls" || tc != 1 {
-t.Fatalf("finish_reason=%q tool_calls=%d, want tool_calls/1", fr, tc)
-}
+	tc := len(resp.Choices[0].Message.ToolCalls)
+	fr := ""
+	if resp.Choices[0].FinishReason != nil {
+		fr = *resp.Choices[0].FinishReason
+	}
+	t.Logf("LLM response: stop_reason=%s, tool_calls=%d, tools_sent=1", fr, tc)
+	if fr != "tool_calls" || tc != 1 {
+		t.Fatalf("finish_reason=%q tool_calls=%d, want tool_calls/1", fr, tc)
+	}
 }
 
 // TestBugReport_OpenAIParallelTools verifies parallel tool calls via OpenAI path with forced streaming.
 func TestBugReport_OpenAIParallelTools(t *testing.T) {
-handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
-body, _ := io.ReadAll(r.Body)
-var oaiReq map[string]json.RawMessage
-json.Unmarshal(body, &oaiReq)
-if string(oaiReq["parallel_tool_calls"]) != "true" {
-t.Error("expected parallel_tool_calls=true injected by proxy")
-}
-if string(oaiReq["stream"]) != "true" {
-t.Error("expected stream=true forced by proxy")
-}
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var oaiReq map[string]json.RawMessage
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		if string(oaiReq["parallel_tool_calls"]) != "true" {
+			t.Error("expected parallel_tool_calls=true injected by proxy")
+		}
+		if string(oaiReq["stream"]) != "true" {
+			t.Error("expected stream=true forced by proxy")
+		}
 
-w.Header().Set("Content-Type", "text/event-stream")
-w.WriteHeader(http.StatusOK)
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"I'll delegate both research tasks in parallel...\"}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc1\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 pros of Go\\\"}\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc2\",\"index\":1,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 cons of Go\\\"}\"}}]}}]}\n\n"))
-w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":50,\"total_tokens\":150}}\n\n"))
-w.Write([]byte("data: [DONE]\n\n"))
-})
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"I'll delegate both research tasks in parallel...\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc1\",\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 pros of Go\\\"}\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_abc2\",\"index\":1,\"type\":\"function\",\"function\":{\"name\":\"delegate_task\",\"arguments\":\"\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"agent\\\":\\\"researcher\\\",\\\"prompt\\\":\\\"List 3 cons of Go\\\"}\"}}]}}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"c1\",\"model\":\"claude-opus-4.6-fast\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":50,\"total_tokens\":150}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
 
-req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
 "model": "claude-opus-4.6-fast",
 "messages": [{"role": "user", "content": "Call delegate_task for pros and cons"}],
 "tools": [
@@ -166,23 +174,25 @@ req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewR
 {"type": "function", "function": {"name": "wait_for_tasks", "parameters": {"type": "object"}}}
 ]
 }`))
-w := httptest.NewRecorder()
-handler.HandleOpenAIChatCompletions(w, req)
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
 
-var resp models.OpenAIResponse
-body, _ := io.ReadAll(w.Result().Body)
-json.Unmarshal(body, &resp)
+	var resp models.OpenAIResponse
+	body, _ := io.ReadAll(w.Result().Body)
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("json.Unmarshal(response) error = %v", err)
+	}
 
-tc := len(resp.Choices[0].Message.ToolCalls)
-fr := ""
-if resp.Choices[0].FinishReason != nil {
-fr = *resp.Choices[0].FinishReason
-}
-t.Logf("LLM response: stop_reason=%s, tool_calls=%d, tools_sent=2", fr, tc)
-if fr != "tool_calls" {
-t.Errorf("finish_reason = %q, want tool_calls", fr)
-}
-if tc != 2 {
-t.Fatalf("tool_calls = %d, want 2 ← THIS WAS THE BUG (was 0 before fix)", tc)
-}
+	tc := len(resp.Choices[0].Message.ToolCalls)
+	fr := ""
+	if resp.Choices[0].FinishReason != nil {
+		fr = *resp.Choices[0].FinishReason
+	}
+	t.Logf("LLM response: stop_reason=%s, tool_calls=%d, tools_sent=2", fr, tc)
+	if fr != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", fr)
+	}
+	if tc != 2 {
+		t.Fatalf("tool_calls = %d, want 2 ← THIS WAS THE BUG (was 0 before fix)", tc)
+	}
 }

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -18,7 +18,7 @@ func TestDoWithRetry_SuccessOnFirstTry(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer server.Close()
 
@@ -36,7 +36,7 @@ func TestDoWithRetry_SuccessOnFirstTry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
@@ -55,7 +55,7 @@ func TestDoWithRetry_RetriesOnServerError(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer server.Close()
 
@@ -73,7 +73,7 @@ func TestDoWithRetry_RetriesOnServerError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
@@ -132,7 +132,7 @@ func TestDoWithRetry_NoRetryOn4xx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -71,7 +71,7 @@ func (fw *flushWriter) Write(p []byte) (int, error) {
 
 // StreamOpenAIPassthrough streams OpenAI SSE bytes directly to the client with no parsing.
 func StreamOpenAIPassthrough(w http.ResponseWriter, body io.ReadCloser) {
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
 
 	fw := &flushWriter{w: w}
@@ -85,7 +85,7 @@ func StreamOpenAIPassthrough(w http.ResponseWriter, body io.ReadCloser) {
 
 // StreamOpenAIToAnthropic translates an OpenAI SSE stream into Anthropic SSE format.
 func StreamOpenAIToAnthropic(w http.ResponseWriter, body io.ReadCloser, model string, requestID string) {
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
 
 	state := newAnthropicStreamState(w, model, requestID)

--- a/proxy/streaming_test.go
+++ b/proxy/streaming_test.go
@@ -176,8 +176,12 @@ func TestStreamOpenAIToAnthropic_TextOnly(t *testing.T) {
 
 	// Verify content_block_delta texts
 	var delta1, delta2 models.AnthropicStreamEvent
-	json.Unmarshal([]byte(events[2].Data), &delta1)
-	json.Unmarshal([]byte(events[3].Data), &delta2)
+	if err := json.Unmarshal([]byte(events[2].Data), &delta1); err != nil {
+		t.Fatalf("unmarshal first content_block_delta: %v", err)
+	}
+	if err := json.Unmarshal([]byte(events[3].Data), &delta2); err != nil {
+		t.Fatalf("unmarshal second content_block_delta: %v", err)
+	}
 	if delta1.Delta == nil || delta1.Delta.Text != "Hello" {
 		t.Errorf("delta[0] text = %q, want %q", delta1.Delta.Text, "Hello")
 	}
@@ -455,7 +459,9 @@ func TestStreamOpenAIToAnthropic_MultipleToolCalls(t *testing.T) {
 
 	// Verify stop reason is tool_use
 	var msgDelta models.AnthropicStreamEvent
-	json.Unmarshal([]byte(events[7].Data), &msgDelta)
+	if err := json.Unmarshal([]byte(events[7].Data), &msgDelta); err != nil {
+		t.Fatalf("unmarshal message_delta: %v", err)
+	}
 	if msgDelta.Delta == nil || msgDelta.Delta.StopReason != "tool_use" {
 		t.Errorf("message_delta stop_reason = %q, want %q", msgDelta.Delta.StopReason, "tool_use")
 	}
@@ -781,14 +787,18 @@ func TestAnthropicResponseJSONShape(t *testing.T) {
 
 	// Validate type is "message"
 	var typ string
-	json.Unmarshal(raw["type"], &typ)
+	if err := json.Unmarshal(raw["type"], &typ); err != nil {
+		t.Fatalf("unmarshal type: %v", err)
+	}
 	if typ != "message" {
 		t.Errorf("type = %q, want %q", typ, "message")
 	}
 
 	// Validate role is "assistant"
 	var role string
-	json.Unmarshal(raw["role"], &role)
+	if err := json.Unmarshal(raw["role"], &role); err != nil {
+		t.Fatalf("unmarshal role: %v", err)
+	}
 	if role != "assistant" {
 		t.Errorf("role = %q, want %q", role, "assistant")
 	}
@@ -804,7 +814,9 @@ func TestAnthropicResponseJSONShape(t *testing.T) {
 
 	// Validate content block shape
 	var block map[string]json.RawMessage
-	json.Unmarshal(content[0], &block)
+	if err := json.Unmarshal(content[0], &block); err != nil {
+		t.Fatalf("unmarshal content block: %v", err)
+	}
 	if _, ok := block["type"]; !ok {
 		t.Error("content block missing 'type' field")
 	}
@@ -814,7 +826,9 @@ func TestAnthropicResponseJSONShape(t *testing.T) {
 
 	// Validate usage shape
 	var usage map[string]json.RawMessage
-	json.Unmarshal(raw["usage"], &usage)
+	if err := json.Unmarshal(raw["usage"], &usage); err != nil {
+		t.Fatalf("unmarshal usage: %v", err)
+	}
 	if _, ok := usage["input_tokens"]; !ok {
 		t.Error("usage missing 'input_tokens'")
 	}
@@ -867,7 +881,9 @@ func TestAnthropicStreamEventShapes(t *testing.T) {
 				t.Error("message_start missing 'message' field")
 			}
 			var msg map[string]json.RawMessage
-			json.Unmarshal(raw["message"], &msg)
+			if err := json.Unmarshal(raw["message"], &msg); err != nil {
+				t.Fatalf("message_start.message unmarshal failed: %v", err)
+			}
 			for _, f := range []string{"id", "type", "role", "model", "content", "usage"} {
 				if _, ok := msg[f]; !ok {
 					t.Errorf("message_start.message missing '%s'", f)
@@ -891,7 +907,9 @@ func TestAnthropicStreamEventShapes(t *testing.T) {
 			}
 			// content_block_delta's delta MUST have a "type" field
 			var delta map[string]json.RawMessage
-			json.Unmarshal(raw["delta"], &delta)
+			if err := json.Unmarshal(raw["delta"], &delta); err != nil {
+				t.Fatalf("content_block_delta.delta unmarshal failed: %v", err)
+			}
 			if _, ok := delta["type"]; !ok {
 				t.Error("content_block_delta.delta missing 'type'")
 			}
@@ -907,7 +925,9 @@ func TestAnthropicStreamEventShapes(t *testing.T) {
 			}
 			// message_delta's delta must NOT have a "type" field
 			var delta map[string]json.RawMessage
-			json.Unmarshal(raw["delta"], &delta)
+			if err := json.Unmarshal(raw["delta"], &delta); err != nil {
+				t.Fatalf("message_delta.delta unmarshal failed: %v", err)
+			}
 			if _, hasType := delta["type"]; hasType {
 				t.Error("message_delta.delta should NOT have 'type' field")
 			}
@@ -1030,7 +1050,9 @@ func TestAnthropicErrorShape(t *testing.T) {
 
 	// Must have "type" = "error"
 	var typ string
-	json.Unmarshal(raw["type"], &typ)
+	if err := json.Unmarshal(raw["type"], &typ); err != nil {
+		t.Fatalf("type field unmarshal: %v", err)
+	}
 	if typ != "error" {
 		t.Errorf("type = %q, want %q", typ, "error")
 	}
@@ -1103,7 +1125,9 @@ func TestAggregateStreamToResponse_ParallelToolCalls(t *testing.T) {
 
 	msg := resp.Choices[0].Message
 	var text string
-	json.Unmarshal(msg.Content, &text)
+	if err := json.Unmarshal(msg.Content, &text); err != nil {
+		t.Fatalf("content unmarshal: %v", err)
+	}
 	if text != "I'll delegate" {
 		t.Errorf("content = %q, want 'I'll delegate'", text)
 	}
@@ -1140,7 +1164,9 @@ func TestAggregateStreamToResponse_TextOnly(t *testing.T) {
 	}
 
 	var text string
-	json.Unmarshal(resp.Choices[0].Message.Content, &text)
+	if err := json.Unmarshal(resp.Choices[0].Message.Content, &text); err != nil {
+		t.Fatalf("content unmarshal: %v", err)
+	}
 	if text != "Hello world" {
 		t.Errorf("content = %q, want 'Hello world'", text)
 	}


### PR DESCRIPTION
## Summary
- Reuse an authenticated GitHub CLI token for Copilot auth before falling back to device-code login
- Keep generic GitHub token env vars out of Vekil's direct auth path while preserving `COPILOT_GITHUB_TOKEN`
- Document the updated auth lookup order and add tests for GitHub CLI token fallback behavior

## Tests
- `go test ./...`
