### PR TITLE
Add Prometheus metrics endpoint and instrumentation

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ const (
 	cliCommandLogout
 )
 
+var buildVersion = "dev"
+
 func main() {
 	// Dispatch subcommands before falling through to the default server mode.
 	switch commandFromArgs(os.Args) {
@@ -216,6 +218,8 @@ func runServe() {
 	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
 	providersConfigPath := flag.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration")
 	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
+	metricsEnabled := flag.Bool("metrics", getEnvBool("METRICS", true), "Expose Prometheus-compatible metrics at /metrics")
+	noMetrics := flag.Bool("no-metrics", getEnvBool("NO_METRICS", false), "Disable Prometheus-compatible metrics")
 	streamingUpstreamTimeout := flag.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
 	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
 	copilotPluginVersion := flag.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header")
@@ -254,6 +258,8 @@ func runServe() {
 		log,
 		*host,
 		*port,
+		server.WithBuildVersion(buildVersion),
+		server.WithMetricsEnabled(*metricsEnabled && !*noMetrics),
 		server.WithStreamingUpstreamTimeout(*streamingUpstreamTimeout),
 		server.WithCopilotHeaderConfig(proxy.CopilotHeaderConfig{
 			EditorVersion:       *copilotEditorVersion,

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -104,6 +104,7 @@ func (h *ProxyHandler) routeChatCompletionsResponse(w http.ResponseWriter, resp 
 // HandleAnthropicMessages handles POST /v1/messages by translating the Anthropic
 // request to OpenAI format, forwarding to Copilot, and translating the response back.
 func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
+	scope := requestMetricsFromContext(r.Context())
 	body, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -117,6 +118,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON in request body")
 		return
 	}
+	scope.SetPublicModel(req.Model)
 
 	h.log.Debug("anthropic request",
 		logger.F("model", req.Model),
@@ -131,7 +133,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(r.Context(), mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, oaiBody)
@@ -165,9 +167,12 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 
 	err = h.routeChatCompletionsResponse(w, resp, mode, chatCompletionsResponseHandlers{
 		stream: func(resp *http.Response) {
-			StreamOpenAIToAnthropic(w, resp.Body, req.Model, "msg_"+uuid.New().String())
+			StreamOpenAIToAnthropic(w, resp.Body, req.Model, "msg_"+uuid.New().String(), func(usage *models.OpenAIUsage) {
+				observeOpenAIUsage(scope, usage)
+			})
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			observeOpenAIUsage(scope, oaiResp.Usage)
 			anthropicResp := TranslateOpenAIToAnthropic(oaiResp, req.Model)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(anthropicResp)
@@ -181,6 +186,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 // HandleOpenAIChatCompletions handles POST /v1/chat/completions by forwarding the
 // request to Copilot with only auth headers injected (near zero-copy passthrough).
 func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *http.Request) {
+	scope := requestMetricsFromContext(r.Context())
 	bodyBytes, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -189,9 +195,10 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	}
 	defer func() { _ = r.Body.Close() }()
 
+	scope.SetPublicModel(extractRequestModel(bodyBytes))
 	bodyBytes, mode := prepareOpenAIChatCompletionsRequest(bodyBytes)
 
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(r.Context(), mode.clientRequestedStream || mode.forceUpstreamStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, bodyBytes)
@@ -216,8 +223,17 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 			StreamOpenAIPassthrough(w, resp.Body)
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			observeOpenAIUsage(scope, oaiResp.Usage)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(oaiResp)
+		},
+		passthrough: func(resp *http.Response) error {
+			return writeUpstreamResponseWithBody(w, resp, func(body []byte) {
+				var parsed models.OpenAIResponse
+				if err := json.Unmarshal(body, &parsed); err == nil {
+					observeOpenAIUsage(scope, parsed.Usage)
+				}
+			})
 		},
 	})
 	if err != nil {

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +16,17 @@ import (
 )
 
 const geminiCountTokensCacheTTL = 60 * time.Second
+
+func normalizeGeminiMetricsEndpoint(path, action string) string {
+	switch {
+	case strings.HasPrefix(path, "/v1beta/models/"):
+		return "/v1beta/models:" + action
+	case strings.HasPrefix(path, "/v1/models/"):
+		return "/v1/models:" + action
+	default:
+		return "/models:" + action
+	}
+}
 
 type geminiCountTokensCache struct {
 	mu      sync.RWMutex
@@ -28,11 +41,14 @@ type geminiCountTokensCacheEntry struct {
 // HandleGeminiModels routes Gemini-native model actions to the corresponding
 // translation handler.
 func (h *ProxyHandler) HandleGeminiModels(w http.ResponseWriter, r *http.Request) {
+	scope := requestMetricsFromContext(r.Context())
 	model, action, err := parseGeminiPath(r.URL.Path)
 	if err != nil {
 		h.writeGeminiProtocolError(w, err)
 		return
 	}
+	scope.SetPublicModel(model)
+	scope.SetEndpoint(normalizeGeminiMetricsEndpoint(r.URL.Path, action))
 
 	switch action {
 	case "generateContent":
@@ -47,6 +63,7 @@ func (h *ProxyHandler) HandleGeminiModels(w http.ResponseWriter, r *http.Request
 }
 
 func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *http.Request, pathModel string, stream bool) {
+	scope := requestMetricsFromContext(r.Context())
 	body, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -87,7 +104,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 		return
 	}
 
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(stream || forceStream)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(r.Context(), stream || forceStream)
 	defer upstreamCancel()
 
 	resp, err := h.postChatCompletions(upstreamCtx, oaiBody)
@@ -110,9 +127,12 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 	}
 	err = h.routeChatCompletionsResponse(w, resp, mode, chatCompletionsResponseHandlers{
 		stream: func(resp *http.Response) {
-			StreamOpenAIToGemini(w, resp.Body)
+			StreamOpenAIToGemini(w, resp.Body, func(usage *models.OpenAIUsage) {
+				observeOpenAIUsage(scope, usage)
+			})
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			observeOpenAIUsage(scope, oaiResp.Usage)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(TranslateOpenAIToGemini(oaiResp))
 		},
@@ -122,6 +142,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 			if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 				return err
 			}
+			observeOpenAIUsage(scope, parsed.Usage)
 
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(TranslateOpenAIToGemini(&parsed))
@@ -138,6 +159,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 }
 
 func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Request, pathModel string) {
+	scope := requestMetricsFromContext(r.Context())
 	body, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -170,7 +192,7 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	oaiResp, err := h.runGeminiCountTokensProbe(oaiReq)
+	oaiResp, err := h.runGeminiCountTokensProbe(r.Context(), oaiReq)
 	if err != nil {
 		h.writeGeminiProtocolError(w, err)
 		return
@@ -184,6 +206,7 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 	result := models.GeminiCountTokensResponse{
 		TotalTokens: oaiResp.Usage.PromptTokens,
 	}
+	observeOpenAIUsage(scope, oaiResp.Usage)
 	if !geminiRequestHasInlineMedia(req) {
 		result.PromptTokensDetails = []models.GeminiTokenCountDetails{{
 			Modality:   "TEXT",
@@ -229,7 +252,7 @@ func geminiContentHasInlineMedia(content *models.GeminiContent) bool {
 	return false
 }
 
-func (h *ProxyHandler) runGeminiCountTokensProbe(baseReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
+func (h *ProxyHandler) runGeminiCountTokensProbe(parent context.Context, baseReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
 	probeReq, err := cloneOpenAIRequest(baseReq)
 	if err != nil {
 		return nil, &geminiProtocolError{
@@ -249,17 +272,17 @@ func (h *ProxyHandler) runGeminiCountTokensProbe(baseReq *models.OpenAIRequest) 
 	probeReq.MaxCompletionTokens = &one
 	probeReq.MaxTokens = nil
 
-	oaiResp, fallback, err := h.executeGeminiCountTokensProbe(probeReq)
+	oaiResp, fallback, err := h.executeGeminiCountTokensProbe(parent, probeReq)
 	if fallback {
 		probeReq.MaxCompletionTokens = nil
 		probeReq.MaxTokens = &one
-		return h.executeGeminiCountTokensProbeFinal(probeReq)
+		return h.executeGeminiCountTokensProbeFinal(parent, probeReq)
 	}
 	return oaiResp, err
 }
 
-func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+func (h *ProxyHandler) executeGeminiCountTokensProbe(parent context.Context, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(parent, false)
 	defer upstreamCancel()
 
 	body, err := json.Marshal(probeReq)
@@ -284,8 +307,8 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequ
 	return h.decodeGeminiProbeResponse(resp)
 }
 
-func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(parent context.Context, probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(parent, false)
 	defer upstreamCancel()
 
 	body, err := json.Marshal(probeReq)

--- a/proxy/gemini_streaming.go
+++ b/proxy/gemini_streaming.go
@@ -43,11 +43,11 @@ func writeGeminiSSEData(w http.ResponseWriter, data interface{}) error {
 
 // StreamOpenAIToGemini translates upstream OpenAI SSE into Gemini-style
 // data-only SSE frames.
-func StreamOpenAIToGemini(w http.ResponseWriter, body io.ReadCloser) {
+func StreamOpenAIToGemini(w http.ResponseWriter, body io.ReadCloser, onUsage func(*models.OpenAIUsage)) {
 	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
 
-	state := newGeminiStreamState(w)
+	state := newGeminiStreamState(w, onUsage)
 	sawDone, err := consumeOpenAIStreamChunks(body, state.consumeChunk)
 	if err != nil || !sawDone {
 		return
@@ -61,18 +61,23 @@ type geminiStreamState struct {
 	bufferedToolCalls  map[int]*geminiStreamingToolCall
 	storedFinishReason string
 	storedUsage        *models.OpenAIUsage
+	onUsage            func(*models.OpenAIUsage)
 }
 
-func newGeminiStreamState(w http.ResponseWriter) *geminiStreamState {
+func newGeminiStreamState(w http.ResponseWriter, onUsage func(*models.OpenAIUsage)) *geminiStreamState {
 	return &geminiStreamState{
 		w:                 w,
 		bufferedToolCalls: make(map[int]*geminiStreamingToolCall),
+		onUsage:           onUsage,
 	}
 }
 
 func (s *geminiStreamState) consumeChunk(chunk models.OpenAIStreamChunk) bool {
 	if chunk.Usage != nil {
 		s.storedUsage = chunk.Usage
+		if s.onUsage != nil {
+			s.onUsage(chunk.Usage)
+		}
 	}
 
 	for _, choice := range chunk.Choices {

--- a/proxy/gemini_streaming_test.go
+++ b/proxy/gemini_streaming_test.go
@@ -67,7 +67,7 @@ func TestStreamOpenAIToGeminiText(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToGemini(w, body)
+	StreamOpenAIToGemini(w, body, nil)
 
 	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
 		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
@@ -180,7 +180,7 @@ func TestStreamOpenAIToGeminiToolCalls(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToGemini(w, body)
+	StreamOpenAIToGemini(w, body, nil)
 
 	frames := parseGeminiSSEFrames(w.Body.String())
 	if len(frames) != 2 {
@@ -267,7 +267,7 @@ func TestStreamOpenAIToGeminiToolCallWithoutArgumentsFlushesEmptyObject(t *testi
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToGemini(w, body)
+	StreamOpenAIToGemini(w, body, nil)
 
 	frames := parseGeminiSSEFrames(w.Body.String())
 	if len(frames) != 2 {
@@ -328,7 +328,7 @@ func TestStreamOpenAIToGemini_NoTailWithoutDone(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToGemini(w, body)
+	StreamOpenAIToGemini(w, body, nil)
 
 	frames := parseGeminiSSEFrames(w.Body.String())
 	if len(frames) != 1 {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -185,6 +185,9 @@ type ProxyHandler struct {
 	client                   *http.Client
 	copilotURL               string
 	copilotHeaders           CopilotHeaderConfig
+	buildVersion             string
+	metricsEnabled           bool
+	metrics                  *proxyMetrics
 	providersConfig          ProvidersConfig
 	providersState           *providerSetup
 	responsesWS              ResponsesWebSocketConfig
@@ -204,6 +207,20 @@ type Option func(*ProxyHandler)
 func WithCopilotHeaderConfig(cfg CopilotHeaderConfig) Option {
 	return func(h *ProxyHandler) {
 		h.copilotHeaders = cfg.withDefaults()
+	}
+}
+
+// WithBuildVersion sets the build version used by metrics and diagnostics.
+func WithBuildVersion(version string) Option {
+	return func(h *ProxyHandler) {
+		h.buildVersion = strings.TrimSpace(version)
+	}
+}
+
+// WithMetricsEnabled toggles Prometheus metrics exposure and instrumentation.
+func WithMetricsEnabled(enabled bool) Option {
+	return func(h *ProxyHandler) {
+		h.metricsEnabled = enabled
 	}
 }
 
@@ -266,6 +283,8 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 		},
 		copilotURL:               "https://api.githubcopilot.com",
 		copilotHeaders:           DefaultCopilotHeaderConfig(),
+		buildVersion:             "dev",
+		metricsEnabled:           true,
 		responsesWS:              DefaultResponsesWebSocketConfig(),
 		streamingUpstreamTimeout: streamingUpstreamTimeout,
 		log:                      log,
@@ -277,6 +296,9 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 	}
 	if err := h.initializeProviders(); err != nil {
 		return nil, err
+	}
+	if h.metricsEnabled {
+		h.metrics = newProxyMetrics(h.buildVersion)
 	}
 	return h, nil
 }
@@ -296,6 +318,32 @@ func (h *ProxyHandler) effectiveStreamingUpstreamTimeout() time.Duration {
 // configured streaming upstream timeout plus the non-streaming request budget.
 func (h *ProxyHandler) ServerWriteTimeout() time.Duration {
 	return h.effectiveStreamingUpstreamTimeout() + upstreamTimeout
+}
+
+// MetricsHandler returns the Prometheus exposition handler when metrics are enabled.
+func (h *ProxyHandler) MetricsHandler() http.Handler {
+	if h == nil || h.metrics == nil {
+		return nil
+	}
+	return h.metrics.handler
+}
+
+func (h *ProxyHandler) instrument(endpoint string, next http.HandlerFunc) http.HandlerFunc {
+	if h == nil || h.metrics == nil {
+		return next
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		scope := h.metrics.beginRequest(endpoint)
+		recorder := newMetricsResponseWriter(w)
+		defer scope.finish(recorder.statusCode)
+		next(recorder, r.WithContext(withRequestMetricsScope(r.Context(), scope)))
+	}
+}
+
+// InstrumentHandler wraps an endpoint handler with request metrics when enabled.
+func (h *ProxyHandler) InstrumentHandler(endpoint string, next http.HandlerFunc) http.HandlerFunc {
+	return h.instrument(endpoint, next)
 }
 
 func setCopilotHeaders(req *http.Request, token string) {

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -1,0 +1,368 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type proxyMetrics struct {
+	handler             http.Handler
+	requestsTotal       *prometheus.CounterVec
+	requestDuration     *prometheus.HistogramVec
+	tokensTotal         *prometheus.CounterVec
+	retriesTotal        *prometheus.CounterVec
+	upstreamErrorsTotal *prometheus.CounterVec
+	inflightRequests    *prometheus.GaugeVec
+}
+
+func newProxyMetrics(buildVersion string) *proxyMetrics {
+	registry := prometheus.NewRegistry()
+
+	requestsTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vekil_requests_total",
+			Help: "Total proxied requests by endpoint, provider, model, and status.",
+		},
+		[]string{"endpoint", "provider", "public_model", "status", "code"},
+	)
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "vekil_request_duration_seconds",
+			Help:    "Proxy request duration by endpoint, provider, model, and status.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"endpoint", "provider", "public_model", "status", "code"},
+	)
+	tokensTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vekil_tokens_total",
+			Help: "Token usage reported by upstream responses.",
+		},
+		[]string{"endpoint", "provider", "public_model", "direction"},
+	)
+	retriesTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vekil_retries_total",
+			Help: "Retry attempts against upstream providers.",
+		},
+		[]string{"endpoint", "provider", "public_model", "reason", "code"},
+	)
+	upstreamErrorsTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vekil_upstream_errors_total",
+			Help: "Upstream transport and HTTP errors observed by the proxy.",
+		},
+		[]string{"endpoint", "provider", "public_model", "reason", "code"},
+	)
+	inflightRequests := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vekil_inflight_requests",
+			Help: "Current in-flight proxy requests.",
+		},
+		[]string{"endpoint"},
+	)
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vekil_build_info",
+			Help: "Build metadata for the running vekil binary.",
+		},
+		[]string{"version"},
+	)
+	buildInfo.WithLabelValues(sanitizeMetricLabel(buildVersion, "dev")).Set(1)
+
+	registry.MustRegister(
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		requestsTotal,
+		requestDuration,
+		tokensTotal,
+		retriesTotal,
+		upstreamErrorsTotal,
+		inflightRequests,
+		buildInfo,
+	)
+
+	return &proxyMetrics{
+		handler:             promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		requestsTotal:       requestsTotal,
+		requestDuration:     requestDuration,
+		tokensTotal:         tokensTotal,
+		retriesTotal:        retriesTotal,
+		upstreamErrorsTotal: upstreamErrorsTotal,
+		inflightRequests:    inflightRequests,
+	}
+}
+
+func (m *proxyMetrics) beginRequest(endpoint string) *requestMetricsScope {
+	if m == nil {
+		return nil
+	}
+	normalizedEndpoint := sanitizeMetricLabel(endpoint, "unknown")
+	scope := &requestMetricsScope{
+		metrics:          m,
+		startedAt:        time.Now(),
+		endpoint:         normalizedEndpoint,
+		inflightEndpoint: normalizedEndpoint,
+		provider:         "unknown",
+		model:            "unknown",
+	}
+	m.inflightRequests.WithLabelValues(normalizedEndpoint).Inc()
+	return scope
+}
+
+type requestMetricsScope struct {
+	metrics   *proxyMetrics
+	startedAt time.Time
+
+	mu              sync.Mutex
+	endpoint        string
+	inflightEndpoint string
+	provider        string
+	model           string
+	finalized       bool
+}
+
+type requestMetricsScopeKey struct{}
+
+func withRequestMetricsScope(ctx context.Context, scope *requestMetricsScope) context.Context {
+	if scope == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, requestMetricsScopeKey{}, scope)
+}
+
+func requestMetricsFromContext(ctx context.Context) *requestMetricsScope {
+	if ctx == nil {
+		return nil
+	}
+	scope, _ := ctx.Value(requestMetricsScopeKey{}).(*requestMetricsScope)
+	return scope
+}
+
+func (s *requestMetricsScope) SetEndpoint(endpoint string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	normalized := sanitizeMetricLabel(endpoint, "unknown")
+	if s.metrics != nil && !s.finalized && s.inflightEndpoint != normalized {
+		s.metrics.inflightRequests.WithLabelValues(s.inflightEndpoint).Dec()
+		s.metrics.inflightRequests.WithLabelValues(normalized).Inc()
+		s.inflightEndpoint = normalized
+	}
+	s.endpoint = normalized
+}
+
+func (s *requestMetricsScope) SetPublicModel(model string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.model = sanitizeMetricLabel(model, "unknown")
+}
+
+func (s *requestMetricsScope) SetProvider(provider string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.provider = sanitizeMetricLabel(provider, "unknown")
+}
+
+func (s *requestMetricsScope) observeTokens(direction string, count int) {
+	if s == nil || s.metrics == nil || count <= 0 {
+		return
+	}
+	endpoint, provider, model := s.snapshot()
+	s.metrics.tokensTotal.WithLabelValues(endpoint, provider, model, sanitizeMetricLabel(direction, "unknown")).Add(float64(count))
+}
+
+func (s *requestMetricsScope) observeOpenAIUsage(usage interface {
+	GetPromptTokens() int
+	GetCompletionTokens() int
+}) {
+	if s == nil || usage == nil {
+		return
+	}
+	s.observeTokens("input", usage.GetPromptTokens())
+	s.observeTokens("output", usage.GetCompletionTokens())
+}
+
+func (s *requestMetricsScope) observeResponsesUsage(inputTokens, outputTokens int) {
+	s.observeTokens("input", inputTokens)
+	s.observeTokens("output", outputTokens)
+}
+
+func (s *requestMetricsScope) observeRetry(reason, code string) {
+	if s == nil || s.metrics == nil {
+		return
+	}
+	endpoint, provider, model := s.snapshot()
+	s.metrics.retriesTotal.WithLabelValues(
+		endpoint,
+		provider,
+		model,
+		sanitizeMetricLabel(reason, "unknown"),
+		sanitizeMetricLabel(code, "unknown"),
+	).Inc()
+}
+
+func (s *requestMetricsScope) observeUpstreamError(reason, code string) {
+	if s == nil || s.metrics == nil {
+		return
+	}
+	endpoint, provider, model := s.snapshot()
+	s.metrics.upstreamErrorsTotal.WithLabelValues(
+		endpoint,
+		provider,
+		model,
+		sanitizeMetricLabel(reason, "unknown"),
+		sanitizeMetricLabel(code, "unknown"),
+	).Inc()
+}
+
+func (s *requestMetricsScope) finish(statusCode int) {
+	if s == nil || s.metrics == nil {
+		return
+	}
+
+	s.mu.Lock()
+	if s.finalized {
+		s.mu.Unlock()
+		return
+	}
+	s.finalized = true
+	endpoint := s.endpoint
+	inflightEndpoint := s.inflightEndpoint
+	provider := s.provider
+	model := s.model
+	s.mu.Unlock()
+
+	s.metrics.inflightRequests.WithLabelValues(inflightEndpoint).Dec()
+
+	status := "error"
+	if statusCode >= 200 && statusCode < 400 {
+		status = "success"
+	}
+	code := strconv.Itoa(statusCode)
+	labels := []string{endpoint, provider, model, status, code}
+	s.metrics.requestsTotal.WithLabelValues(labels...).Inc()
+	s.metrics.requestDuration.WithLabelValues(labels...).Observe(time.Since(s.startedAt).Seconds())
+}
+
+func (s *requestMetricsScope) snapshot() (endpoint, provider, model string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.endpoint, s.provider, s.model
+}
+
+func sanitizeMetricLabel(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func classifyUpstreamMetricsReason(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	var upstreamErr *upstreamError
+	if errors.As(err, &upstreamErr) {
+		return "status_code"
+	}
+	return "transport"
+}
+
+func classifyUpstreamMetricsCode(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	var upstreamErr *upstreamError
+	if errors.As(err, &upstreamErr) {
+		return strconv.Itoa(upstreamErr.statusCode)
+	}
+	return "transport"
+}
+
+type openAIUsageAdapter struct {
+	promptTokens     int
+	completionTokens int
+}
+
+func (u openAIUsageAdapter) GetPromptTokens() int     { return u.promptTokens }
+func (u openAIUsageAdapter) GetCompletionTokens() int { return u.completionTokens }
+
+type metricsResponseWriter struct {
+	http.ResponseWriter
+	statusCode  int
+	wroteHeader bool
+}
+
+func newMetricsResponseWriter(w http.ResponseWriter) *metricsResponseWriter {
+	return &metricsResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+}
+
+func (w *metricsResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *metricsResponseWriter) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *metricsResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if rf, ok := w.ResponseWriter.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(w.ResponseWriter, r)
+}
+
+func (w *metricsResponseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *metricsResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	return hijacker.Hijack()
+}
+
+func (w *metricsResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := w.ResponseWriter.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, opts)
+}

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
+)
+
+func metricsBodyHasLine(body, metric string, parts ...string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, metric+"{") {
+			continue
+		}
+		matches := true
+		for _, part := range parts {
+			if !strings.Contains(line, part) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInstrumentHandler_RecordsRequestAndBuildMetrics(t *testing.T) {
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithMetricsEnabled(true),
+		WithBuildVersion("1.2.3"),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+
+	wrapped := handler.InstrumentHandler("/v1/test", func(w http.ResponseWriter, r *http.Request) {
+		scope := requestMetricsFromContext(r.Context())
+		scope.SetProvider("copilot")
+		scope.SetPublicModel("gpt-4.1")
+		scope.observeTokens("input", 11)
+		scope.observeTokens("output", 7)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(`{"model":"gpt-4.1"}`))
+	rec := httptest.NewRecorder()
+	wrapped(rec, req)
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	handler.MetricsHandler().ServeHTTP(metricsRec, metricsReq)
+
+	body := metricsRec.Body.String()
+	if !metricsBodyHasLine(body, "vekil_requests_total", `endpoint="/v1/test"`, `provider="copilot"`, `public_model="gpt-4.1"`, `status="success"`, `code="201"`) {
+		t.Fatalf("metrics output missing request counter:\n%s", body)
+	}
+	if !metricsBodyHasLine(body, "vekil_tokens_total", `endpoint="/v1/test"`, `provider="copilot"`, `public_model="gpt-4.1"`, `direction="input"`) {
+		t.Fatalf("metrics output missing input token counter:\n%s", body)
+	}
+	if !metricsBodyHasLine(body, "vekil_tokens_total", `endpoint="/v1/test"`, `provider="copilot"`, `public_model="gpt-4.1"`, `direction="output"`) {
+		t.Fatalf("metrics output missing output token counter:\n%s", body)
+	}
+	if !strings.Contains(body, `vekil_build_info{version="1.2.3"} 1`) {
+		t.Fatalf("metrics output missing build info:\n%s", body)
+	}
+}
+
+func TestDoWithRetry_RecordsRetryMetrics(t *testing.T) {
+	attempts := 0
+	handler := newRoundTripTestProxyHandler(t, func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"retry"}`)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`ok`)),
+		}, nil
+	})
+	handler.metrics = newProxyMetrics("dev")
+
+	scope := handler.metrics.beginRequest("/v1/test")
+	scope.SetProvider("copilot")
+	scope.SetPublicModel("gpt-4.1")
+	ctx := withRequestMetricsScope(context.Background(), scope)
+
+	resp, err := handler.doWithRetry(ctx, func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, "http://upstream.test/test", nil)
+	})
+	if err != nil {
+		t.Fatalf("doWithRetry() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	scope.finish(http.StatusOK)
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	handler.MetricsHandler().ServeHTTP(metricsRec, metricsReq)
+
+	body := metricsRec.Body.String()
+	if !metricsBodyHasLine(body, "vekil_retries_total", `endpoint="/v1/test"`, `provider="copilot"`, `public_model="gpt-4.1"`, `reason="status_code"`, `code="429"`) {
+		t.Fatalf("metrics output missing retry counter:\n%s", body)
+	}
+}

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -42,6 +42,7 @@ func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 // HandleResponses handles POST /v1/responses by forwarding the request to
 // Copilot's responses endpoint with only auth headers injected.
 func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
+	scope := requestMetricsFromContext(r.Context())
 	bodyBytes, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -51,6 +52,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = r.Body.Close() }()
 
 	bodyBytes = h.rewriteResponsesRequestBody(bodyBytes, "responses", true)
+	scope.SetPublicModel(extractRequestModel(bodyBytes))
 
 	var partial struct {
 		Stream *bool `json:"stream,omitempty"`
@@ -60,7 +62,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 
 	extraHeaders := responsesExtraHeadersFromRequest(r)
 
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(isStreaming)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(r.Context(), isStreaming)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithHeaders(upstreamCtx, bodyBytes, extraHeaders)
@@ -100,7 +102,13 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeUpstreamResponse(w, resp)
+	if err := writeUpstreamResponseWithBody(w, resp, func(body []byte) {
+		if inputTokens, outputTokens, ok := extractResponsesUsage(body); ok {
+			scope.observeResponsesUsage(inputTokens, outputTokens)
+		}
+	}); err != nil {
+		writeOpenAIError(w, http.StatusBadGateway, "failed to read upstream response", "server_error")
+	}
 }
 
 // compactPrompt is the system instruction used when the upstream does not
@@ -127,6 +135,7 @@ Be concise, structured, and action-oriented. Do not chat with the user. Do not a
 // that Codex expects. The returned compaction item is a proxy-owned token that
 // this proxy can later expand back into summarized context for /responses.
 func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
+	scope := requestMetricsFromContext(r.Context())
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -136,6 +145,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = r.Body.Close() }()
 
 	bodyBytes = h.rewriteResponsesRequestBody(bodyBytes, "responses/compact", false)
+	scope.SetPublicModel(extractRequestModel(bodyBytes))
 
 	var body map[string]json.RawMessage
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
@@ -146,7 +156,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	body["instructions"] = prompt
 	bodyBytes, _ = json.Marshal(body)
 
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(r.Context(), false)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, bodyBytes, responsesExtraHeadersFromRequest(r))
@@ -179,6 +189,9 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "failed to read upstream response", "server_error")
 		return
+	}
+	if inputTokens, outputTokens, ok := extractResponsesUsage(respBody); ok {
+		scope.observeResponsesUsage(inputTokens, outputTokens)
 	}
 
 	summaryText, err := extractResponsesOutputText(respBody)
@@ -232,6 +245,7 @@ Respond with a JSON array where each element has "trace_summary" and "memory_sum
 // the traces to the upstream /responses endpoint with a summarization prompt,
 // then transforming the response into the format Codex expects.
 func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Request) {
+	scope := requestMetricsFromContext(r.Context())
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
@@ -249,6 +263,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 		writeOpenAIError(w, http.StatusBadRequest, "invalid JSON in request body", "invalid_request_error")
 		return
 	}
+	scope.SetPublicModel(memReq.Model)
 
 	tracesJSON, _ := json.Marshal(memReq.Traces)
 	userContent := "Summarize the following session traces:\n\n" + string(tracesJSON)
@@ -271,7 +286,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	}
 	reqBody, _ := json.Marshal(responsesReq)
 
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFromParent(r.Context(), false)
 	defer upstreamCancel()
 
 	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, reqBody, responsesExtraHeadersFromRequest(r))
@@ -304,6 +319,9 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "failed to read upstream response", "server_error")
 		return
+	}
+	if inputTokens, outputTokens, ok := extractResponsesUsage(respBody); ok {
+		scope.observeResponsesUsage(inputTokens, outputTokens)
 	}
 
 	summaryText, err := extractResponsesOutputText(respBody)

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -52,7 +52,7 @@ func drainAndClose(body io.ReadCloser) {
 
 // doWithRetry executes an HTTP request with retry on transient failures.
 // The reqFactory is called on each attempt to produce a fresh request body.
-func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*http.Response, error) {
+func (h *ProxyHandler) doWithRetry(ctx context.Context, reqFactory func() (*http.Request, error)) (*http.Response, error) {
 	maxRetries := h.maxRetries
 	if maxRetries == 0 {
 		maxRetries = 3
@@ -63,7 +63,8 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 	}
 
 	var lastErr error
-	for attempt := range maxRetries {
+	scope := requestMetricsFromContext(ctx)
+	for attempt := 0; attempt < maxRetries; attempt++ {
 		req, err := reqFactory()
 		if err != nil {
 			return nil, err
@@ -73,6 +74,7 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		if err != nil {
 			lastErr = err
 			if attempt < maxRetries-1 {
+				scope.observeRetry("transport", "transport")
 				if ctxErr := sleepWithContext(req.Context(), backoff(retryDelay, attempt)); ctxErr != nil {
 					return nil, ctxErr
 				}
@@ -91,6 +93,7 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		lastErr = &upstreamError{statusCode: resp.StatusCode}
 
 		if attempt < maxRetries-1 {
+			scope.observeRetry("status_code", strconv.Itoa(resp.StatusCode))
 			delay := backoff(retryDelay, attempt)
 			if ra, ok := parseRetryAfter(retryAfterHeader); ok && ra > delay {
 				delay = ra

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -84,11 +84,11 @@ func StreamOpenAIPassthrough(w http.ResponseWriter, body io.ReadCloser) {
 }
 
 // StreamOpenAIToAnthropic translates an OpenAI SSE stream into Anthropic SSE format.
-func StreamOpenAIToAnthropic(w http.ResponseWriter, body io.ReadCloser, model string, requestID string) {
+func StreamOpenAIToAnthropic(w http.ResponseWriter, body io.ReadCloser, model string, requestID string, onUsage func(*models.OpenAIUsage)) {
 	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
 
-	state := newAnthropicStreamState(w, model, requestID)
+	state := newAnthropicStreamState(w, model, requestID, onUsage)
 	if !state.start() {
 		return
 	}
@@ -131,15 +131,17 @@ type anthropicStreamState struct {
 	textBlockIndex      int
 	storedFinishReason  string
 	storedUsage         *models.OpenAIUsage
+	onUsage             func(*models.OpenAIUsage)
 	toolCallBlockIndex  map[int]int
 	openToolCallIndexes map[int]struct{}
 }
 
-func newAnthropicStreamState(w http.ResponseWriter, model string, requestID string) *anthropicStreamState {
+func newAnthropicStreamState(w http.ResponseWriter, model string, requestID string, onUsage func(*models.OpenAIUsage)) *anthropicStreamState {
 	return &anthropicStreamState{
 		w:                   w,
 		model:               model,
 		requestID:           requestID,
+		onUsage:             onUsage,
 		textBlockIndex:      -1,
 		toolCallBlockIndex:  make(map[int]int),
 		openToolCallIndexes: make(map[int]struct{}),
@@ -167,6 +169,9 @@ func (s *anthropicStreamState) emit(eventType string, data interface{}) bool {
 func (s *anthropicStreamState) consumeChunk(chunk models.OpenAIStreamChunk) bool {
 	if chunk.Usage != nil {
 		s.storedUsage = chunk.Usage
+		if s.onUsage != nil {
+			s.onUsage(chunk.Usage)
+		}
 	}
 
 	for _, choice := range chunk.Choices {

--- a/proxy/streaming_test.go
+++ b/proxy/streaming_test.go
@@ -118,7 +118,7 @@ func TestStreamOpenAIToAnthropic_TextOnly(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-3-sonnet", "req-123")
+	StreamOpenAIToAnthropic(w, body, "claude-3-sonnet", "req-123", nil)
 
 	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
 		t.Errorf("Content-Type = %q, want %q", ct, "text/event-stream")
@@ -259,7 +259,7 @@ func TestStreamOpenAIToAnthropic_ToolCall(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-3-sonnet", "req-456")
+	StreamOpenAIToAnthropic(w, body, "claude-3-sonnet", "req-456", nil)
 
 	events := parseSSEEvents(w.Body.String())
 
@@ -379,7 +379,7 @@ func TestStreamOpenAIToAnthropic_MultipleToolCalls(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-opus-4.6-fast", "req-789")
+	StreamOpenAIToAnthropic(w, body, "claude-opus-4.6-fast", "req-789", nil)
 	events := parseSSEEvents(w.Body.String())
 
 	expectedTypes := []string{
@@ -518,7 +518,7 @@ func TestStreamOpenAIToAnthropic_InterleavedParallelToolCalls(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-opus-4.6-fast", "req-interleaved")
+	StreamOpenAIToAnthropic(w, body, "claude-opus-4.6-fast", "req-interleaved", nil)
 	events := parseSSEEvents(w.Body.String())
 
 	expectedTypes := []string{
@@ -623,7 +623,7 @@ func TestStreamOpenAIToAnthropic_TextAfterToolCall(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-opus-4.6-fast", "req-tool-text")
+	StreamOpenAIToAnthropic(w, body, "claude-opus-4.6-fast", "req-tool-text", nil)
 	events := parseSSEEvents(w.Body.String())
 
 	expectedTypes := []string{
@@ -718,7 +718,7 @@ func TestStreamMessageDeltaNoTypeField(t *testing.T) {
 		"[DONE]",
 	)
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-test", "msg_test")
+	StreamOpenAIToAnthropic(w, body, "claude-test", "msg_test", nil)
 	events := parseSSEEvents(w.Body.String())
 
 	// Find message_delta event
@@ -860,7 +860,7 @@ func TestAnthropicStreamEventShapes(t *testing.T) {
 
 	body := buildSSEStream(mustMarshal(t, chunk1), mustMarshal(t, chunk2), "[DONE]")
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-sonnet-4", "msg_123")
+	StreamOpenAIToAnthropic(w, body, "claude-sonnet-4", "msg_123", nil)
 	events := parseSSEEvents(w.Body.String())
 
 	// Validate each event type's JSON shape
@@ -1287,7 +1287,7 @@ func TestStreamOpenAIToAnthropic_NoSuccessTailOnScannerFailure(t *testing.T) {
 	)
 
 	w := httptest.NewRecorder()
-	StreamOpenAIToAnthropic(w, body, "claude-sonnet-4", "req-scan-fail")
+	StreamOpenAIToAnthropic(w, body, "claude-sonnet-4", "req-scan-fail", nil)
 
 	events := parseSSEEvents(w.Body.String())
 	for _, evt := range events {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -8,17 +8,28 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
 func (h *ProxyHandler) newInferenceUpstreamContext(streaming bool) (context.Context, context.CancelFunc) {
-	// Use background context with timeout to avoid cancellation from client
-	// disconnects while still preventing goroutine leaks on upstream hangs.
+	return h.newInferenceUpstreamContextFromParent(nil, streaming)
+}
+
+func (h *ProxyHandler) newInferenceUpstreamContextFromParent(parent context.Context, streaming bool) (context.Context, context.CancelFunc) {
+	// Use a cancellation-detached parent context so request-scoped values such as
+	// metrics labels still flow through, without aborting upstream work on client
+	// disconnects.
+	base := context.Background()
+	if parent != nil {
+		base = context.WithoutCancel(parent)
+	}
+
 	timeout := upstreamTimeout
 	if streaming {
 		timeout = h.effectiveStreamingUpstreamTimeout()
 	}
-	return context.WithTimeout(context.Background(), timeout)
+	return context.WithTimeout(base, timeout)
 }
 
 func upstreamStatusCode(err error, fallback int) int {
@@ -117,20 +128,40 @@ func mergeHeaderValues(dst, src http.Header) {
 	}
 }
 
-func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, []byte, error) {
+type resolvedProviderRequest struct {
+	provider      *providerRuntime
+	rewrittenBody []byte
+	publicModel   string
+}
+
+func (r resolvedProviderRequest) applyMetricsScope(scope *requestMetricsScope) {
+	if scope == nil {
+		return
+	}
+	scope.SetPublicModel(r.publicModel)
+	if r.provider != nil {
+		scope.SetProvider(r.provider.id)
+	}
+}
+
+func (h *ProxyHandler) resolveProviderRequestDetailed(body []byte, endpoint string) (*resolvedProviderRequest, error) {
 	model := extractRequestModel(body)
 	provider, owner, known := h.resolveProviderModel(model, endpoint)
+	resolved := &resolvedProviderRequest{
+		provider:    provider,
+		publicModel: model,
+	}
 	if provider == nil {
-		return nil, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
+		return resolved, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
 	}
 	if !providerSupportsEndpoint(provider, endpoint) {
-		return nil, nil, &providerRequestError{
+		return resolved, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("provider %q does not support %s", provider.id, endpoint),
 		}
 	}
 	if known && !providerModelSupportsEndpoint(owner, endpoint) {
-		return nil, nil, &providerRequestError{
+		return resolved, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
 		}
@@ -138,9 +169,18 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 
 	rewrittenBody, _, err := rewriteRequestModelForProvider(body, owner.upstreamModel)
 	if err != nil {
-		return nil, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+		return resolved, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 	}
-	return provider, rewrittenBody, nil
+	resolved.rewrittenBody = rewrittenBody
+	return resolved, nil
+}
+
+func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, []byte, error) {
+	resolved, err := h.resolveProviderRequestDetailed(body, endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resolved.provider, resolved.rewrittenBody, nil
 }
 
 func providerSupportsEndpoint(provider *providerRuntime, endpoint string) bool {
@@ -158,18 +198,31 @@ func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body [
 }
 
 func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	provider, rewrittenBody, err := h.resolveProviderRequest(body, path)
+	scope := requestMetricsFromContext(ctx)
+
+	resolved, err := h.resolveProviderRequestDetailed(body, path)
+	if resolved != nil {
+		resolved.applyMetricsScope(scope)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "")
+	resp, err := h.doWithRetry(ctx, func() (*http.Request, error) {
+		req, err := h.newProviderJSONRequest(ctx, resolved.provider, http.MethodPost, path, resolved.rewrittenBody, extraHeaders, "")
 		if err != nil {
 			return nil, err
 		}
 		return req, nil
 	})
+	if err != nil {
+		scope.observeUpstreamError(classifyUpstreamMetricsReason(err), classifyUpstreamMetricsCode(err))
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		scope.observeUpstreamError("status_code", strconv.Itoa(resp.StatusCode))
+	}
+	return resp, nil
 }
 
 func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*http.Response, error) {
@@ -185,4 +238,21 @@ func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {
 	copyPassthroughHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+func writeUpstreamResponseWithBody(w http.ResponseWriter, resp *http.Response, observeBody func([]byte)) error {
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if observeBody != nil {
+		observeBody(body)
+	}
+
+	copyPassthroughHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, err = w.Write(body)
+	return err
 }

--- a/proxy/usage_metrics.go
+++ b/proxy/usage_metrics.go
@@ -1,0 +1,36 @@
+package proxy
+
+import (
+	"encoding/json"
+
+	"github.com/sozercan/vekil/models"
+)
+
+func observeOpenAIUsage(scope *requestMetricsScope, usage *models.OpenAIUsage) {
+	if scope == nil || usage == nil {
+		return
+	}
+	scope.observeTokens("input", usage.PromptTokens)
+	scope.observeTokens("output", usage.CompletionTokens)
+}
+
+func observeAnthropicUsage(scope *requestMetricsScope, usage models.AnthropicUsage) {
+	if scope == nil {
+		return
+	}
+	scope.observeTokens("input", usage.InputTokens)
+	scope.observeTokens("output", usage.OutputTokens)
+}
+
+func extractResponsesUsage(body []byte) (inputTokens, outputTokens int, ok bool) {
+	var payload struct {
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return 0, 0, false
+	}
+	return payload.Usage.InputTokens, payload.Usage.OutputTokens, true
+}

--- a/server/server.go
+++ b/server/server.go
@@ -40,6 +40,16 @@ func WithCopilotHeaderConfig(cfg proxy.CopilotHeaderConfig) Option {
 	return WithProxyOptions(proxy.WithCopilotHeaderConfig(cfg))
 }
 
+// WithBuildVersion propagates the binary version into proxy diagnostics.
+func WithBuildVersion(version string) Option {
+	return WithProxyOptions(proxy.WithBuildVersion(version))
+}
+
+// WithMetricsEnabled toggles Prometheus metrics exposure and instrumentation.
+func WithMetricsEnabled(enabled bool) Option {
+	return WithProxyOptions(proxy.WithMetricsEnabled(enabled))
+}
+
 // WithResponsesWebSocketConfig overrides websocket-session handling for
 // GET /v1/responses Codex clients.
 func WithResponsesWebSocketConfig(cfg proxy.ResponsesWebSocketConfig) Option {
@@ -67,18 +77,21 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
-	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
-	mux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
-	mux.HandleFunc("POST /v1/responses", handler.HandleResponses)
-	mux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
-	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
+	mux.HandleFunc("POST /v1/messages", handler.InstrumentHandler("/v1/messages", handler.HandleAnthropicMessages))
+	mux.HandleFunc("POST /v1/chat/completions", handler.InstrumentHandler("/v1/chat/completions", handler.HandleOpenAIChatCompletions))
+	mux.HandleFunc("POST /v1beta/models/", handler.InstrumentHandler("/v1beta/models", handler.HandleGeminiModels))
+	mux.HandleFunc("POST /v1/models/", handler.InstrumentHandler("/v1/models", handler.HandleGeminiModels))
+	mux.HandleFunc("POST /models/", handler.InstrumentHandler("/models", handler.HandleGeminiModels))
+	mux.HandleFunc("POST /v1/responses/compact", handler.InstrumentHandler("/v1/responses/compact", handler.HandleCompact))
+	mux.HandleFunc("POST /v1/responses", handler.InstrumentHandler("/v1/responses", handler.HandleResponses))
+	mux.HandleFunc("GET /v1/responses", handler.InstrumentHandler("/v1/responses/ws", handler.HandleResponsesWebSocket))
+	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.InstrumentHandler("/v1/memories/trace_summarize", handler.HandleMemorySummarize))
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	if metricsHandler := handler.MetricsHandler(); metricsHandler != nil {
+		mux.Handle("GET /metrics", metricsHandler)
+	}
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net"
 	"strconv"
 	"strings"
@@ -94,5 +96,51 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestNew_MountsMetricsEndpointByDefault(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(w.Body.String(), "vekil_build_info") {
+		t.Fatalf("GET /metrics body missing vekil metrics:\n%s", w.Body.String())
+	}
+}
+
+func TestNew_DoesNotMountMetricsEndpointWhenDisabled(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+		WithMetricsEnabled(false),
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /metrics status = %d, want 404 when disabled", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
## Summary
- add a Prometheus-compatible `/metrics` endpoint on the existing server
- add request, duration, token, retry, upstream error, inflight, and build info metrics
- add focused metrics/server tests
- document the metrics flag and histogram buckets
- add an example Grafana dashboard JSON

## Review status
This PR is a reviewed handoff for follow-up, not an approved merge.

## Remaining review notes
- Security review: `/metrics` is enabled by default on the default listener, which may expose runtime/build telemetry without auth; reviewers recommend making metrics opt-in by default or otherwise keeping it off the public listener.
- Security + quality review: `public_model` and Gemini `endpoint` labels appear user-controlled and insufficiently normalized, creating unbounded-cardinality risk; reviewers recommend collapsing to a bounded allowlisted set.
- Quality review: dependency/signature completeness should be rechecked from a clean build environment; reviewer flagged potential missing Prometheus module updates and possible `doWithRetry` call-site mismatches.
- Quality review: `/v1/responses` streaming and websocket-backed paths may have incomplete usage/metrics coverage and need targeted regression tests.

## Changed files
- `main.go`
- `proxy/chat_handlers.go`
- `proxy/gemini_handler.go`
- `proxy/gemini_streaming.go`
- `proxy/gemini_streaming_test.go`
- `proxy/handler.go`
- `proxy/metrics.go`
- `proxy/metrics_test.go`
- `proxy/responses_handler.go`
- `proxy/retry.go`
- `proxy/streaming.go`
- `proxy/streaming_test.go`
- `proxy/upstream_http.go`
- `proxy/usage_metrics.go`
- `server/server.go`
- `server/server_test.go`
