### PR TITLE
Handle compact upstream 413 with chunked fallback

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1314,6 +1314,138 @@ func TestHandleCompact_ReturnsOriginal413WhenChunkedMergeFails(t *testing.T) {
 	}
 }
 
+func TestHandleCompact_CapsOriginal413BodyWhenChunkedMergeFails(t *testing.T) {
+	largeText := strings.Repeat("a", 5*1024*1024)
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first " + largeText},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second " + largeText},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	oversized413Body := strings.Repeat("x", compactUpstreamErrorBodySize+1024)
+	var calls atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		input, ok := req["input"].([]interface{})
+		if !ok {
+			t.Fatalf("expected input array, got %#v", req["input"])
+		}
+
+		switch call := calls.Add(1); call {
+		case 1:
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(oversized413Body))
+		case 2, 3:
+			if len(input) != 1 {
+				t.Fatalf("expected fallback chunk to have 1 item, got %d", len(input))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-chunk","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"chunk summary"}]}]}`))
+		case 4:
+			if len(input) != 2 {
+				t.Fatalf("expected merge request to contain 2 chunk summaries, got %d", len(input))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"merge failed"}}`))
+		default:
+			t.Fatalf("unexpected /responses request count %d", call)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected capped original 413, got %d: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) != compactUpstreamErrorBodySize {
+		t.Fatalf("expected capped 413 body length %d, got %d", compactUpstreamErrorBodySize, len(body))
+	}
+	if strings.Trim(string(body), "x") != "" {
+		t.Fatalf("expected capped body to preserve the upstream prefix, got %q", body[:min(len(body), 32)])
+	}
+	if calls.Load() != 4 {
+		t.Fatalf("expected initial request, 2 chunk requests, and failed merge; got %d calls", calls.Load())
+	}
+}
+
+func TestSplitCompactInputByBodySizeUsesEncodedItemSizes(t *testing.T) {
+	requestFields := map[string]json.RawMessage{
+		"model": json.RawMessage(`"gpt-5.4"`),
+		"input": json.RawMessage(`[]`),
+	}
+	input := []json.RawMessage{
+		json.RawMessage(`{"type":"message","role":"user","content":[{"type":"input_text","text":"<>& first"}]}`),
+		json.RawMessage(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"<>& second"}]}`),
+		json.RawMessage(`{"type":"message","role":"user","content":[{"type":"input_text","text":"<>& third"}]}`),
+	}
+
+	twoItemBody, err := marshalCompactResponsesRequest(requestFields, input[:2])
+	if err != nil {
+		t.Fatalf("failed to marshal two-item body: %v", err)
+	}
+	threeItemBody, err := marshalCompactResponsesRequest(requestFields, input)
+	if err != nil {
+		t.Fatalf("failed to marshal three-item body: %v", err)
+	}
+	if len(threeItemBody) <= len(twoItemBody) {
+		t.Fatalf("expected three-item body to exceed two-item body: %d <= %d", len(threeItemBody), len(twoItemBody))
+	}
+
+	chunks, err := splitCompactInputByBodySize(requestFields, input, len(twoItemBody))
+	if err != nil {
+		t.Fatalf("split failed: %v", err)
+	}
+	gotSizes := make([]int, 0, len(chunks))
+	for _, chunk := range chunks {
+		gotSizes = append(gotSizes, len(chunk))
+	}
+	if len(gotSizes) != 2 || gotSizes[0] != 2 || gotSizes[1] != 1 {
+		t.Fatalf("expected chunks sized [2,1], got %#v", gotSizes)
+	}
+	for i, chunk := range chunks {
+		body, err := marshalCompactResponsesRequest(requestFields, chunk)
+		if err != nil {
+			t.Fatalf("failed to marshal chunk %d: %v", i, err)
+		}
+		if len(body) > len(twoItemBody) {
+			t.Fatalf("chunk %d body exceeded max: got %d, max %d", i, len(body), len(twoItemBody))
+		}
+	}
+}
+
 func TestHandleCompact_StripsInlineRenderMarkers(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1047,6 +1047,273 @@ func TestHandleCompact_LargeBodyAllowed(t *testing.T) {
 	}
 }
 
+func TestHandleCompact_FallsBackToChunkedCompactionOnUpstream413(t *testing.T) {
+	largeText := strings.Repeat("a", 3*1024*1024)
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first " + largeText},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second " + largeText},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "third " + largeText},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	var mu sync.Mutex
+	var bodySizes []int
+	var inputCounts []int
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Errorf("expected upstream path /responses, got %q", r.URL.Path)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		instructions, _ := req["instructions"].(string)
+		if !strings.Contains(instructions, "CONTEXT CHECKPOINT COMPACTION") {
+			t.Fatalf("expected compaction prompt as instructions, got %q", instructions)
+		}
+		input, ok := req["input"].([]interface{})
+		if !ok {
+			t.Fatalf("expected input array, got %#v", req["input"])
+		}
+
+		mu.Lock()
+		bodySizes = append(bodySizes, len(body))
+		inputCounts = append(inputCounts, len(input))
+		call := len(bodySizes)
+		mu.Unlock()
+
+		switch call {
+		case 1:
+			if len(input) != 3 {
+				t.Fatalf("expected initial one-shot compact input to have 3 items, got %d", len(input))
+			}
+			if len(body) <= compactUpstreamChunkBodySize {
+				t.Fatalf("expected initial compact body to exceed chunk target, got %d bytes", len(body))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(`{"error":{"message":"payload too large"}}`))
+		case 2:
+			if len(input) != 2 {
+				t.Fatalf("expected first fallback chunk to have 2 items, got %d", len(input))
+			}
+			if len(body) > compactUpstreamChunkBodySize {
+				t.Fatalf("expected first fallback chunk body to fit target, got %d bytes", len(body))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-chunk-1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary of first two items"}]}]}`))
+		case 3:
+			if len(input) != 1 {
+				t.Fatalf("expected second fallback chunk to have 1 item, got %d", len(input))
+			}
+			if len(body) > compactUpstreamChunkBodySize {
+				t.Fatalf("expected second fallback chunk body to fit target, got %d bytes", len(body))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-chunk-2","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary of final item"}]}]}`))
+		case 4:
+			if len(input) != 2 {
+				t.Fatalf("expected merge request to contain 2 chunk summaries, got %d", len(input))
+			}
+			if got := requireMessageTextWithRole(t, input[0], "user"); got != "Partial checkpoint summary 1 of 2:\nsummary of first two items" {
+				t.Fatalf("unexpected first merge summary: %q", got)
+			}
+			if got := requireMessageTextWithRole(t, input[1], "user"); got != "Partial checkpoint summary 2 of 2:\nsummary of final item" {
+				t.Fatalf("unexpected second merge summary: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-merged","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"final merged summary"}]}]}`))
+		default:
+			t.Fatalf("unexpected /responses request count %d", call)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	mu.Lock()
+	gotBodySizes := append([]int(nil), bodySizes...)
+	gotInputCounts := append([]int(nil), inputCounts...)
+	mu.Unlock()
+	if len(gotBodySizes) != 4 {
+		t.Fatalf("expected 4 upstream requests (initial + 2 chunks + merge), got %d", len(gotBodySizes))
+	}
+	if gotInputCounts[0] != 3 || gotInputCounts[1] != 2 || gotInputCounts[2] != 1 || gotInputCounts[3] != 2 {
+		t.Fatalf("unexpected upstream input counts: %v", gotInputCounts)
+	}
+	if gotBodySizes[0] <= gotBodySizes[1] || gotBodySizes[0] <= gotBodySizes[2] {
+		t.Fatalf("expected fallback chunk bodies to be smaller than initial body, sizes=%v", gotBodySizes)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result struct {
+		Output []struct {
+			Type             string `json:"type"`
+			EncryptedContent string `json:"encrypted_content"`
+			Content          []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse compact response: %v", err)
+	}
+	if len(result.Output) != 2 {
+		t.Fatalf("expected 2 output items, got %d", len(result.Output))
+	}
+	if result.Output[0].Type != "message" || len(result.Output[0].Content) == 0 || result.Output[0].Content[0].Text != "final merged summary" {
+		t.Fatalf("expected final merged summary message, got %+v", result.Output[0])
+	}
+	if result.Output[1].Type != "compaction" {
+		t.Fatalf("expected compaction item, got %+v", result.Output[1])
+	}
+	if got := decodeCompactionSummaryForTest(t, result.Output[1].EncryptedContent); got != "final merged summary" {
+		t.Errorf("expected encoded final merged summary, got %q", got)
+	}
+}
+
+func TestHandleCompact_ReturnsOriginal413WhenChunkedMergeFails(t *testing.T) {
+	largeText := strings.Repeat("a", 5*1024*1024)
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "first " + largeText},
+				},
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "second " + largeText},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	const original413Body = `{"error":{"message":"original payload too large"}}`
+
+	var mu sync.Mutex
+	var inputCounts []int
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		input, ok := req["input"].([]interface{})
+		if !ok {
+			t.Fatalf("expected input array, got %#v", req["input"])
+		}
+
+		mu.Lock()
+		inputCounts = append(inputCounts, len(input))
+		call := len(inputCounts)
+		mu.Unlock()
+
+		switch call {
+		case 1:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(original413Body))
+		case 2:
+			if len(input) != 1 {
+				t.Fatalf("expected first fallback chunk to have 1 item, got %d", len(input))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-chunk-1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary of first item"}]}]}`))
+		case 3:
+			if len(input) != 1 {
+				t.Fatalf("expected second fallback chunk to have 1 item, got %d", len(input))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-chunk-2","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary of second item"}]}]}`))
+		case 4:
+			if len(input) != 2 {
+				t.Fatalf("expected merge request to contain 2 chunk summaries, got %d", len(input))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"merge failed"}}`))
+		default:
+			t.Fatalf("unexpected /responses request count %d", call)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected original 413, got %d: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != original413Body {
+		t.Fatalf("expected original 413 body %s, got %s", original413Body, body)
+	}
+
+	mu.Lock()
+	gotInputCounts := append([]int(nil), inputCounts...)
+	mu.Unlock()
+	if len(gotInputCounts) != 4 {
+		t.Fatalf("expected 4 upstream requests (initial + 2 chunks + failed merge), got %d", len(gotInputCounts))
+	}
+	if gotInputCounts[0] != 2 || gotInputCounts[1] != 1 || gotInputCounts[2] != 1 || gotInputCounts[3] != 2 {
+		t.Fatalf("unexpected upstream input counts: %v", gotInputCounts)
+	}
+}
+
 func TestHandleCompact_StripsInlineRenderMarkers(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -110,7 +110,12 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 // proxy-owned opaque token rather than a real upstream-encrypted payload.
 // compactUpstreamChunkBodySize is measured against the serialized upstream
 // request body size, not the model-visible token budget.
-const compactUpstreamChunkBodySize = 8 << 20
+const (
+	compactUpstreamChunkBodySize = 8 << 20
+	// compactUpstreamErrorBodySize caps upstream error bodies that the compact
+	// fallback buffers only so it can replay the original failure if chunking fails.
+	compactUpstreamErrorBodySize = 1 << 20
+)
 
 const compactPrompt = `You are performing a CONTEXT CHECKPOINT COMPACTION for an interrupted coding-agent session. Create a handoff summary for another LLM that must continue the same task seamlessly.
 
@@ -412,12 +417,18 @@ func (h *ProxyHandler) compactResponsesRequestDepth(ctx context.Context, request
 		return "", resp, nil
 	}
 
-	respBody, readErr := io.ReadAll(resp.Body)
+	respBody, truncated, readErr := readBodyWithCap(resp.Body, compactUpstreamErrorBodySize)
 	_ = resp.Body.Close()
 	if readErr != nil {
 		return "", nil, readErr
 	}
 	originalResp := cloneHTTPResponseWithBody(resp, respBody)
+	if truncated {
+		originalResp.Header.Del("Content-Length")
+		h.log.Debug("truncated upstream 413 response body for compact fallback",
+			logger.F("max_bytes", compactUpstreamErrorBodySize),
+		)
+	}
 
 	summary, err := h.compactResponsesRequestInChunks(ctx, requestFields, extraHeaders, depth+1)
 	if err != nil {
@@ -456,9 +467,26 @@ func cloneHTTPResponseWithBody(resp *http.Response, body []byte) *http.Response 
 	}
 	cloned := new(http.Response)
 	*cloned = *resp
+	if resp.Header != nil {
+		cloned.Header = resp.Header.Clone()
+	}
 	cloned.Body = io.NopCloser(bytes.NewReader(body))
 	cloned.ContentLength = int64(len(body))
 	return cloned
+}
+
+func readBodyWithCap(r io.Reader, maxBytes int) ([]byte, bool, error) {
+	if maxBytes < 0 {
+		return nil, false, fmt.Errorf("invalid body cap %d", maxBytes)
+	}
+	body, err := io.ReadAll(io.LimitReader(r, int64(maxBytes)+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(body) > maxBytes {
+		return body[:maxBytes], true, nil
+	}
+	return body, false, nil
 }
 
 func (h *ProxyHandler) compactResponsesRequestInChunks(ctx context.Context, requestFields map[string]json.RawMessage, extraHeaders http.Header, depth int) (string, error) {
@@ -492,7 +520,7 @@ func (h *ProxyHandler) compactResponsesRequestInChunks(ctx context.Context, requ
 			return "", err
 		}
 		if resp != nil {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, compactUpstreamErrorBodySize))
 			_ = resp.Body.Close()
 			return "", fmt.Errorf("compact chunk %d returned %d: %s", i+1, resp.StatusCode, strings.TrimSpace(string(body)))
 		}
@@ -519,27 +547,51 @@ func splitCompactInputByBodySize(requestFields map[string]json.RawMessage, input
 		return nil, fmt.Errorf("invalid compact chunk size %d", maxBodySize)
 	}
 
+	emptyBody, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{})
+	if err != nil {
+		return nil, err
+	}
+	// The rest of the compact request is stable while splitting. Track only the
+	// encoded JSON array size for input so each item is marshaled once instead of
+	// re-marshaling the whole candidate body for every append.
+	fixedBodySize := len(emptyBody) - len("[]")
+
 	chunks := make([][]json.RawMessage, 0, 2)
 	current := make([]json.RawMessage, 0, len(input))
+	currentArraySize := len("[]")
 	for _, item := range input {
-		candidate := append(append([]json.RawMessage(nil), current...), item)
-		candidateBody, err := marshalCompactResponsesRequest(requestFields, candidate)
+		itemSize, err := encodedRawMessageSize(item)
 		if err != nil {
 			return nil, err
 		}
-		if len(candidateBody) <= maxBodySize || len(current) == 0 {
-			current = candidate
+
+		candidateArraySize := currentArraySize + len(",") + itemSize
+		if len(current) == 0 {
+			candidateArraySize = len("[]") + itemSize
+		}
+		if fixedBodySize+candidateArraySize <= maxBodySize || len(current) == 0 {
+			current = append(current, item)
+			currentArraySize = candidateArraySize
 			continue
 		}
 
 		chunks = append(chunks, current)
 		current = []json.RawMessage{item}
+		currentArraySize = len("[]") + itemSize
 	}
 	if len(current) > 0 {
 		chunks = append(chunks, current)
 	}
 
 	return chunks, nil
+}
+
+func encodedRawMessageSize(raw json.RawMessage) (int, error) {
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return 0, err
+	}
+	return len(encoded), nil
 }
 
 func (h *ProxyHandler) mergeCompactionSummaries(ctx context.Context, requestFields map[string]json.RawMessage, summaries []string, extraHeaders http.Header, depth int) (string, error) {
@@ -574,7 +626,7 @@ func (h *ProxyHandler) mergeCompactionSummaries(ctx context.Context, requestFiel
 		return "", err
 	}
 	if resp != nil {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, compactUpstreamErrorBodySize))
 		_ = resp.Body.Close()
 		return "", fmt.Errorf("compact summary merge returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
@@ -888,7 +940,7 @@ func (h *ProxyHandler) compactResponsesInput(ctx context.Context, model string, 
 	}
 	if resp != nil {
 		defer func() { _ = resp.Body.Close() }()
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, compactUpstreamErrorBodySize))
 		return "", fmt.Errorf("compaction request returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return summary, nil

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -108,6 +108,8 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 // compact request into a regular /responses call with this prompt so the
 // model produces a summarized handoff. The resulting compaction item is a
 // proxy-owned opaque token rather than a real upstream-encrypted payload.
+const compactUpstreamChunkBodySize = 8 << 20
+
 const compactPrompt = `You are performing a CONTEXT CHECKPOINT COMPACTION for an interrupted coding-agent session. Create a handoff summary for another LLM that must continue the same task seamlessly.
 
 Write the summary so the next assistant can resume work without asking the user to restate the task.
@@ -142,14 +144,11 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusBadRequest, "invalid JSON in request body", "invalid_request_error")
 		return
 	}
-	prompt, _ := json.Marshal(compactPrompt)
-	body["instructions"] = prompt
-	bodyBytes, _ = json.Marshal(body)
 
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
 	defer upstreamCancel()
 
-	resp, err := h.postResponsesWithFallbackHeaders(upstreamCtx, bodyBytes, responsesExtraHeadersFromRequest(r))
+	summaryText, resp, err := h.compactResponsesRequest(upstreamCtx, body, responsesExtraHeadersFromRequest(r))
 	if err != nil {
 		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "compact"), logger.Err(err))
@@ -164,9 +163,8 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
 		if contentType := resp.Header.Get("Content-Type"); contentType != "" {
 			w.Header().Set("Content-Type", contentType)
 		}
@@ -175,46 +173,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadGateway, "failed to read upstream response", "server_error")
-		return
-	}
-
-	summaryText, err := extractResponsesOutputText(respBody)
-	if err != nil {
-		writeOpenAIError(w, http.StatusBadGateway, "failed to parse upstream response", "server_error")
-		return
-	}
-
-	type contentPart struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	}
-	type outputItem struct {
-		Type             string        `json:"type"`
-		Role             string        `json:"role,omitempty"`
-		Content          []contentPart `json:"content,omitempty"`
-		EncryptedContent string        `json:"encrypted_content,omitempty"`
-	}
-	compactResp := struct {
-		Output []outputItem `json:"output"`
-	}{
-		Output: []outputItem{
-			{
-				Type:    "message",
-				Role:    "assistant",
-				Content: []contentPart{{Type: "output_text", Text: summaryText}},
-			},
-			{
-				Type:             "compaction",
-				EncryptedContent: encodeSyntheticCompaction(summaryText),
-			},
-		},
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(compactResp)
+	writeCompactResponse(w, summaryText)
 }
 
 // memorySummarizePrompt is the system instruction used to summarize conversation
@@ -382,6 +341,242 @@ func extractResponsesOutputText(body []byte) (string, error) {
 	}
 
 	return sanitizeProxySummaryText(sb.String()), nil
+}
+
+func writeCompactResponse(w http.ResponseWriter, summaryText string) {
+	type contentPart struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type outputItem struct {
+		Type             string        `json:"type"`
+		Role             string        `json:"role,omitempty"`
+		Content          []contentPart `json:"content,omitempty"`
+		EncryptedContent string        `json:"encrypted_content,omitempty"`
+	}
+	compactResp := struct {
+		Output []outputItem `json:"output"`
+	}{
+		Output: []outputItem{
+			{
+				Type:    "message",
+				Role:    "assistant",
+				Content: []contentPart{{Type: "output_text", Text: summaryText}},
+			},
+			{
+				Type:             "compaction",
+				EncryptedContent: encodeSyntheticCompaction(summaryText),
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(compactResp)
+}
+
+func (h *ProxyHandler) compactResponsesRequest(ctx context.Context, requestFields map[string]json.RawMessage, extraHeaders http.Header) (string, *http.Response, error) {
+	return h.compactResponsesRequestDepth(ctx, requestFields, extraHeaders, 0)
+}
+
+func (h *ProxyHandler) compactResponsesRequestDepth(ctx context.Context, requestFields map[string]json.RawMessage, extraHeaders http.Header, depth int) (string, *http.Response, error) {
+	if depth > 8 {
+		return "", nil, fmt.Errorf("compaction chunk recursion limit exceeded")
+	}
+
+	bodyBytes, err := marshalCompactResponsesRequest(requestFields, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	resp, err := h.postResponsesWithFallbackHeaders(ctx, bodyBytes, extraHeaders)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", nil, err
+		}
+		summary, err := extractResponsesOutputText(respBody)
+		if err != nil {
+			return "", nil, err
+		}
+		return summary, nil, nil
+	}
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		return "", resp, nil
+	}
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return "", nil, readErr
+	}
+	originalResp := cloneHTTPResponseWithBody(resp, respBody)
+
+	summary, err := h.compactResponsesRequestInChunks(ctx, requestFields, extraHeaders, depth+1)
+	if err != nil {
+		h.log.Debug("chunked compact request failed", logger.Err(err))
+		return "", originalResp, nil
+	}
+	return summary, nil, nil
+}
+
+func marshalCompactResponsesRequest(requestFields map[string]json.RawMessage, input []json.RawMessage) ([]byte, error) {
+	body := make(map[string]json.RawMessage, len(requestFields)+1)
+	for key, value := range requestFields {
+		body[key] = value
+	}
+
+	prompt, err := json.Marshal(compactPrompt)
+	if err != nil {
+		return nil, err
+	}
+	body["instructions"] = prompt
+
+	if input != nil {
+		inputRaw, err := json.Marshal(input)
+		if err != nil {
+			return nil, err
+		}
+		body["input"] = inputRaw
+	}
+
+	return json.Marshal(body)
+}
+
+func cloneHTTPResponseWithBody(resp *http.Response, body []byte) *http.Response {
+	if resp == nil {
+		return nil
+	}
+	cloned := new(http.Response)
+	*cloned = *resp
+	cloned.Body = io.NopCloser(bytes.NewReader(body))
+	cloned.ContentLength = int64(len(body))
+	return cloned
+}
+
+func (h *ProxyHandler) compactResponsesRequestInChunks(ctx context.Context, requestFields map[string]json.RawMessage, extraHeaders http.Header, depth int) (string, error) {
+	var input []json.RawMessage
+	if err := json.Unmarshal(requestFields["input"], &input); err != nil {
+		return "", err
+	}
+	if len(input) < 2 {
+		return "", fmt.Errorf("compact request input cannot be split")
+	}
+
+	chunks, err := splitCompactInputByBodySize(requestFields, input, compactUpstreamChunkBodySize)
+	if err != nil {
+		return "", err
+	}
+	if len(chunks) < 2 {
+		return "", fmt.Errorf("compact request input cannot be split below upstream payload limit")
+	}
+
+	h.log.Info("retrying compact request with chunked history after 413",
+		logger.F("original_items", len(input)),
+		logger.F("chunks", len(chunks)),
+		logger.F("original_bytes", rawMessagesSize(input)),
+	)
+
+	summaries := make([]string, 0, len(chunks))
+	for i, chunk := range chunks {
+		chunkFields := copyResponsesRequestFieldsWithInput(requestFields, chunk)
+		summary, resp, err := h.compactResponsesRequestDepth(ctx, chunkFields, extraHeaders, depth)
+		if err != nil {
+			return "", err
+		}
+		if resp != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			_ = resp.Body.Close()
+			return "", fmt.Errorf("compact chunk %d returned %d: %s", i+1, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		summaries = append(summaries, summary)
+	}
+
+	return h.mergeCompactionSummaries(ctx, requestFields, summaries, extraHeaders, depth)
+}
+
+func copyResponsesRequestFieldsWithInput(requestFields map[string]json.RawMessage, input []json.RawMessage) map[string]json.RawMessage {
+	copied := make(map[string]json.RawMessage, len(requestFields)+1)
+	for key, value := range requestFields {
+		copied[key] = value
+	}
+	inputRaw, err := json.Marshal(input)
+	if err == nil {
+		copied["input"] = inputRaw
+	}
+	return copied
+}
+
+func splitCompactInputByBodySize(requestFields map[string]json.RawMessage, input []json.RawMessage, maxBodySize int) ([][]json.RawMessage, error) {
+	if maxBodySize <= 0 {
+		return nil, fmt.Errorf("invalid compact chunk size %d", maxBodySize)
+	}
+
+	chunks := make([][]json.RawMessage, 0, 2)
+	current := make([]json.RawMessage, 0, len(input))
+	for _, item := range input {
+		candidate := append(append([]json.RawMessage(nil), current...), item)
+		candidateBody, err := marshalCompactResponsesRequest(requestFields, candidate)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidateBody) <= maxBodySize || len(current) == 0 {
+			current = candidate
+			continue
+		}
+
+		chunks = append(chunks, current)
+		current = []json.RawMessage{item}
+	}
+	if len(current) > 0 {
+		chunks = append(chunks, current)
+	}
+
+	return chunks, nil
+}
+
+func (h *ProxyHandler) mergeCompactionSummaries(ctx context.Context, requestFields map[string]json.RawMessage, summaries []string, extraHeaders http.Header, depth int) (string, error) {
+	switch len(summaries) {
+	case 0:
+		return "", nil
+	case 1:
+		return summaries[0], nil
+	}
+
+	input := make([]json.RawMessage, 0, len(summaries))
+	for i, summary := range summaries {
+		message, err := json.Marshal(map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]string{
+				{
+					"type": "input_text",
+					"text": fmt.Sprintf("Partial checkpoint summary %d of %d:\n%s", i+1, len(summaries), summary),
+				},
+			},
+		})
+		if err != nil {
+			return "", err
+		}
+		input = append(input, json.RawMessage(message))
+	}
+
+	mergeFields := copyResponsesRequestFieldsWithInput(requestFields, input)
+	summary, resp, err := h.compactResponsesRequestDepth(ctx, mergeFields, extraHeaders, depth)
+	if err != nil {
+		return "", err
+	}
+	if resp != nil {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		_ = resp.Body.Close()
+		return "", fmt.Errorf("compact summary merge returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return summary, nil
 }
 
 func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint string, injectResumePrompt bool) []byte {
@@ -672,32 +867,29 @@ func (h *ProxyHandler) compactResponsesInput(ctx context.Context, model string, 
 		return "", fmt.Errorf("missing model for websocket compaction")
 	}
 
-	bodyBytes, err := json.Marshal(map[string]interface{}{
-		"model":        model,
-		"instructions": compactPrompt,
-		"input":        input,
-	})
+	modelRaw, err := json.Marshal(model)
+	if err != nil {
+		return "", err
+	}
+	inputRaw, err := json.Marshal(input)
 	if err != nil {
 		return "", err
 	}
 
-	resp, err := h.postResponsesWithFallbackHeaders(ctx, bodyBytes, extraHeaders)
+	requestFields := map[string]json.RawMessage{
+		"model": modelRaw,
+		"input": inputRaw,
+	}
+	summary, resp, err := h.compactResponsesRequest(ctx, requestFields, extraHeaders)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		return "", fmt.Errorf("compaction request returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	return extractResponsesOutputText(respBody)
+	return summary, nil
 }
 
 func isUnsupportedResponsesModelError(statusCode int, body []byte) bool {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -108,6 +108,8 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 // compact request into a regular /responses call with this prompt so the
 // model produces a summarized handoff. The resulting compaction item is a
 // proxy-owned opaque token rather than a real upstream-encrypted payload.
+// compactUpstreamChunkBodySize is measured against the serialized upstream
+// request body size, not the model-visible token budget.
 const compactUpstreamChunkBodySize = 8 << 20
 
 const compactPrompt = `You are performing a CONTEXT CHECKPOINT COMPACTION for an interrupted coding-agent session. Create a handoff summary for another LLM that must continue the same task seamlessly.


### PR DESCRIPTION
## Summary
- retry /responses/compact proxy requests as chunked /responses summaries when upstream returns 413
- merge partial summaries into the same Codex-compatible compact response shape
- preserve original non-413 upstream behavior and return the original 413 if fallback fails

## Testing
- go test ./proxy/ -run TestHandleCompact -count=1
- go test ./...