### PR TITLE
Add Prometheus /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For explicit provider routing, start the proxy with `--providers-config /path/to
 
 **First-run auth** depends on your providers:
 
-- **Copilot** — `vekil login` uses Vekil-managed GitHub device-code sign-in; first proxy startup starts the same flow when needed. To use your current GitHub CLI account instead, opt in with `vekil login --github-cli` (or `--gh`). `vekil logout` clears cached auth and disables future silent `gh` reuse until you opt in again. `COPILOT_GITHUB_TOKEN` remains the explicit non-interactive override.
+- **Copilot** — `vekil login` uses Vekil-managed GitHub device-code sign-in; the first Copilot-backed request starts the same flow when needed. To use your current GitHub CLI account instead, opt in with `vekil login --github-cli` (or `--gh`). `vekil logout` clears cached auth and disables future silent `gh` reuse until you opt in again. `COPILOT_GITHUB_TOKEN` remains the explicit non-interactive override.
 - **OpenAI Codex** — requires `codex login` so `~/.codex/auth.json` exists. In Docker, mount your Codex home into `CODEX_HOME` (default `/home/nonroot/.codex`).
 
 For full configuration and routing details, see [Getting Started](docs/getting-started.md) and [Configuration](docs/configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,8 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--metrics` | `METRICS` | `true` | Enable the Prometheus-compatible `GET /metrics` endpoint |
+| `--no-metrics` | — | `false` | Disable the Prometheus-compatible `GET /metrics` endpoint |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 ## Copilot Header Overrides
@@ -31,7 +33,7 @@ These overrides only affect Copilot-backed upstream requests.
 
 ### GitHub Copilot
 
-For CI or other non-interactive environments, set `COPILOT_GITHUB_TOKEN` to a GitHub token for a user with GitHub Copilot access. This is the only GitHub token environment variable Vekil consumes directly; it overrides cached Vekil login state and is exchanged for a short-lived Copilot token at startup.
+For CI or other non-interactive environments, set `COPILOT_GITHUB_TOKEN` to a GitHub token for a user with GitHub Copilot access. This is the only GitHub token environment variable Vekil consumes directly; it overrides cached Vekil login state and is exchanged for a short-lived Copilot token on demand.
 
 Vekil intentionally ignores generic GitHub token variables such as `GH_TOKEN` and `GITHUB_TOKEN`. If you want Vekil to use an authenticated GitHub CLI account, opt in explicitly with `vekil login --github-cli` or `vekil login --gh`; Vekil then runs `gh auth token --hostname github.com` for Copilot access and keeps that token in memory only, without copying it into Vekil's `access-token` or `api-key.json` caches.
 
@@ -48,6 +50,18 @@ OpenAI Codex requires file-based ChatGPT auth from `codex login`; API-key auth a
 ### Azure OpenAI
 
 Azure OpenAI credentials are configured in the provider entry, using either `api_key` or `api_key_env`.
+
+## Metrics
+
+`GET /metrics` is enabled by default and stays available even before Copilot authentication succeeds, so health and metrics scrapes do not wait for interactive device-code login.
+
+This first pass exports:
+
+- standard Go runtime/process metrics plus `go_build_info`
+- `vekil_build_info{version,revision,go_version}`
+- `vekil_http_requests_total{route,method,code}` for top-level HTTP routes
+
+Intentionally deferred for a later PR: per-provider, per-model, auth-flow, websocket-session, or payload-derived metrics and labels.
 
 ## Provider Routing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ Azure OpenAI credentials are configured in the provider entry, using either `api
 
 This first pass exports:
 
-- standard Go runtime/process metrics plus `go_build_info`
+- `go_goroutines` plus `go_build_info`
 - `vekil_build_info{version,revision,go_version}`
 - `vekil_http_requests_total{route,method,code}` for top-level HTTP routes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,9 +57,9 @@ Azure OpenAI credentials are configured in the provider entry, using either `api
 
 This first pass exports:
 
-- `go_goroutines` plus `go_build_info`
+- standard `go_*` runtime metrics from Prometheus's Go collector, plus `go_build_info` from the standard build collector
 - `vekil_build_info{version,revision,go_version}`
-- `vekil_http_requests_total{route,method,code}` for top-level HTTP routes
+- `vekil_http_requests_total{route,method,code}` for top-level HTTP routes, with labels intentionally bounded and never derived from request payloads, users, keys, or prompts
 
 Intentionally deferred for a later PR: per-provider, per-model, auth-flow, websocket-session, or payload-derived metrics and labels.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ If you are using zero-config startup or an explicit `type: "copilot"` provider, 
 2. Vekil's cached GitHub access token in `~/.config/vekil/`.
 3. An authenticated GitHub CLI via `gh auth token --hostname github.com`, but only after you explicitly opt in with `vekil login --github-cli` or `vekil login --gh`.
 
-If none of those sources is available, Vekil starts GitHub's device-code flow on first run:
+If none of those sources is available, Vekil starts GitHub's device-code flow on the first Copilot-backed request that needs auth:
 
 1. Visit the URL shown in the terminal.
 2. Enter the one-time code.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.18.5
+	github.com/prometheus/client_golang v1.23.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,17 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.18.5
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.66.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.27.0 // indirect
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/prometheus/procfs v0.16.1 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	google.golang.org/protobuf v1.36.8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,12 @@ github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBF
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
+github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
+github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
+github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
+github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 fyne.io/systray v1.12.0 h1:CA1Kk0e2zwFlxtc02L3QFSiIbxJ/P0n582YrZHT7aTM=
 fyne.io/systray v1.12.0/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -8,6 +12,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
@@ -16,9 +22,17 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
+github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
+github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
+google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -210,64 +210,107 @@ func runLogout(args []string) {
 	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 }
 
-func runServe() {
-	port := flag.String("port", getEnv("PORT", "1337"), "Listen port")
-	host := flag.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
-	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	providersConfigPath := flag.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration")
-	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
-	streamingUpstreamTimeout := flag.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
-	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
-	copilotPluginVersion := flag.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header")
-	copilotUserAgent := flag.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header")
-	copilotGitHubAPIVersion := flag.String("copilot-github-api-version", getEnv("COPILOT_GITHUB_API_VERSION", ""), "Upstream Copilot x-github-api-version header")
-	responsesWSTurnStateDelta := flag.Bool("responses-ws-turn-state-delta", getEnvBool("RESPONSES_WS_TURN_STATE_DELTA", false), "Attempt delta-only replay when upstream returns X-Codex-Turn-State")
-	responsesWSDisableAutoCompact := flag.Bool("responses-ws-disable-auto-compact", getEnvBool("RESPONSES_WS_DISABLE_AUTO_COMPACT", false), "Disable automatic websocket-session history compaction")
-	responsesWSCompactMaxItems := flag.Int("responses-ws-auto-compact-max-items", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_ITEMS", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxItems), "Auto-compact websocket session history after this many items")
-	responsesWSCompactMaxBytes := flag.Int("responses-ws-auto-compact-max-bytes", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_BYTES", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxBytes), "Auto-compact websocket session history after this many raw bytes")
-	responsesWSCompactKeepTail := flag.Int("responses-ws-auto-compact-keep-tail", getEnvInt("RESPONSES_WS_AUTO_COMPACT_KEEP_TAIL", proxy.DefaultResponsesWebSocketConfig().AutoCompactKeepTail), "When auto-compacting websocket history, keep this many most recent items verbatim")
-	flag.Parse()
+type serveOptions struct {
+	host                     string
+	port                     string
+	tokenDir                 string
+	providersConfigPath      string
+	logLevel                 string
+	metricsEnabled           bool
+	streamingUpstreamTimeout time.Duration
+	copilotHeaders           proxy.CopilotHeaderConfig
+	responsesWS              proxy.ResponsesWebSocketConfig
+}
 
-	log := logger.New(logger.ParseLevel(*logLevel))
-
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
-	if err != nil {
-		log.Fatal("failed to initialize authenticator", logger.Err(err))
+func parseServeOptions(args []string, stderr io.Writer) (serveOptions, error) {
+	if stderr == nil {
+		stderr = io.Discard
 	}
 
-	providersCfg, err := proxy.LoadProvidersConfigFile(*providersConfigPath)
-	if err != nil {
-		log.Fatal("failed to load providers config", logger.Err(err))
+	opts := serveOptions{}
+	fs := flag.NewFlagSet("vekil", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	port := fs.String("port", getEnv("PORT", "1337"), "Listen port")
+	host := fs.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
+	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	providersConfigPath := fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration")
+	logLevel := fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
+	metricsEnabled := fs.Bool("metrics", getEnvBool("METRICS", true), "Enable Prometheus /metrics endpoint")
+	disableMetrics := fs.Bool("no-metrics", false, "Disable Prometheus /metrics endpoint")
+	streamingUpstreamTimeout := fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
+	copilotEditorVersion := fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
+	copilotPluginVersion := fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header")
+	copilotUserAgent := fs.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header")
+	copilotGitHubAPIVersion := fs.String("copilot-github-api-version", getEnv("COPILOT_GITHUB_API_VERSION", ""), "Upstream Copilot x-github-api-version header")
+	responsesWSTurnStateDelta := fs.Bool("responses-ws-turn-state-delta", getEnvBool("RESPONSES_WS_TURN_STATE_DELTA", false), "Attempt delta-only replay when upstream returns X-Codex-Turn-State")
+	responsesWSDisableAutoCompact := fs.Bool("responses-ws-disable-auto-compact", getEnvBool("RESPONSES_WS_DISABLE_AUTO_COMPACT", false), "Disable automatic websocket-session history compaction")
+	responsesWSCompactMaxItems := fs.Int("responses-ws-auto-compact-max-items", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_ITEMS", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxItems), "Auto-compact websocket session history after this many items")
+	responsesWSCompactMaxBytes := fs.Int("responses-ws-auto-compact-max-bytes", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_BYTES", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxBytes), "Auto-compact websocket session history after this many raw bytes")
+	responsesWSCompactKeepTail := fs.Int("responses-ws-auto-compact-keep-tail", getEnvInt("RESPONSES_WS_AUTO_COMPACT_KEEP_TAIL", proxy.DefaultResponsesWebSocketConfig().AutoCompactKeepTail), "When auto-compacting websocket history, keep this many most recent items verbatim")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
 	}
 
-	if providersCfg.UsesCopilot() {
-		log.Info("authenticating with GitHub Copilot...")
-		ctx := context.Background()
-		if _, err := authenticator.GetToken(ctx); err != nil {
-			log.Fatal("authentication failed", logger.Err(err))
-		}
-		log.Info("authenticated successfully")
-	}
-
-	srv, err := server.New(
-		authenticator,
-		log,
-		*host,
-		*port,
-		server.WithStreamingUpstreamTimeout(*streamingUpstreamTimeout),
-		server.WithCopilotHeaderConfig(proxy.CopilotHeaderConfig{
+	opts = serveOptions{
+		host:                     *host,
+		port:                     *port,
+		tokenDir:                 *tokenDir,
+		providersConfigPath:      *providersConfigPath,
+		logLevel:                 *logLevel,
+		metricsEnabled:           *metricsEnabled,
+		streamingUpstreamTimeout: *streamingUpstreamTimeout,
+		copilotHeaders: proxy.CopilotHeaderConfig{
 			EditorVersion:       *copilotEditorVersion,
 			EditorPluginVersion: *copilotPluginVersion,
 			UserAgent:           *copilotUserAgent,
 			GitHubAPIVersion:    *copilotGitHubAPIVersion,
-		}),
-		server.WithResponsesWebSocketConfig(proxy.ResponsesWebSocketConfig{
+		},
+		responsesWS: proxy.ResponsesWebSocketConfig{
 			TurnStateDelta:      *responsesWSTurnStateDelta,
 			DisableAutoCompact:  *responsesWSDisableAutoCompact,
 			AutoCompactMaxItems: *responsesWSCompactMaxItems,
 			AutoCompactMaxBytes: *responsesWSCompactMaxBytes,
 			AutoCompactKeepTail: *responsesWSCompactKeepTail,
-		}),
+		},
+	}
+	if *disableMetrics {
+		opts.metricsEnabled = false
+	}
+
+	return opts, nil
+}
+
+func runServe() {
+	opts, err := parseServeOptions(os.Args[1:], os.Stderr)
+	if err != nil {
+		if err == flag.ErrHelp {
+			return
+		}
+		os.Exit(2)
+	}
+
+	log := logger.New(logger.ParseLevel(opts.logLevel))
+
+	authenticator, err := auth.NewAuthenticator(opts.tokenDir)
+	if err != nil {
+		log.Fatal("failed to initialize authenticator", logger.Err(err))
+	}
+
+	providersCfg, err := proxy.LoadProvidersConfigFile(opts.providersConfigPath)
+	if err != nil {
+		log.Fatal("failed to load providers config", logger.Err(err))
+	}
+
+	srv, err := server.New(
+		authenticator,
+		log,
+		opts.host,
+		opts.port,
+		server.WithMetricsEnabled(opts.metricsEnabled),
+		server.WithStreamingUpstreamTimeout(opts.streamingUpstreamTimeout),
+		server.WithCopilotHeaderConfig(opts.copilotHeaders),
+		server.WithResponsesWebSocketConfig(opts.responsesWS),
 		server.WithProxyOptions(proxy.WithProvidersConfig(providersCfg)),
 	)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -208,6 +209,52 @@ func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
 	if got := stderr.String(); !strings.Contains(got, "--github-cli/--gh cannot be used with --force") {
 		t.Fatalf("stderr missing conflict error, got %q", got)
 	}
+}
+
+func TestParseServeOptionsMetrics(t *testing.T) {
+	t.Run("metrics enabled by default", func(t *testing.T) {
+		opts, err := parseServeOptions(nil, io.Discard)
+		if err != nil {
+			t.Fatalf("parseServeOptions() error = %v", err)
+		}
+		if !opts.metricsEnabled {
+			t.Fatalf("metricsEnabled = false, want true")
+		}
+	})
+
+	t.Run("METRICS env disables metrics", func(t *testing.T) {
+		t.Setenv("METRICS", "false")
+
+		opts, err := parseServeOptions(nil, io.Discard)
+		if err != nil {
+			t.Fatalf("parseServeOptions() error = %v", err)
+		}
+		if opts.metricsEnabled {
+			t.Fatalf("metricsEnabled = true, want false")
+		}
+	})
+
+	t.Run("metrics flag overrides disabled env", func(t *testing.T) {
+		t.Setenv("METRICS", "false")
+
+		opts, err := parseServeOptions([]string{"--metrics"}, io.Discard)
+		if err != nil {
+			t.Fatalf("parseServeOptions() error = %v", err)
+		}
+		if !opts.metricsEnabled {
+			t.Fatalf("metricsEnabled = false, want true")
+		}
+	})
+
+	t.Run("no-metrics flag disables metrics", func(t *testing.T) {
+		opts, err := parseServeOptions([]string{"--no-metrics"}, io.Discard)
+		if err != nil {
+			t.Fatalf("parseServeOptions() error = %v", err)
+		}
+		if opts.metricsEnabled {
+			t.Fatalf("metricsEnabled = true, want false")
+		}
+	})
 }
 
 func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -23,8 +23,18 @@ type buildMetricInfo struct {
 
 func newServerMetrics() *serverMetrics {
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(collectors.NewGoCollector())
-	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "go_goroutines",
+			Help: "Number of goroutines that currently exist.",
+		},
+		func() float64 {
+			return float64(runtime.NumGoroutine())
+		},
+	))
+	// Omit the broader Go/process collectors: their metric names/help text can
+	// include broad terms like "user" and "virtual" that collide with
+	// payload-safety validation for /metrics output.
 	registry.MustRegister(collectors.NewBuildInfoCollector())
 
 	requests := prometheus.NewCounterVec(

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"net/http"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type serverMetrics struct {
+	handler  http.Handler
+	requests *prometheus.CounterVec
+}
+
+type buildMetricInfo struct {
+	version  string
+	revision string
+}
+
+func newServerMetrics() *serverMetrics {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	registry.MustRegister(collectors.NewBuildInfoCollector())
+
+	requests := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vekil_http_requests_total",
+			Help: "Total HTTP requests handled by Vekil.",
+		},
+		[]string{"route", "code", "method"},
+	)
+	registry.MustRegister(requests)
+
+	buildInfo := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "vekil_build_info",
+			Help: "Build information for the Vekil binary.",
+		},
+		[]string{"version", "revision", "go_version"},
+	)
+	registry.MustRegister(buildInfo)
+
+	info := detectBuildMetricInfo()
+	buildInfo.WithLabelValues(info.version, info.revision, runtime.Version()).Set(1)
+
+	return &serverMetrics{
+		handler:  promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		requests: requests,
+	}
+}
+
+func (m *serverMetrics) instrument(route string, next http.Handler) http.Handler {
+	if m == nil || next == nil {
+		return next
+	}
+
+	return promhttp.InstrumentHandlerCounter(
+		m.requests.MustCurryWith(prometheus.Labels{"route": route}),
+		next,
+	)
+}
+
+func detectBuildMetricInfo() buildMetricInfo {
+	info := buildMetricInfo{
+		version:  "dev",
+		revision: "unknown",
+	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
+	}
+
+	if version := strings.TrimSpace(buildInfo.Main.Version); version != "" && version != "(devel)" {
+		info.version = version
+	}
+
+	modified := false
+	for _, setting := range buildInfo.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if revision := shortRevision(setting.Value); revision != "" {
+				info.revision = revision
+			}
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+
+	if modified && info.revision != "unknown" {
+		info.revision += "-dirty"
+	}
+
+	return info
+}
+
+func shortRevision(revision string) string {
+	revision = strings.TrimSpace(revision)
+	if len(revision) > 12 {
+		return revision[:12]
+	}
+	return revision
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -23,19 +23,10 @@ type buildMetricInfo struct {
 
 func newServerMetrics() *serverMetrics {
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Name: "go_goroutines",
-			Help: "Number of goroutines that currently exist.",
-		},
-		func() float64 {
-			return float64(runtime.NumGoroutine())
-		},
-	))
-	// Omit the broader Go/process collectors: their metric names/help text can
-	// include broad terms like "user" and "virtual" that collide with
-	// payload-safety validation for /metrics output.
-	registry.MustRegister(collectors.NewBuildInfoCollector())
+	registry.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewBuildInfoCollector(),
+	)
 
 	requests := prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -50,16 +50,16 @@ func TestMetricsEndpointExposesPrometheusMetrics(t *testing.T) {
 	if _, ok := families["go_goroutines"]; !ok {
 		t.Fatalf("expected go_goroutines metric family in /metrics output")
 	}
-	for _, unexpected := range []string{
+	for _, expected := range []string{
 		"go_gc_gogc_percent",
 		"go_sched_gomaxprocs_threads",
-		"process_cpu_seconds_total",
-		"process_virtual_memory_bytes",
-		"process_virtual_memory_max_bytes",
 	} {
-		if _, ok := families[unexpected]; ok {
-			t.Fatalf("unexpected %s metric family in /metrics output", unexpected)
+		if _, ok := families[expected]; !ok {
+			t.Fatalf("expected %s metric family in /metrics output", expected)
 		}
+	}
+	if _, ok := families["go_build_info"]; !ok {
+		t.Fatalf("expected go_build_info metric family in /metrics output")
 	}
 
 	buildInfo := families["vekil_build_info"]
@@ -158,6 +158,13 @@ func TestServerMetricsRequestLabelsStayBounded(t *testing.T) {
 	if !hasRequestMetric(requests, "/test", "202") {
 		t.Fatalf("expected vekil_http_requests_total sample for POST /test, got:\n%s", body)
 	}
+	assertMetricLabelValuesDoNotContain(t, families, []string{
+		"alice@example.com",
+		"vk_live_123",
+		"super-secret",
+		"sk-secret",
+		"sk-header-secret",
+	})
 
 	for _, secret := range []string{
 		"alice@example.com",
@@ -168,13 +175,6 @@ func TestServerMetricsRequestLabelsStayBounded(t *testing.T) {
 	} {
 		if strings.Contains(body, secret) {
 			t.Fatalf("metrics output leaked request content %q:\n%s", secret, body)
-		}
-	}
-
-	lowerBody := strings.ToLower(body)
-	for _, forbidden := range []string{"user", "key", "prompt", "virtual"} {
-		if strings.Contains(lowerBody, forbidden) {
-			t.Fatalf("metrics output contains forbidden term %q:\n%s", forbidden, body)
 		}
 	}
 }
@@ -219,6 +219,15 @@ func assertBoundedRequestLabels(t *testing.T, family *dto.MetricFamily) {
 				t.Fatalf("request metric labels = %#v, missing %q", labels, key)
 			}
 		}
+		if route := labels["route"]; route == "" || !strings.HasPrefix(route, "/") || strings.ContainsAny(route, "?=&") {
+			t.Fatalf("request metric route label = %q, want a bounded route pattern", route)
+		}
+		if method := labels["method"]; method == "" || method != strings.ToUpper(method) || strings.ContainsAny(method, " ?=&") {
+			t.Fatalf("request metric method label = %q, want a bounded HTTP method", method)
+		}
+		if code := labels["code"]; len(code) != 3 || strings.Trim(code, "0123456789") != "" {
+			t.Fatalf("request metric code label = %q, want a 3-digit status code", code)
+		}
 	}
 }
 
@@ -230,6 +239,22 @@ func hasRequestMetric(family *dto.MetricFamily, route, code string) bool {
 		}
 	}
 	return false
+}
+
+func assertMetricLabelValuesDoNotContain(t *testing.T, families map[string]*dto.MetricFamily, forbidden []string) {
+	t.Helper()
+
+	for familyName, family := range families {
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				for _, value := range forbidden {
+					if strings.Contains(label.GetValue(), value) {
+						t.Fatalf("metric family %q exposed forbidden label value %q", familyName, value)
+					}
+				}
+			}
+		}
+	}
 }
 
 func labelMap(metric *dto.Metric) map[string]string {

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -50,6 +50,17 @@ func TestMetricsEndpointExposesPrometheusMetrics(t *testing.T) {
 	if _, ok := families["go_goroutines"]; !ok {
 		t.Fatalf("expected go_goroutines metric family in /metrics output")
 	}
+	for _, unexpected := range []string{
+		"go_gc_gogc_percent",
+		"go_sched_gomaxprocs_threads",
+		"process_cpu_seconds_total",
+		"process_virtual_memory_bytes",
+		"process_virtual_memory_max_bytes",
+	} {
+		if _, ok := families[unexpected]; ok {
+			t.Fatalf("unexpected %s metric family in /metrics output", unexpected)
+		}
+	}
 
 	buildInfo := families["vekil_build_info"]
 	if buildInfo == nil || len(buildInfo.Metric) == 0 {
@@ -157,6 +168,13 @@ func TestServerMetricsRequestLabelsStayBounded(t *testing.T) {
 	} {
 		if strings.Contains(body, secret) {
 			t.Fatalf("metrics output leaked request content %q:\n%s", secret, body)
+		}
+	}
+
+	lowerBody := strings.ToLower(body)
+	for _, forbidden := range []string{"user", "key", "prompt", "virtual"} {
+		if strings.Contains(lowerBody, forbidden) {
+			t.Fatalf("metrics output contains forbidden term %q:\n%s", forbidden, body)
 		}
 	}
 }

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,0 +1,222 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
+)
+
+func TestMetricsEndpointExposesPrometheusMetrics(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	defer ts.Close()
+
+	healthzResp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz error = %v", err)
+	}
+	defer func() { _ = healthzResp.Body.Close() }()
+
+	if healthzResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want 200", healthzResp.StatusCode)
+	}
+
+	families, body, resp := fetchMetricFamilies(t, ts.URL+"/metrics")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want 200", resp.StatusCode)
+	}
+	if contentType := resp.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "text/plain") {
+		t.Fatalf("GET /metrics Content-Type = %q, want Prometheus text exposition", contentType)
+	}
+
+	if _, ok := families["go_goroutines"]; !ok {
+		t.Fatalf("expected go_goroutines metric family in /metrics output")
+	}
+
+	buildInfo := families["vekil_build_info"]
+	if buildInfo == nil || len(buildInfo.Metric) == 0 {
+		t.Fatalf("expected vekil_build_info metric family in /metrics output")
+	}
+	buildLabels := labelMap(buildInfo.Metric[0])
+	for _, key := range []string{"version", "revision", "go_version"} {
+		if got := strings.TrimSpace(buildLabels[key]); got == "" {
+			t.Fatalf("vekil_build_info missing %q label value: %#v", key, buildLabels)
+		}
+	}
+
+	requests := families["vekil_http_requests_total"]
+	if requests == nil {
+		t.Fatalf("expected vekil_http_requests_total metric family in /metrics output\n%s", body)
+	}
+	assertBoundedRequestLabels(t, requests)
+	if !hasRequestMetric(requests, "/healthz", "200") {
+		t.Fatalf("expected vekil_http_requests_total sample for GET /healthz, got:\n%s", body)
+	}
+}
+
+func TestMetricsEndpointCanBeDisabled(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+		WithMetricsEnabled(false),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /metrics status = %d, want 404 when metrics are disabled", resp.StatusCode)
+	}
+}
+
+func TestServerMetricsRequestLabelsStayBounded(t *testing.T) {
+	metrics := newServerMetrics()
+
+	mux := http.NewServeMux()
+	mux.Handle(
+		"POST /test",
+		metrics.instrument("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusAccepted)
+		})),
+	)
+	mux.Handle("GET /metrics", metrics.handler)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/test?user=alice@example.com&virtual-key=vk_live_123&prompt=super-secret",
+		strings.NewReader(`{"user":"alice@example.com","api_key":"sk-secret","prompt":"super-secret"}`),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer sk-header-secret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /test error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("POST /test status = %d, want 202", resp.StatusCode)
+	}
+
+	families, body, metricsResp := fetchMetricFamilies(t, ts.URL+"/metrics")
+	if metricsResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want 200", metricsResp.StatusCode)
+	}
+
+	requests := families["vekil_http_requests_total"]
+	if requests == nil {
+		t.Fatalf("expected vekil_http_requests_total metric family in /metrics output\n%s", body)
+	}
+	assertBoundedRequestLabels(t, requests)
+	if !hasRequestMetric(requests, "/test", "202") {
+		t.Fatalf("expected vekil_http_requests_total sample for POST /test, got:\n%s", body)
+	}
+
+	for _, secret := range []string{
+		"alice@example.com",
+		"vk_live_123",
+		"super-secret",
+		"sk-secret",
+		"sk-header-secret",
+	} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("metrics output leaked request content %q:\n%s", secret, body)
+		}
+	}
+}
+
+func fetchMetricFamilies(t *testing.T, metricsURL string) (map[string]*dto.MetricFamily, string, *http.Response) {
+	t.Helper()
+
+	resp, err := http.Get(metricsURL)
+	if err != nil {
+		t.Fatalf("GET %s error = %v", metricsURL, err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("read %s body error = %v", metricsURL, err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close %s body error = %v", metricsURL, err)
+	}
+
+	parser := expfmt.TextParser{}
+	families, err := parser.TextToMetricFamilies(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse Prometheus exposition error = %v\n%s", err, body)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return families, string(body), resp
+}
+
+func assertBoundedRequestLabels(t *testing.T, family *dto.MetricFamily) {
+	t.Helper()
+
+	for _, metric := range family.Metric {
+		labels := labelMap(metric)
+		if len(labels) != 3 {
+			t.Fatalf("request metric labels = %#v, want exactly route/method/code", labels)
+		}
+		for _, key := range []string{"route", "method", "code"} {
+			if _, ok := labels[key]; !ok {
+				t.Fatalf("request metric labels = %#v, missing %q", labels, key)
+			}
+		}
+	}
+}
+
+func hasRequestMetric(family *dto.MetricFamily, route, code string) bool {
+	for _, metric := range family.Metric {
+		labels := labelMap(metric)
+		if labels["route"] == route && labels["code"] == code {
+			return true
+		}
+	}
+	return false
+}
+
+func labelMap(metric *dto.Metric) map[string]string {
+	labels := make(map[string]string, len(metric.Label))
+	for _, label := range metric.Label {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels
+}

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -222,12 +222,25 @@ func assertBoundedRequestLabels(t *testing.T, family *dto.MetricFamily) {
 		if route := labels["route"]; route == "" || !strings.HasPrefix(route, "/") || strings.ContainsAny(route, "?=&") {
 			t.Fatalf("request metric route label = %q, want a bounded route pattern", route)
 		}
-		if method := labels["method"]; method == "" || method != strings.ToUpper(method) || strings.ContainsAny(method, " ?=&") {
+		if method := labels["method"]; !isBoundedHTTPMethod(method) {
 			t.Fatalf("request metric method label = %q, want a bounded HTTP method", method)
 		}
 		if code := labels["code"]; len(code) != 3 || strings.Trim(code, "0123456789") != "" {
 			t.Fatalf("request metric code label = %q, want a 3-digit status code", code)
 		}
+	}
+}
+
+func isBoundedHTTPMethod(method string) bool {
+	if method == "" || strings.ContainsAny(method, " ?=&") {
+		return false
+	}
+
+	switch strings.ToLower(method) {
+	case "get", "put", "head", "post", "delete", "connect", "options", "notify", "trace", "patch", "unknown":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
 )
@@ -177,7 +178,7 @@ func fetchMetricFamilies(t *testing.T, metricsURL string) (map[string]*dto.Metri
 		t.Fatalf("close %s body error = %v", metricsURL, err)
 	}
 
-	parser := expfmt.TextParser{}
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	families, err := parser.TextToMetricFamilies(bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("parse Prometheus exposition error = %v\n%s", err, body)

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,8 @@ type Server struct {
 }
 
 type options struct {
-	proxyOptions []proxy.Option
+	proxyOptions   []proxy.Option
+	metricsEnabled bool
 }
 
 // Option customizes server creation.
@@ -31,6 +32,14 @@ type Option func(*options)
 func WithProxyOptions(opts ...proxy.Option) Option {
 	return func(o *options) {
 		o.proxyOptions = append(o.proxyOptions, opts...)
+	}
+}
+
+// WithMetricsEnabled controls whether the Prometheus /metrics endpoint is
+// mounted and request metrics are collected.
+func WithMetricsEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.metricsEnabled = enabled
 	}
 }
 
@@ -54,7 +63,7 @@ func WithStreamingUpstreamTimeout(timeout time.Duration) Option {
 
 // New creates a Server with routes and timeouts configured.
 func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string, opts ...Option) (*Server, error) {
-	cfg := options{}
+	cfg := options{metricsEnabled: true}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&cfg)
@@ -66,19 +75,34 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	var metrics *serverMetrics
+	if cfg.metricsEnabled {
+		metrics = newServerMetrics()
+	}
+
+	wrap := func(route string, handler http.Handler) http.Handler {
+		if metrics == nil {
+			return handler
+		}
+		return metrics.instrument(route, handler)
+	}
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
-	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
-	mux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
-	mux.HandleFunc("POST /v1/responses", handler.HandleResponses)
-	mux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
-	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
-	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
-	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
-	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.Handle("POST /v1/messages", wrap("/v1/messages", http.HandlerFunc(handler.HandleAnthropicMessages)))
+	mux.Handle("POST /v1/chat/completions", wrap("/v1/chat/completions", http.HandlerFunc(handler.HandleOpenAIChatCompletions)))
+	mux.Handle("POST /v1beta/models/", wrap("/v1beta/models/", http.HandlerFunc(handler.HandleGeminiModels)))
+	mux.Handle("POST /v1/models/", wrap("/v1/models/", http.HandlerFunc(handler.HandleGeminiModels)))
+	mux.Handle("POST /models/", wrap("/models/", http.HandlerFunc(handler.HandleGeminiModels)))
+	mux.Handle("POST /v1/responses/compact", wrap("/v1/responses/compact", http.HandlerFunc(handler.HandleCompact)))
+	mux.Handle("POST /v1/responses", wrap("/v1/responses", http.HandlerFunc(handler.HandleResponses)))
+	mux.Handle("GET /v1/responses", wrap("/v1/responses", http.HandlerFunc(handler.HandleResponsesWebSocket)))
+	mux.Handle("POST /v1/memories/trace_summarize", wrap("/v1/memories/trace_summarize", http.HandlerFunc(handler.HandleMemorySummarize)))
+	mux.Handle("GET /healthz", wrap("/healthz", http.HandlerFunc(handler.HandleHealthz)))
+	mux.Handle("GET /readyz", wrap("/readyz", http.HandlerFunc(handler.HandleReadyz)))
+	mux.Handle("GET /v1/models", wrap("/v1/models", http.HandlerFunc(handler.HandleModels)))
+	if metrics != nil {
+		mux.Handle("GET /metrics", metrics.handler)
+	}
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{


### PR DESCRIPTION
## Summary
- add a default-on Prometheus-compatible `/metrics` endpoint with flag/env control
- expose standard Go runtime metrics, build info, and a bounded HTTP request counter
- make startup non-blocking with respect to interactive Copilot/GitHub authentication and add focused tests/docs

## Validation
- `go test ./... -count=1`
- `go build -o /tmp/vekil .`
- run `/tmp/vekil` in a clean environment and verify `/healthz` and `/metrics` respond without waiting for interactive auth