### PR TITLE
Handle oversized fixed fields in compact fallback

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -140,7 +140,7 @@ Compatibility shim for environments expecting `/responses/compact`. The proxy re
 - a normal assistant summary message
 - a proxy-owned opaque `compaction` item whose `encrypted_content` can later be sent back to `/v1/responses` or `/v1/responses/compact`
 
-Requests to this endpoint are accepted up to `64 MiB` so large session histories can be compacted without tripping the default request-body limit.
+Requests to this endpoint are accepted up to `64 MiB` so large session histories can be compacted without tripping the default request-body limit. If the upstream `/responses` call still rejects the compact payload with `413 Payload Too Large`, the proxy retries by compacting the input in chunks, including splitting oversized individual input items or string inputs into synthetic historical-context chunks before merging the partial summaries into one final checkpoint. During this fallback only, oversized fixed fields such as large `tools` arrays or `text` schemas may be omitted from retry requests when needed to stay under upstream payload limits.
 
 If the requested model does not support the upstream Responses API, the proxy retries against a compatible fallback model discovered from `/models`.
 That fallback stays within the selected provider; the proxy does not silently switch providers.

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1210,6 +1210,334 @@ func TestHandleCompact_FallsBackToChunkedCompactionOnUpstream413(t *testing.T) {
 	}
 }
 
+func TestHandleCompact_FallsBackToChunkedCompactionForStringInputOnUpstream413(t *testing.T) {
+	largeText := strings.Repeat("a", compactUpstreamChunkBodySize+(512*1024))
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": largeText,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	var calls atomic.Int32
+	var chunkCalls atomic.Int32
+	var mergeCalls atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+
+		switch call := calls.Add(1); call {
+		case 1:
+			if len(body) <= compactUpstreamChunkBodySize {
+				t.Fatalf("expected initial compact body to exceed chunk target, got %d bytes", len(body))
+			}
+			if _, ok := req["input"].(string); !ok {
+				t.Fatalf("expected initial input to remain a string, got %#v", req["input"])
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(`{"error":{"message":"failed to parse request","code":"payload_too_large"}}`))
+			return
+		default:
+			if len(body) > compactUpstreamChunkBodySize {
+				t.Fatalf("fallback compact body exceeded chunk target: got %d bytes", len(body))
+			}
+		}
+
+		input, ok := req["input"].([]interface{})
+		if !ok || len(input) == 0 {
+			t.Fatalf("expected fallback input array, got %#v", req["input"])
+		}
+		text := requireMessageTextWithRole(t, input[0], "user")
+		switch {
+		case strings.Contains(text, "Partial checkpoint summary"):
+			mergeCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-merge","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"final merged string summary"}]}]}`))
+		case strings.Contains(text, "Oversized compact input item chunk"):
+			chunkCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-chunk","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"chunk summary"}]}]}`))
+		default:
+			t.Fatalf("unexpected fallback compact input text: %.200q", text)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if chunkCalls.Load() < 2 {
+		t.Fatalf("expected at least two fallback chunk requests, got %d", chunkCalls.Load())
+	}
+	if mergeCalls.Load() != 1 {
+		t.Fatalf("expected one merge request, got %d", mergeCalls.Load())
+	}
+	if calls.Load() != 1+chunkCalls.Load()+mergeCalls.Load() {
+		t.Fatalf("unexpected upstream request accounting: calls=%d chunks=%d merges=%d", calls.Load(), chunkCalls.Load(), mergeCalls.Load())
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var result struct {
+		Output []struct {
+			Type             string `json:"type"`
+			EncryptedContent string `json:"encrypted_content"`
+			Content          []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse compact response: %v", err)
+	}
+	if len(result.Output) != 2 || result.Output[0].Content[0].Text != "final merged string summary" {
+		t.Fatalf("expected final merged compact response, got %+v", result.Output)
+	}
+	if got := decodeCompactionSummaryForTest(t, result.Output[1].EncryptedContent); got != "final merged string summary" {
+		t.Fatalf("expected encoded final merged summary, got %q", got)
+	}
+}
+
+func TestHandleCompact_StripsOversizedToolsDuring413Fallback(t *testing.T) {
+	hugeToolDescription := strings.Repeat("a", compactUpstreamChunkBodySize)
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "please compact this small history"},
+				},
+			},
+		},
+		"tools": []interface{}{
+			map[string]interface{}{
+				"type":        "function",
+				"name":        "oversized_tool",
+				"description": hugeToolDescription,
+				"parameters": map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		},
+		"tool_choice": map[string]interface{}{"type": "function", "name": "oversized_tool"},
+		"text":        map[string]interface{}{"format": map[string]string{"type": "text"}},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	var calls atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		input, ok := req["input"].([]interface{})
+		if !ok || len(input) != 1 {
+			t.Fatalf("expected one compact input item, got %#v", req["input"])
+		}
+
+		switch call := calls.Add(1); call {
+		case 1:
+			if len(body) <= compactUpstreamChunkBodySize {
+				t.Fatalf("expected initial compact body to exceed chunk target, got %d bytes", len(body))
+			}
+			if _, ok := req["tools"]; !ok {
+				t.Fatalf("expected initial upstream request to include tools")
+			}
+			if _, ok := req["tool_choice"]; !ok {
+				t.Fatalf("expected initial upstream request to include tool_choice")
+			}
+			if _, ok := req["text"]; !ok {
+				t.Fatalf("expected initial upstream request to include text")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(`{"error":{"message":"payload too large"}}`))
+		case 2:
+			if len(body) > compactUpstreamChunkBodySize {
+				t.Fatalf("expected sanitized compact fallback body to fit target, got %d bytes", len(body))
+			}
+			if _, ok := req["tools"]; ok {
+				t.Fatalf("expected sanitized fallback request to omit oversized tools")
+			}
+			if _, ok := req["tool_choice"]; ok {
+				t.Fatalf("expected sanitized fallback request to omit tool_choice with tools")
+			}
+			if _, ok := req["text"]; !ok {
+				t.Fatalf("expected sanitized fallback request to preserve small text field")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-sanitized-tools","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary without oversized tools"}]}]}`))
+		default:
+			t.Fatalf("unexpected /responses request count %d", call)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected initial request and one sanitized fallback request, got %d", calls.Load())
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	summary, encryptedSummary := requireCompactResponseSummaryForTest(t, body)
+	if summary != "summary without oversized tools" {
+		t.Fatalf("expected sanitized tools summary, got %q", summary)
+	}
+	if encryptedSummary != "summary without oversized tools" {
+		t.Fatalf("expected encoded sanitized tools summary, got %q", encryptedSummary)
+	}
+}
+
+func TestHandleCompact_StripsOversizedTextDuring413Fallback(t *testing.T) {
+	hugeJSONSchemaDescription := strings.Repeat("b", compactUpstreamChunkBodySize)
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model": "gpt-5.4",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "please compact this history with a text schema"},
+				},
+			},
+		},
+		"tools": []interface{}{
+			map[string]interface{}{
+				"type":        "function",
+				"name":        "small_tool",
+				"description": "small tool that should survive fallback sanitization",
+				"parameters": map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		},
+		"tool_choice": map[string]interface{}{"type": "function", "name": "small_tool"},
+		"text": map[string]interface{}{
+			"format": map[string]interface{}{
+				"type": "json_schema",
+				"name": "oversized_schema",
+				"schema": map[string]interface{}{
+					"type":        "object",
+					"description": hugeJSONSchemaDescription,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	var calls atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream body: %v", err)
+		}
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+		input, ok := req["input"].([]interface{})
+		if !ok || len(input) != 1 {
+			t.Fatalf("expected one compact input item, got %#v", req["input"])
+		}
+
+		switch call := calls.Add(1); call {
+		case 1:
+			if len(body) <= compactUpstreamChunkBodySize {
+				t.Fatalf("expected initial compact body to exceed chunk target, got %d bytes", len(body))
+			}
+			if _, ok := req["text"]; !ok {
+				t.Fatalf("expected initial upstream request to include text")
+			}
+			if _, ok := req["tools"]; !ok {
+				t.Fatalf("expected initial upstream request to include tools")
+			}
+			if _, ok := req["tool_choice"]; !ok {
+				t.Fatalf("expected initial upstream request to include tool_choice")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			_, _ = w.Write([]byte(`{"error":{"message":"payload too large"}}`))
+		case 2:
+			if len(body) > compactUpstreamChunkBodySize {
+				t.Fatalf("expected sanitized compact fallback body to fit target, got %d bytes", len(body))
+			}
+			if _, ok := req["text"]; ok {
+				t.Fatalf("expected sanitized fallback request to omit oversized text field")
+			}
+			if _, ok := req["tools"]; !ok {
+				t.Fatalf("expected sanitized fallback request to preserve small tools")
+			}
+			if _, ok := req["tool_choice"]; !ok {
+				t.Fatalf("expected sanitized fallback request to preserve tool_choice with tools")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-sanitized-text","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary without oversized text schema"}]}]}`))
+		default:
+			t.Fatalf("unexpected /responses request count %d", call)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleCompact(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected initial request and one sanitized fallback request, got %d", calls.Load())
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	summary, encryptedSummary := requireCompactResponseSummaryForTest(t, body)
+	if summary != "summary without oversized text schema" {
+		t.Fatalf("expected sanitized text summary, got %q", summary)
+	}
+	if encryptedSummary != "summary without oversized text schema" {
+		t.Fatalf("expected encoded sanitized text summary, got %q", encryptedSummary)
+	}
+}
+
 func TestHandleCompact_ReturnsOriginal413WhenChunkedMergeFails(t *testing.T) {
 	largeText := strings.Repeat("a", 5*1024*1024)
 	reqBody, err := json.Marshal(map[string]interface{}{
@@ -1398,6 +1726,62 @@ func TestHandleCompact_CapsOriginal413BodyWhenChunkedMergeFails(t *testing.T) {
 	}
 	if calls.Load() != 4 {
 		t.Fatalf("expected initial request, 2 chunk requests, and failed merge; got %d calls", calls.Load())
+	}
+}
+
+func TestSplitOversizedCompactInputItemsByBodySize(t *testing.T) {
+	modelRaw, _ := json.Marshal("gpt-5.4")
+	inputRaw := json.RawMessage(`[]`)
+	requestFields := map[string]json.RawMessage{
+		"model": modelRaw,
+		"input": inputRaw,
+	}
+	oversizedItem, err := json.Marshal(map[string]interface{}{
+		"type": "message",
+		"role": "user",
+		"content": []map[string]string{
+			{"type": "input_text", "text": strings.Repeat("oversized ", 2048)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal oversized item: %v", err)
+	}
+
+	maxBodySize := 4096
+	singleBody, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{oversizedItem})
+	if err != nil {
+		t.Fatalf("failed to marshal single item body: %v", err)
+	}
+	if len(singleBody) <= maxBodySize {
+		t.Fatalf("expected single item body to exceed test max, got %d", len(singleBody))
+	}
+
+	splitItems, split, err := splitOversizedCompactInputItemsByBodySize(requestFields, []json.RawMessage{oversizedItem}, maxBodySize)
+	if err != nil {
+		t.Fatalf("split oversized item failed: %v", err)
+	}
+	if !split {
+		t.Fatal("expected oversized item to be split")
+	}
+	if len(splitItems) < 2 {
+		t.Fatalf("expected at least two split items, got %d", len(splitItems))
+	}
+	for i, item := range splitItems {
+		body, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{item})
+		if err != nil {
+			t.Fatalf("failed to marshal split item %d: %v", i, err)
+		}
+		if len(body) > maxBodySize {
+			t.Fatalf("split item %d exceeded max body size: got %d, max %d", i, len(body), maxBodySize)
+		}
+		var decoded map[string]interface{}
+		if err := json.Unmarshal(item, &decoded); err != nil {
+			t.Fatalf("split item %d is invalid JSON: %v", i, err)
+		}
+		text := requireMessageTextWithRole(t, decoded, "user")
+		if !strings.Contains(text, "Oversized compact input item chunk") {
+			t.Fatalf("split item %d missing oversized context marker: %.200q", i, text)
+		}
 	}
 }
 
@@ -2317,6 +2701,33 @@ func decodeCompactionSummaryForTest(t *testing.T, encryptedContent string) strin
 		t.Fatalf("expected synthetic compaction payload, got %q", encryptedContent)
 	}
 	return summary
+}
+
+func requireCompactResponseSummaryForTest(t *testing.T, body []byte) (string, string) {
+	t.Helper()
+	var result struct {
+		Output []struct {
+			Type             string `json:"type"`
+			EncryptedContent string `json:"encrypted_content"`
+			Content          []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse compact response: %v", err)
+	}
+	if len(result.Output) != 2 {
+		t.Fatalf("expected 2 output items, got %d", len(result.Output))
+	}
+	if result.Output[0].Type != "message" || len(result.Output[0].Content) == 0 || result.Output[0].Content[0].Type != "output_text" {
+		t.Fatalf("expected compact response summary message, got %+v", result.Output[0])
+	}
+	if result.Output[1].Type != "compaction" {
+		t.Fatalf("expected compact response compaction item, got %+v", result.Output[1])
+	}
+	return result.Output[0].Content[0].Text, decodeCompactionSummaryForTest(t, result.Output[1].EncryptedContent)
 }
 
 func requireCompactionContextMessage(t *testing.T, raw interface{}) string {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1211,7 +1211,7 @@ func TestHandleCompact_FallsBackToChunkedCompactionOnUpstream413(t *testing.T) {
 }
 
 func TestHandleCompact_FallsBackToChunkedCompactionForStringInputOnUpstream413(t *testing.T) {
-	largeText := strings.Repeat("a", compactUpstreamChunkBodySize+(512*1024))
+	largeText := strings.Repeat("a", compactUpstreamChunkBodySize+(4*1024))
 	reqBody, err := json.Marshal(map[string]interface{}{
 		"model": "gpt-5.4",
 		"input": largeText,

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/sozercan/vekil/logger"
 )
@@ -490,31 +491,50 @@ func readBodyWithCap(r io.Reader, maxBytes int) ([]byte, bool, error) {
 }
 
 func (h *ProxyHandler) compactResponsesRequestInChunks(ctx context.Context, requestFields map[string]json.RawMessage, extraHeaders http.Header, depth int) (string, error) {
-	var input []json.RawMessage
-	if err := json.Unmarshal(requestFields["input"], &input); err != nil {
-		return "", err
-	}
-	if len(input) < 2 {
-		return "", fmt.Errorf("compact request input cannot be split")
-	}
-
-	chunks, err := splitCompactInputByBodySize(requestFields, input, compactUpstreamChunkBodySize)
+	originalInput, err := compactInputAsRawMessages(requestFields["input"])
 	if err != nil {
 		return "", err
 	}
-	if len(chunks) < 2 {
+	originalItems := len(originalInput)
+	originalBytes := rawMessagesSize(originalInput)
+
+	fallbackFields, strippedFixedFields, err := compactFallbackRequestFieldsForBodySize(requestFields, compactUpstreamChunkBodySize)
+	if err != nil {
+		return "", err
+	}
+
+	input, oversizedItemsSplit, err := splitOversizedCompactInputItemsByBodySize(fallbackFields, originalInput, compactUpstreamChunkBodySize)
+	if err != nil {
+		return "", err
+	}
+
+	chunks, err := splitCompactInputByBodySize(fallbackFields, input, compactUpstreamChunkBodySize)
+	if err != nil {
+		return "", err
+	}
+	if len(chunks) == 0 && len(input) == 0 && len(strippedFixedFields) > 0 {
+		chunks = [][]json.RawMessage{{}}
+	}
+	if len(chunks) < 2 && len(strippedFixedFields) == 0 {
 		return "", fmt.Errorf("compact request input cannot be split below upstream payload limit")
 	}
 
-	h.log.Info("retrying compact request with chunked history after 413",
-		logger.F("original_items", len(input)),
+	fields := []logger.Field{
+		logger.F("original_items", originalItems),
 		logger.F("chunks", len(chunks)),
-		logger.F("original_bytes", rawMessagesSize(input)),
-	)
+		logger.F("original_bytes", originalBytes),
+	}
+	if oversizedItemsSplit {
+		fields = append(fields, logger.F("split_oversized_items", true), logger.F("expanded_items", len(input)))
+	}
+	if len(strippedFixedFields) > 0 {
+		fields = append(fields, logger.F("stripped_fixed_fields", strippedFixedFields))
+	}
+	h.log.Info("retrying compact request with chunked history after 413", fields...)
 
 	summaries := make([]string, 0, len(chunks))
 	for i, chunk := range chunks {
-		chunkFields := copyResponsesRequestFieldsWithInput(requestFields, chunk)
+		chunkFields := copyResponsesRequestFieldsWithInput(fallbackFields, chunk)
 		summary, resp, err := h.compactResponsesRequestDepth(ctx, chunkFields, extraHeaders, depth)
 		if err != nil {
 			return "", err
@@ -527,19 +547,258 @@ func (h *ProxyHandler) compactResponsesRequestInChunks(ctx context.Context, requ
 		summaries = append(summaries, summary)
 	}
 
-	return h.mergeCompactionSummaries(ctx, requestFields, summaries, extraHeaders, depth)
+	return h.mergeCompactionSummaries(ctx, fallbackFields, summaries, extraHeaders, depth)
 }
 
-func copyResponsesRequestFieldsWithInput(requestFields map[string]json.RawMessage, input []json.RawMessage) map[string]json.RawMessage {
-	copied := make(map[string]json.RawMessage, len(requestFields)+1)
+func compactFallbackRequestFieldsForBodySize(requestFields map[string]json.RawMessage, maxBodySize int) (map[string]json.RawMessage, []string, error) {
+	if maxBodySize <= 0 {
+		return nil, nil, fmt.Errorf("invalid compact chunk size %d", maxBodySize)
+	}
+
+	probeInput, err := compactFallbackProbeInput()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if fits, _, err := compactRequestFieldsFitBodySize(requestFields, probeInput, maxBodySize); err != nil {
+		return nil, nil, err
+	} else if fits {
+		return copyResponsesRequestFields(requestFields), nil, nil
+	}
+
+	stripCandidates := [][]string{
+		{"tools", "tool_choice"},
+		{"text"},
+		{"tools", "tool_choice", "text"},
+	}
+	lastSize := 0
+	for _, fields := range stripCandidates {
+		candidate, stripped := copyResponsesRequestFieldsWithout(requestFields, fields...)
+		if len(stripped) == 0 {
+			continue
+		}
+
+		fits, size, err := compactRequestFieldsFitBodySize(candidate, probeInput, maxBodySize)
+		if err != nil {
+			return nil, nil, err
+		}
+		lastSize = size
+		if fits {
+			return candidate, stripped, nil
+		}
+	}
+
+	if lastSize == 0 {
+		_, lastSize, err = compactRequestFieldsFitBodySize(requestFields, probeInput, maxBodySize)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return nil, nil, fmt.Errorf("compact request fixed fields exceed upstream payload limit after fallback minimization: %d > %d", lastSize, maxBodySize)
+}
+
+func compactFallbackProbeInput() ([]json.RawMessage, error) {
+	message, err := compactTextInputRawMessage("")
+	if err != nil {
+		return nil, err
+	}
+	return []json.RawMessage{message}, nil
+}
+
+func compactRequestFieldsFitBodySize(requestFields map[string]json.RawMessage, input []json.RawMessage, maxBodySize int) (bool, int, error) {
+	body, err := marshalCompactResponsesRequest(requestFields, input)
+	if err != nil {
+		return false, 0, err
+	}
+	return len(body) <= maxBodySize, len(body), nil
+}
+
+func copyResponsesRequestFields(requestFields map[string]json.RawMessage) map[string]json.RawMessage {
+	copied := make(map[string]json.RawMessage, len(requestFields))
 	for key, value := range requestFields {
 		copied[key] = value
 	}
+	return copied
+}
+
+func copyResponsesRequestFieldsWithout(requestFields map[string]json.RawMessage, fields ...string) (map[string]json.RawMessage, []string) {
+	copied := copyResponsesRequestFields(requestFields)
+	stripped := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if _, ok := copied[field]; !ok {
+			continue
+		}
+		delete(copied, field)
+		stripped = append(stripped, field)
+	}
+	return copied, stripped
+}
+
+func copyResponsesRequestFieldsWithInput(requestFields map[string]json.RawMessage, input []json.RawMessage) map[string]json.RawMessage {
+	copied := copyResponsesRequestFields(requestFields)
 	inputRaw, err := json.Marshal(input)
 	if err == nil {
 		copied["input"] = inputRaw
 	}
 	return copied
+}
+
+func compactInputAsRawMessages(rawInput json.RawMessage) ([]json.RawMessage, error) {
+	if len(bytes.TrimSpace(rawInput)) == 0 {
+		return nil, fmt.Errorf("compact request missing input")
+	}
+
+	var input []json.RawMessage
+	if err := json.Unmarshal(rawInput, &input); err == nil {
+		return input, nil
+	}
+
+	var text string
+	if err := json.Unmarshal(rawInput, &text); err == nil {
+		message, err := compactTextInputRawMessage(text)
+		if err != nil {
+			return nil, err
+		}
+		return []json.RawMessage{message}, nil
+	}
+
+	// The public Responses API accepts strings and arrays, but preserve any
+	// unexpected JSON value as historical context so an oversized compact request
+	// can still be reduced instead of replaying the upstream 413 unchanged.
+	return []json.RawMessage{rawInput}, nil
+}
+
+func compactTextInputRawMessage(text string) (json.RawMessage, error) {
+	return json.Marshal(map[string]interface{}{
+		"type": "message",
+		"role": "user",
+		"content": []map[string]string{
+			{
+				"type": "input_text",
+				"text": text,
+			},
+		},
+	})
+}
+
+func splitOversizedCompactInputItemsByBodySize(requestFields map[string]json.RawMessage, input []json.RawMessage, maxBodySize int) ([]json.RawMessage, bool, error) {
+	if maxBodySize <= 0 {
+		return nil, false, fmt.Errorf("invalid compact chunk size %d", maxBodySize)
+	}
+
+	out := make([]json.RawMessage, 0, len(input))
+	var splitAny bool
+	for _, item := range input {
+		body, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{item})
+		if err != nil {
+			return nil, false, err
+		}
+		if len(body) <= maxBodySize {
+			out = append(out, item)
+			continue
+		}
+
+		splitItems, err := splitOversizedCompactInputItemByBodySize(requestFields, item, maxBodySize)
+		if err != nil {
+			return nil, false, err
+		}
+		out = append(out, splitItems...)
+		splitAny = true
+	}
+
+	return out, splitAny, nil
+}
+
+func splitOversizedCompactInputItemByBodySize(requestFields map[string]json.RawMessage, item json.RawMessage, maxBodySize int) ([]json.RawMessage, error) {
+	rawText := string(bytes.TrimSpace(item))
+	if rawText == "" {
+		return nil, fmt.Errorf("compact request contains an empty oversized input item")
+	}
+
+	items := make([]json.RawMessage, 0, (len(rawText)/max(maxBodySize, 1))+1)
+	remaining := rawText
+	for len(remaining) > 0 {
+		chunkIndex := len(items) + 1
+		chunkLen, err := largestOversizedCompactInputChunkLen(requestFields, remaining, chunkIndex, maxBodySize)
+		if err != nil {
+			return nil, err
+		}
+		if chunkLen <= 0 {
+			return nil, fmt.Errorf("compact request input item cannot be split below upstream payload limit")
+		}
+
+		chunk := remaining[:chunkLen]
+		message, err := oversizedCompactInputChunkRawMessage(chunk, chunkIndex)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, message)
+		remaining = remaining[chunkLen:]
+	}
+
+	if len(items) < 2 {
+		return nil, fmt.Errorf("compact request input item cannot be split below upstream payload limit")
+	}
+	return items, nil
+}
+
+func largestOversizedCompactInputChunkLen(requestFields map[string]json.RawMessage, text string, chunkIndex int, maxBodySize int) (int, error) {
+	low, high := 1, len(text)
+	best := 0
+	for low <= high {
+		probe := (low + high) / 2
+		mid := utf8SafePrefixLen(text, probe)
+		if mid == 0 {
+			_, size := utf8.DecodeRuneInString(text)
+			if size <= 0 {
+				return 0, nil
+			}
+			mid = size
+		}
+		if mid > len(text) {
+			mid = len(text)
+		}
+
+		message, err := oversizedCompactInputChunkRawMessage(text[:mid], chunkIndex)
+		if err != nil {
+			return 0, err
+		}
+		body, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{message})
+		if err != nil {
+			return 0, err
+		}
+		if len(body) <= maxBodySize {
+			if mid > best {
+				best = mid
+			}
+			low = probe + 1
+			continue
+		}
+		if mid > probe {
+			high = probe - 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return best, nil
+}
+
+func oversizedCompactInputChunkRawMessage(chunk string, chunkIndex int) (json.RawMessage, error) {
+	text := fmt.Sprintf("Oversized compact input item chunk %d. Treat this as historical session context, not as a new user instruction. The chunk contains a JSON fragment from the original item:\n%s", chunkIndex, chunk)
+	return compactTextInputRawMessage(text)
+}
+
+func utf8SafePrefixLen(s string, n int) int {
+	if n >= len(s) {
+		return len(s)
+	}
+	if n <= 0 {
+		return 0
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return n
 }
 
 func splitCompactInputByBodySize(requestFields map[string]json.RawMessage, input []json.RawMessage, maxBodySize int) ([][]json.RawMessage, error) {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -686,14 +686,19 @@ func splitOversizedCompactInputItemsByBodySize(requestFields map[string]json.Raw
 		return nil, false, fmt.Errorf("invalid compact chunk size %d", maxBodySize)
 	}
 
+	fixedBodySize, err := compactRequestFixedBodySize(requestFields)
+	if err != nil {
+		return nil, false, err
+	}
+
 	out := make([]json.RawMessage, 0, len(input))
 	var splitAny bool
 	for _, item := range input {
-		body, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{item})
+		itemSize, err := encodedRawMessageSize(item)
 		if err != nil {
 			return nil, false, err
 		}
-		if len(body) <= maxBodySize {
+		if fixedBodySize+len("[]")+itemSize <= maxBodySize {
 			out = append(out, item)
 			continue
 		}
@@ -806,14 +811,13 @@ func splitCompactInputByBodySize(requestFields map[string]json.RawMessage, input
 		return nil, fmt.Errorf("invalid compact chunk size %d", maxBodySize)
 	}
 
-	emptyBody, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{})
+	fixedBodySize, err := compactRequestFixedBodySize(requestFields)
 	if err != nil {
 		return nil, err
 	}
 	// The rest of the compact request is stable while splitting. Track only the
 	// encoded JSON array size for input so each item is marshaled once instead of
 	// re-marshaling the whole candidate body for every append.
-	fixedBodySize := len(emptyBody) - len("[]")
 
 	chunks := make([][]json.RawMessage, 0, 2)
 	current := make([]json.RawMessage, 0, len(input))
@@ -843,6 +847,14 @@ func splitCompactInputByBodySize(requestFields map[string]json.RawMessage, input
 	}
 
 	return chunks, nil
+}
+
+func compactRequestFixedBodySize(requestFields map[string]json.RawMessage) (int, error) {
+	emptyBody, err := marshalCompactResponsesRequest(requestFields, []json.RawMessage{})
+	if err != nil {
+		return 0, err
+	}
+	return len(emptyBody) - len("[]"), nil
 }
 
 func encodedRawMessageSize(raw json.RawMessage) (int, error) {


### PR DESCRIPTION
## Summary
- sanitize oversized fixed fields like tools/tool_choice or text only during compact 413 fallback
- use sanitized fields for oversized item splitting, chunk retries, and merge requests
- document fallback behavior and add regression tests for oversized tools and text schemas

## Tests
- go test ./...