### PR TITLE
Fix Gemini countTokens fallback metrics handling

### DIFF
--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -276,12 +278,64 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequ
 		return nil, false, mapGeminiTransportError(err)
 	}
 
-	if resp.StatusCode == http.StatusBadRequest && probeReq.MaxCompletionTokens != nil {
+	fallback, err := shouldFallbackGeminiCountTokensProbe(resp, probeReq)
+	if err != nil {
+		return nil, false, &geminiProtocolError{
+			statusCode: http.StatusInternalServerError,
+			status:     "INTERNAL",
+			message:    "failed to inspect upstream countTokens probe error",
+		}
+	}
+	if fallback {
 		_ = resp.Body.Close()
 		return nil, true, nil
 	}
 
 	return h.decodeGeminiProbeResponse(resp)
+}
+
+func shouldFallbackGeminiCountTokensProbe(resp *http.Response, probeReq *models.OpenAIRequest) (bool, error) {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest || probeReq == nil || probeReq.MaxCompletionTokens == nil {
+		return false, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return false, err
+	}
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return isGeminiCountTokensMaxCompletionTokensFallback(body), nil
+}
+
+func isGeminiCountTokensMaxCompletionTokensFallback(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+
+	text := strings.ToLower(string(body))
+	if !strings.Contains(text, "max_completion_tokens") {
+		return false
+	}
+
+	for _, hint := range []string{
+		"unsupported",
+		"not supported",
+		"unknown parameter",
+		"unknown field",
+		"unexpected field",
+		"unrecognized",
+		"extra inputs are not permitted",
+		"additional properties are not allowed",
+		"use max_tokens",
+	} {
+		if strings.Contains(text, hint) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -2090,6 +2090,128 @@ func TestHandleGeminiModelsCountTokensFallbackAndCache(t *testing.T) {
 	}
 }
 
+func TestHandleGeminiModelsCountTokensDoesNotFallbackOnUnexpectedBadRequest(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if callCount != 1 {
+			t.Fatalf("unexpected upstream call %d", callCount)
+		}
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("MaxCompletionTokens = %v, want 1", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("MaxTokens = %v, want nil", oaiReq.MaxTokens)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad upstream request"}}`))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 400: %s", resp.StatusCode, string(body))
+	}
+
+	var errResp models.GeminiErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Error.Status != "INVALID_ARGUMENT" {
+		t.Errorf("status = %q, want INVALID_ARGUMENT", errResp.Error.Status)
+	}
+	if !strings.Contains(errResp.Error.Message, "upstream error (400)") {
+		t.Errorf("message = %q, want upstream 400 detail", errResp.Error.Message)
+	}
+	if callCount != 1 {
+		t.Fatalf("upstream callCount = %d, want 1", callCount)
+	}
+}
+
+func TestHandleGeminiModelsCountTokensRetriesFirstProbeOn429(t *testing.T) {
+	callCount := 0
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("call %d MaxCompletionTokens = %v, want 1", callCount, oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("call %d MaxTokens = %v, want nil", callCount, oaiReq.MaxTokens)
+		}
+
+		switch callCount {
+		case 1:
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"retry later"}}`))
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(models.OpenAIResponse{
+				ID:      "chatcmpl-retry",
+				Object:  "chat.completion",
+				Created: 123,
+				Model:   "gemini-2.5-pro",
+				Choices: []models.OpenAIChoice{{
+					Index:        0,
+					Message:      models.OpenAIMessage{Role: "assistant", Content: json.RawMessage(`"ok"`)},
+					FinishReason: strPtr("stop"),
+				}},
+				Usage: &models.OpenAIUsage{PromptTokens: 13, CompletionTokens: 1, TotalTokens: 14},
+			})
+		default:
+			t.Fatalf("unexpected upstream call %d", callCount)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{
+		"contents": [{"role":"user","parts":[{"text":"Count this"}]}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(body))
+	}
+
+	var countResp models.GeminiCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode countTokens response: %v", err)
+	}
+	if countResp.TotalTokens != 13 {
+		t.Errorf("TotalTokens = %d, want 13", countResp.TotalTokens)
+	}
+	if callCount != 2 {
+		t.Fatalf("upstream callCount = %d, want 2", callCount)
+	}
+}
+
 func TestHandleGeminiModelsCountTokensWithInlineImageOmitsPromptDetails(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		var oaiReq models.OpenAIRequest


### PR DESCRIPTION
## Summary
- narrow Gemini countTokens fallback to the expected `max_completion_tokens` 400 case
- preserve first-probe retry/upstream error metrics for real 429/5xx/timeout outcomes
- add regression coverage for unexpected 400 handling and 429-then-success countTokens flow

## Validation
- repository evidence: `go.mod` declares Go 1.25 and CI uses `actions/setup-go` with `go-version-file: go.mod`
- validated with `golang:1.25`
- command: `export PATH=/usr/local/go/bin:$PATH; export GOCACHE=/tmp/go-cache; export GOMODCACHE=/tmp/go-mod-cache; export CGO_ENABLED=0; go test ./proxy -run 'TestHandleGeminiModelsCountTokens' -count=1 && go test ./...`

## Review
- security review: approved
- quality review: approved