### PR TITLE
Implement issue #77 Gemini countTokens fallback metrics handling

### DIFF
--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -383,27 +383,30 @@ func extractGeminiCountTokensFallbackError(body []byte) (message, param, code st
 }
 
 func geminiCountTokensMaxCompletionTokensFallbackMatch(message, param, code string) bool {
-	message = strings.ToLower(message)
-	param = strings.ToLower(param)
-	code = strings.ToLower(code)
+	normalizedMessage := strings.ToLower(strings.TrimSpace(message))
+	normalizedMessage = strings.NewReplacer("'", "", "\"", "", "`", "").Replace(normalizedMessage)
+	normalizedMessage = strings.Join(strings.Fields(normalizedMessage), " ")
+	param = strings.ToLower(strings.TrimSpace(param))
+	code = strings.ToLower(strings.TrimSpace(code))
 
-	mentionsMaxCompletionTokens := param == "max_completion_tokens" || strings.Contains(message, "max_completion_tokens")
-	if !mentionsMaxCompletionTokens {
-		return false
+	if param == "max_completion_tokens" {
+		switch code {
+		case "unsupported_parameter", "unknown_parameter":
+			return true
+		}
 	}
 
-	switch code {
-	case "unsupported_parameter", "unknown_parameter":
-		return true
-	}
-
-	return strings.Contains(message, "unsupported") ||
-		strings.Contains(message, "not supported") ||
-		strings.Contains(message, "unknown parameter") ||
-		strings.Contains(message, "unrecognized request argument") ||
-		strings.Contains(message, "unsupported_parameter") ||
-		strings.Contains(message, "unknown_parameter") ||
-		strings.Contains(message, "max_tokens")
+	return strings.Contains(normalizedMessage, "max_completion_tokens unsupported") ||
+		strings.Contains(normalizedMessage, "max_completion_tokens not supported") ||
+		strings.Contains(normalizedMessage, "max_completion_tokens is not supported") ||
+		strings.Contains(normalizedMessage, "parameter max_completion_tokens is not supported") ||
+		strings.Contains(normalizedMessage, "unsupported parameter: max_completion_tokens") ||
+		strings.Contains(normalizedMessage, "unknown parameter: max_completion_tokens") ||
+		strings.Contains(normalizedMessage, "unrecognized request argument supplied: max_completion_tokens") ||
+		strings.Contains(normalizedMessage, "unsupported_parameter: max_completion_tokens") ||
+		strings.Contains(normalizedMessage, "unsupported_parameter max_completion_tokens") ||
+		strings.Contains(normalizedMessage, "unknown_parameter: max_completion_tokens") ||
+		strings.Contains(normalizedMessage, "unknown_parameter max_completion_tokens")
 }
 
 func (h *ProxyHandler) writeGeminiProtocolError(w http.ResponseWriter, err error) {

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -276,7 +278,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequ
 		return nil, false, mapGeminiTransportError(err)
 	}
 
-	if resp.StatusCode == http.StatusBadRequest && probeReq.MaxCompletionTokens != nil {
+	if shouldFallbackGeminiCountTokensProbe(resp, probeReq) {
 		_ = resp.Body.Close()
 		return nil, true, nil
 	}
@@ -329,6 +331,79 @@ func (h *ProxyHandler) decodeGeminiProbeResponse(resp *http.Response) (*models.O
 	}
 
 	return &oaiResp, false, nil
+}
+
+func shouldFallbackGeminiCountTokensProbe(resp *http.Response, probeReq *models.OpenAIRequest) bool {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest || probeReq == nil || probeReq.MaxCompletionTokens == nil {
+		return false
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return isGeminiCountTokensMaxCompletionTokensFallback(body)
+}
+
+func isGeminiCountTokensMaxCompletionTokensFallback(body []byte) bool {
+	message, param, code := extractGeminiCountTokensFallbackError(body)
+	if geminiCountTokensMaxCompletionTokensFallbackMatch(message, param, code) {
+		return true
+	}
+
+	return geminiCountTokensMaxCompletionTokensFallbackMatch(strings.ToLower(strings.TrimSpace(string(body))), "", "")
+}
+
+func extractGeminiCountTokensFallbackError(body []byte) (message, param, code string) {
+	var envelope struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", "", ""
+	}
+
+	if len(envelope.Error) != 0 {
+		var errorText string
+		if err := json.Unmarshal(envelope.Error, &errorText); err == nil {
+			return errorText, "", ""
+		}
+
+		var details struct {
+			Message string `json:"message"`
+			Param   string `json:"param"`
+			Code    string `json:"code"`
+		}
+		if err := json.Unmarshal(envelope.Error, &details); err == nil {
+			return details.Message, details.Param, details.Code
+		}
+	}
+
+	return envelope.Message, "", ""
+}
+
+func geminiCountTokensMaxCompletionTokensFallbackMatch(message, param, code string) bool {
+	message = strings.ToLower(message)
+	param = strings.ToLower(param)
+	code = strings.ToLower(code)
+
+	mentionsMaxCompletionTokens := param == "max_completion_tokens" || strings.Contains(message, "max_completion_tokens")
+	if !mentionsMaxCompletionTokens {
+		return false
+	}
+
+	switch code {
+	case "unsupported_parameter", "unknown_parameter":
+		return true
+	}
+
+	return strings.Contains(message, "unsupported") ||
+		strings.Contains(message, "not supported") ||
+		strings.Contains(message, "unknown parameter") ||
+		strings.Contains(message, "unrecognized request argument") ||
+		strings.Contains(message, "unsupported_parameter") ||
+		strings.Contains(message, "unknown_parameter") ||
+		strings.Contains(message, "max_tokens")
 }
 
 func (h *ProxyHandler) writeGeminiProtocolError(w http.ResponseWriter, err error) {

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -2212,6 +2212,59 @@ func TestHandleGeminiModelsCountTokensDoesNotFallbackOnUnexpectedBadRequest(t *t
 	}
 }
 
+func TestHandleGeminiModelsCountTokensDoesNotFallbackOnBadRequestMentioningBothTokenFields(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("MaxCompletionTokens = %v, want 1", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("MaxTokens = %v, want nil", oaiReq.MaxTokens)
+		}
+
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"Only one of 'max_completion_tokens' or 'max_tokens' may be set.","param":"max_completion_tokens","code":"invalid_request_error"}}`))
+	})
+
+	reqBody := `{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 400: %s", resp.StatusCode, string(body))
+	}
+
+	var errResp models.GeminiErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Error.Status != "INVALID_ARGUMENT" {
+		t.Fatalf("status = %q, want INVALID_ARGUMENT", errResp.Error.Status)
+	}
+	if !strings.Contains(errResp.Error.Message, "upstream error (400)") {
+		t.Fatalf("message = %q, want upstream 400 detail", errResp.Error.Message)
+	}
+
+	if callCount != 1 {
+		t.Fatalf("upstream callCount = %d, want 1", callCount)
+	}
+}
+
 func TestIsGeminiCountTokensMaxCompletionTokensFallback(t *testing.T) {
 	tests := []struct {
 		name string
@@ -2231,6 +2284,11 @@ func TestIsGeminiCountTokensMaxCompletionTokensFallback(t *testing.T) {
 		{
 			name: "unrelated bad request",
 			body: `{"error":{"message":"messages[0] is invalid","param":"messages","code":"invalid_request_error"}}`,
+			want: false,
+		},
+		{
+			name: "bad request mentioning both token fields",
+			body: `{"error":{"message":"Only one of 'max_completion_tokens' or 'max_tokens' may be set.","param":"max_completion_tokens","code":"invalid_request_error"}}`,
 			want: false,
 		},
 	}

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -2090,6 +2090,160 @@ func TestHandleGeminiModelsCountTokensFallbackAndCache(t *testing.T) {
 	}
 }
 
+func TestHandleGeminiModelsCountTokensRetriesBeforeSuccess(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("MaxCompletionTokens = %v, want 1", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("MaxTokens = %v, want nil", oaiReq.MaxTokens)
+		}
+
+		switch callCount {
+		case 1:
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"retry later"}}`))
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(models.OpenAIResponse{
+				ID:      "chatcmpl-retry",
+				Object:  "chat.completion",
+				Created: 123,
+				Model:   "gemini-2.5-pro",
+				Choices: []models.OpenAIChoice{{
+					Index:        0,
+					Message:      models.OpenAIMessage{Role: "assistant", Content: json.RawMessage(`"ok"`)},
+					FinishReason: strPtr("stop"),
+				}},
+				Usage: &models.OpenAIUsage{PromptTokens: 13, CompletionTokens: 1, TotalTokens: 14},
+			})
+		default:
+			t.Fatalf("unexpected upstream call %d", callCount)
+		}
+	})
+
+	reqBody := `{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(body))
+	}
+
+	var countResp models.GeminiCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode countTokens response: %v", err)
+	}
+	if countResp.TotalTokens != 13 {
+		t.Fatalf("TotalTokens = %d, want 13", countResp.TotalTokens)
+	}
+
+	if callCount != 2 {
+		t.Fatalf("upstream callCount = %d, want 2", callCount)
+	}
+}
+
+func TestHandleGeminiModelsCountTokensDoesNotFallbackOnUnexpectedBadRequest(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("MaxCompletionTokens = %v, want 1", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("MaxTokens = %v, want nil", oaiReq.MaxTokens)
+		}
+
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"messages[0] is invalid","param":"messages","code":"invalid_request_error"}}`))
+	})
+
+	reqBody := `{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 400: %s", resp.StatusCode, string(body))
+	}
+
+	var errResp models.GeminiErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Error.Status != "INVALID_ARGUMENT" {
+		t.Fatalf("status = %q, want INVALID_ARGUMENT", errResp.Error.Status)
+	}
+	if !strings.Contains(errResp.Error.Message, "upstream error (400)") {
+		t.Fatalf("message = %q, want upstream 400 detail", errResp.Error.Message)
+	}
+
+	if callCount != 1 {
+		t.Fatalf("upstream callCount = %d, want 1", callCount)
+	}
+}
+
+func TestIsGeminiCountTokensMaxCompletionTokensFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "legacy string error",
+			body: `{"error":"max_completion_tokens unsupported"}`,
+			want: true,
+		},
+		{
+			name: "structured unsupported parameter error",
+			body: `{"error":{"message":"Unsupported parameter: 'max_completion_tokens' is not supported with this model. Use 'max_tokens' instead.","param":"max_completion_tokens","code":"unsupported_parameter"}}`,
+			want: true,
+		},
+		{
+			name: "unrelated bad request",
+			body: `{"error":{"message":"messages[0] is invalid","param":"messages","code":"invalid_request_error"}}`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGeminiCountTokensMaxCompletionTokensFallback([]byte(tt.body)); got != tt.want {
+				t.Fatalf("isGeminiCountTokensMaxCompletionTokensFallback() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandleGeminiModelsCountTokensWithInlineImageOmitsPromptDetails(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		var oaiReq models.OpenAIRequest


### PR DESCRIPTION
## Summary
- narrow Gemini countTokens fallback handling to only the expected unsupported/unknown `max_completion_tokens` 400 responses
- preserve normal retry/error metrics behavior for real first-probe 429/5xx/timeout outcomes
- add regression coverage for 429-then-success and non-fallback 400 cases

## Validation
- `go test ./proxy -count=1`