### PR TITLE
Fix Gemini countTokens fallback metrics handling

### DIFF
--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -276,7 +278,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequ
 		return nil, false, mapGeminiTransportError(err)
 	}
 
-	if resp.StatusCode == http.StatusBadRequest && probeReq.MaxCompletionTokens != nil {
+	if shouldFallbackGeminiCountTokensProbe(resp, probeReq) {
 		_ = resp.Body.Close()
 		return nil, true, nil
 	}
@@ -329,6 +331,72 @@ func (h *ProxyHandler) decodeGeminiProbeResponse(resp *http.Response) (*models.O
 	}
 
 	return &oaiResp, false, nil
+}
+
+func shouldFallbackGeminiCountTokensProbe(resp *http.Response, probeReq *models.OpenAIRequest) bool {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest || probeReq == nil || probeReq.MaxCompletionTokens == nil {
+		return false
+	}
+
+	body := readGeminiProbeErrorBody(resp)
+	if len(body) == 0 {
+		return false
+	}
+
+	return isGeminiCountTokensFallbackBadRequest(body)
+}
+
+func readGeminiProbeErrorBody(resp *http.Response) []byte {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err == nil {
+		drainAndClose(resp.Body)
+	} else {
+		_ = resp.Body.Close()
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return body
+}
+
+func isGeminiCountTokensFallbackBadRequest(body []byte) bool {
+	type openAIErrorObject struct {
+		Message string `json:"message"`
+		Param   string `json:"param"`
+		Code    string `json:"code"`
+	}
+	type openAIErrorEnvelope struct {
+		Error json.RawMessage `json:"error"`
+	}
+
+	var envelope openAIErrorEnvelope
+	if err := json.Unmarshal(body, &envelope); err == nil && len(envelope.Error) > 0 {
+		var errorText string
+		if err := json.Unmarshal(envelope.Error, &errorText); err == nil {
+			return isUnsupportedMaxCompletionTokensText(errorText)
+		}
+
+		var errorObject openAIErrorObject
+		if err := json.Unmarshal(envelope.Error, &errorObject); err == nil {
+			if strings.EqualFold(strings.TrimSpace(errorObject.Param), "max_completion_tokens") &&
+				strings.EqualFold(strings.TrimSpace(errorObject.Code), "unsupported_parameter") {
+				return true
+			}
+			return isUnsupportedMaxCompletionTokensText(errorObject.Message)
+		}
+	}
+
+	return isUnsupportedMaxCompletionTokensText(string(body))
+}
+
+func isUnsupportedMaxCompletionTokensText(text string) bool {
+	lower := strings.ToLower(text)
+	if !strings.Contains(lower, "max_completion_tokens") {
+		return false
+	}
+	return strings.Contains(lower, "unsupported") || strings.Contains(lower, "not supported")
 }
 
 func (h *ProxyHandler) writeGeminiProtocolError(w http.ResponseWriter, err error) {

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -2029,7 +2029,7 @@ func TestHandleGeminiModelsCountTokensFallbackAndCache(t *testing.T) {
 				t.Fatalf("MaxTokens = %v, want nil", oaiReq.MaxTokens)
 			}
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error":"max_completion_tokens unsupported"}`))
+			_, _ = w.Write([]byte(`{"error":{"message":"Unsupported parameter: 'max_completion_tokens' is not supported with this model.","param":"max_completion_tokens","code":"unsupported_parameter"}}`))
 		case 2:
 			if oaiReq.MaxCompletionTokens != nil {
 				t.Fatalf("MaxCompletionTokens = %v, want nil", oaiReq.MaxCompletionTokens)
@@ -2083,6 +2083,130 @@ func TestHandleGeminiModelsCountTokensFallbackAndCache(t *testing.T) {
 		if len(countResp.PromptTokensDetails) != 1 || countResp.PromptTokensDetails[0].Modality != "TEXT" {
 			t.Errorf("iteration %d PromptTokensDetails = %#v, want TEXT detail", i, countResp.PromptTokensDetails)
 		}
+	}
+
+	if callCount != 2 {
+		t.Fatalf("upstream callCount = %d, want 2", callCount)
+	}
+}
+
+func TestHandleGeminiModelsCountTokensDoesNotFallbackOnUnexpectedBadRequest(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		if callCount != 1 {
+			t.Fatalf("unexpected upstream call %d", callCount)
+		}
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("MaxCompletionTokens = %v, want 1", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("MaxTokens = %v, want nil", oaiReq.MaxTokens)
+		}
+
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"messages must not be empty"}}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 400: %s", resp.StatusCode, string(body))
+	}
+
+	var errResp models.GeminiErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Error.Status != "INVALID_ARGUMENT" {
+		t.Fatalf("status = %q, want INVALID_ARGUMENT", errResp.Error.Status)
+	}
+
+	if callCount != 1 {
+		t.Fatalf("upstream callCount = %d, want 1", callCount)
+	}
+}
+
+func TestHandleGeminiModelsCountTokensRetries429ThenSuccess(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.Stream == nil || *oaiReq.Stream {
+			t.Fatalf("Stream = %v, want false", oaiReq.Stream)
+		}
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("call %d MaxCompletionTokens = %v, want 1", callCount, oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("call %d MaxTokens = %v, want nil", callCount, oaiReq.MaxTokens)
+		}
+
+		switch callCount {
+		case 1:
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(models.OpenAIResponse{
+				ID:      "chatcmpl-429",
+				Object:  "chat.completion",
+				Created: 123,
+				Model:   "gemini-2.5-pro",
+				Choices: []models.OpenAIChoice{{
+					Index:        0,
+					Message:      models.OpenAIMessage{Role: "assistant", Content: json.RawMessage(`"ok"`)},
+					FinishReason: strPtr("stop"),
+				}},
+				Usage: &models.OpenAIUsage{PromptTokens: 13, CompletionTokens: 1, TotalTokens: 14},
+			})
+		default:
+			t.Fatalf("unexpected upstream call %d", callCount)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(body))
+	}
+
+	var countResp models.GeminiCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode countTokens response: %v", err)
+	}
+	if countResp.TotalTokens != 13 {
+		t.Fatalf("TotalTokens = %d, want 13", countResp.TotalTokens)
 	}
 
 	if callCount != 2 {


### PR DESCRIPTION
## Summary
- narrow Gemini `countTokens` fallback handling to only the expected unsupported `max_completion_tokens` 400
- preserve first-probe retry/error metrics for real 429/5xx/timeout outcomes
- add regression coverage for unexpected 400 passthrough and 429-then-success probe behavior

## Validation
- discovery evidence: `go.mod` declares `go 1.25`; CI uses `actions/setup-go` with `go-version-file: go.mod`
- `go test ./proxy -count=1`

## Review
- security: approved
- quality: approved