### PR TITLE
Add live compact smoke workflow check

### DIFF
--- a/.github/workflows/live-copilot-smoke.yaml
+++ b/.github/workflows/live-copilot-smoke.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
     steps:
@@ -65,6 +65,12 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: make build
 
+      - name: Run live compaction smoke check
+        if: steps.gate.outputs.run == 'true'
+        env:
+          LIVE_COMPACT_SMOKE_DIR: ${{ runner.temp }}/live-compact-smoke
+        run: scripts/live-compact-smoke.sh
+
       - name: Install Codex CLI
         if: steps.gate.outputs.run == 'true'
         run: npm install -g @openai/codex@latest
@@ -92,7 +98,7 @@ jobs:
           LIVE_CLI_SMOKE_DIR: ${{ runner.temp }}/live-cli-smoke
         run: scripts/live-cli-smoke.sh
 
-      - name: Show proxy log on failure
+      - name: Show proxy logs on failure
         if: failure() && steps.gate.outputs.run == 'true'
         run: |
           redact() {
@@ -102,13 +108,17 @@ jobs:
               -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
               -e 's/("access_token":"[^"]*")/"access_token":"[REDACTED]"/g' \
               -e 's/("token":"[^"]*")/"token":"[REDACTED]"/g' \
+              -e 's/("encrypted_content"[[:space:]]*:[[:space:]]*")[^"]*(")/\1[REDACTED]\2/g' \
               -e 's/(Please visit https:\/\/github\.com\/login\/device and enter code: )[A-Z0-9-]+/\1[REDACTED]/g'
           }
-          if [ -f "$RUNNER_TEMP/live-cli-smoke/proxy.log" ]; then
-            redact < "$RUNNER_TEMP/live-cli-smoke/proxy.log"
-          fi
+          for log in "$RUNNER_TEMP/live-compact-smoke/proxy.log" "$RUNNER_TEMP/live-cli-smoke/proxy.log"; do
+            if [ -f "$log" ]; then
+              echo "--- $log ---"
+              redact < "$log"
+            fi
+          done
 
-      - name: Show CLI outputs on failure
+      - name: Show smoke outputs on failure
         if: failure() && steps.gate.outputs.run == 'true'
         run: |
           redact() {
@@ -118,11 +128,19 @@ jobs:
               -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
               -e 's/("access_token":"[^"]*")/"access_token":"[REDACTED]"/g' \
               -e 's/("token":"[^"]*")/"token":"[REDACTED]"/g' \
+              -e 's/("encrypted_content"[[:space:]]*:[[:space:]]*")[^"]*(")/\1[REDACTED]\2/g' \
               -e 's/(Please visit https:\/\/github\.com\/login\/device and enter code: )[A-Z0-9-]+/\1[REDACTED]/g'
           }
+          if [ -d "$RUNNER_TEMP/live-compact-smoke" ]; then
+            find "$RUNNER_TEMP/live-compact-smoke" -maxdepth 1 -type f \
+              \( -name '*.json' -o -name '*.txt' \) -print0 | while IFS= read -r -d '' file; do
+              echo "--- $file ---"
+              redact < "$file"
+            done
+          fi
           if [ -d "$RUNNER_TEMP/live-cli-smoke/outputs" ]; then
             find "$RUNNER_TEMP/live-cli-smoke/outputs" -maxdepth 1 -type f -print0 | while IFS= read -r -d '' file; do
-              echo "$file"
+              echo "--- $file ---"
               redact < "$file"
             done
           fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,9 +60,11 @@ To publish Sparkle updates, configure both `SPARKLE_PUBLIC_ED_KEY` and `SPARKLE_
 
 The repository also includes a manual `Live Copilot Smoke` workflow in [`.github/workflows/live-copilot-smoke.yaml`](../.github/workflows/live-copilot-smoke.yaml).
 
-It builds the proxy, installs Codex, Claude Code, and Gemini CLI on a GitHub-hosted runner, and then runs [`scripts/live-cli-smoke.sh`](../scripts/live-cli-smoke.sh).
+It builds the proxy, runs [`scripts/live-compact-smoke.sh`](../scripts/live-compact-smoke.sh), installs Codex, Claude Code, and Gemini CLI on a GitHub-hosted runner, and then runs [`scripts/live-cli-smoke.sh`](../scripts/live-cli-smoke.sh).
 
-The smoke script starts the proxy with a non-interactive GitHub token, waits for `/readyz`, selects currently available OpenAI, Anthropic, and Gemini models from `/v1/models`, and runs one file-reading headless check per CLI using isolated temp-home config directories.
+The compaction smoke script starts the proxy with a non-interactive GitHub token, waits for `/readyz`, selects a currently available OpenAI/Codex model from `/v1/models`, posts to `/v1/responses/compact`, verifies that the response contains both a summary message and a non-empty compaction item, and replays that compaction item through `/v1/responses`.
+
+The CLI smoke script starts the proxy with the same token pattern, waits for `/readyz`, selects currently available OpenAI, Anthropic, and Gemini models from `/v1/models`, and runs one file-reading headless check per CLI using isolated temp-home config directories.
 
 This workflow is intentionally provider-specific: it exercises a live Copilot-backed deployment because zero-config startup is the simplest upstream path to run in GitHub Actions. It is useful as a real integration smoke test, but it is not the complete provider matrix for Azure OpenAI or OpenAI Codex configs.
 
@@ -75,4 +77,4 @@ To use it:
 
 This workflow is intentionally separate from the normal CI workflow so pull requests and forked builds remain deterministic and do not depend on live provider credentials.
 
-You can also run the same smoke script locally after building `vekil` and installing those three CLIs.
+You can also run the same smoke scripts locally after building `vekil`; the CLI smoke script additionally requires those three CLIs to be installed.

--- a/scripts/live-compact-smoke.sh
+++ b/scripts/live-compact-smoke.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ORIGINAL_HOME="${HOME}"
+
+PROXY_BIN="${PROXY_BIN:-${REPO_ROOT}/vekil}"
+PROXY_HOST="${PROXY_HOST:-127.0.0.1}"
+PROXY_PORT="${PROXY_PORT:-1337}"
+PROXY_BASE_URL="http://${PROXY_HOST}:${PROXY_PORT}"
+START_PROXY="${START_PROXY:-1}"
+TMP_PARENT="${LIVE_COMPACT_SMOKE_TMP_PARENT:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}}"
+SMOKE_DIR="${LIVE_COMPACT_SMOKE_DIR:-$(mktemp -d "${TMP_PARENT%/}/live-compact-smoke.XXXXXX")}"
+PROXY_LOG="${SMOKE_DIR}/proxy.log"
+MODELS_JSON="${SMOKE_DIR}/models.json"
+COMPACT_REQUEST_JSON="${SMOKE_DIR}/compact-request.json"
+COMPACT_RESPONSE_JSON="${SMOKE_DIR}/compact-response.json"
+COMPACTION_ITEM_JSON="${SMOKE_DIR}/compaction-item.json"
+REPLAY_REQUEST_JSON="${SMOKE_DIR}/replay-request.json"
+REPLAY_RESPONSE_JSON="${SMOKE_DIR}/replay-response.json"
+REPLAY_MARKER="VEKIL_COMPACTION_REPLAY_OK"
+
+if [[ -n "${COPILOT_GITHUB_TOKEN:-}" ]]; then
+  PROXY_TOKEN_DIR="${PROXY_TOKEN_DIR:-${SMOKE_DIR}/proxy-token}"
+else
+  PROXY_TOKEN_DIR="${PROXY_TOKEN_DIR:-${ORIGINAL_HOME}/.config/vekil}"
+fi
+
+proxy_pid=""
+
+cleanup() {
+  if [[ -n "${proxy_pid}" ]] && kill -0 "${proxy_pid}" 2>/dev/null; then
+    kill "${proxy_pid}" 2>/dev/null || true
+    wait "${proxy_pid}" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT
+
+seed_access_token() {
+  if [[ -z "${COPILOT_GITHUB_TOKEN:-}" ]]; then
+    return 0
+  fi
+
+  printf '%s\n' "${COPILOT_GITHUB_TOKEN}" > "${PROXY_TOKEN_DIR}/access-token"
+  chmod 600 "${PROXY_TOKEN_DIR}/access-token"
+}
+
+model_exists() {
+  jq -e --arg model "$1" '.data[]? | select(.id == $model)' "${MODELS_JSON}" >/dev/null
+}
+
+pick_model() {
+  local family="$1"
+  shift
+
+  local candidate
+  for candidate in "$@"; do
+    if model_exists "${candidate}"; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  log "Available models from ${PROXY_BASE_URL}/v1/models:"
+  jq -r '.data[].id' "${MODELS_JSON}" >&2
+  die "unable to find a ${family} model from preferred list: $*"
+}
+
+start_proxy() {
+  [[ -x "${PROXY_BIN}" ]] || die "proxy binary not found or not executable: ${PROXY_BIN}"
+
+  mkdir -p "${SMOKE_DIR}" "${PROXY_TOKEN_DIR}"
+  seed_access_token
+
+  log "Starting proxy at ${PROXY_BASE_URL}"
+  "${PROXY_BIN}" \
+    --host "${PROXY_HOST}" \
+    --port "${PROXY_PORT}" \
+    --token-dir "${PROXY_TOKEN_DIR}" \
+    --log-level debug \
+    >"${PROXY_LOG}" 2>&1 &
+  proxy_pid="$!"
+}
+
+wait_for_ready() {
+  local attempt
+  for attempt in $(seq 1 60); do
+    if curl -fsS "${PROXY_BASE_URL}/readyz" > "${SMOKE_DIR}/readyz.json"; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  if [[ -f "${PROXY_LOG}" ]]; then
+    log "Proxy log from failed readiness check:"
+    cat "${PROXY_LOG}" >&2
+  fi
+
+  die "proxy never became ready at ${PROXY_BASE_URL}"
+}
+
+fetch_models() {
+  curl -fsS "${PROXY_BASE_URL}/v1/models" > "${MODELS_JSON}"
+  jq -e '.data | length > 0' "${MODELS_JSON}" >/dev/null || die "no models returned by ${PROXY_BASE_URL}/v1/models"
+}
+
+write_compact_request() {
+  local model="$1"
+
+  jq -n \
+    --arg model "${model}" \
+    '{
+      model: $model,
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "We are testing live /v1/responses/compact through the local proxy. The task is in progress: create a compact checkpoint, then replay the returned compaction item through /v1/responses. Remember the verification marker VEKIL_COMPACTION_LIVE_SMOKE."
+            }
+          ]
+        },
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "Acknowledged. The live compact smoke test should produce a concise checkpoint summary and an opaque compaction token."
+            }
+          ]
+        }
+      ]
+    }' > "${COMPACT_REQUEST_JSON}"
+}
+
+post_json() {
+  local endpoint="$1"
+  local request_file="$2"
+  local response_file="$3"
+  local status
+
+  status="$(curl -sS \
+    -o "${response_file}" \
+    -w '%{http_code}' \
+    -X POST "${PROXY_BASE_URL}${endpoint}" \
+    -H 'Content-Type: application/json' \
+    --data-binary "@${request_file}")"
+
+  if [[ "${status}" != "200" ]]; then
+    if [[ -s "${response_file}" ]]; then
+      log "${endpoint} response body:"
+      cat "${response_file}" >&2
+    fi
+    die "${endpoint} returned HTTP ${status}"
+  fi
+}
+
+assert_compact_response() {
+  jq -e '
+    ([.output[]? | select(.type == "message") | .content[]? | select((.type == "output_text" or .type == "text") and ((.text // "") | length > 0))] | length > 0)
+    and
+    ([.output[]? | select(.type == "compaction" and ((.encrypted_content // "") | length > 0))] | length > 0)
+  ' "${COMPACT_RESPONSE_JSON}" >/dev/null || die "compact response did not contain a summary message and non-empty compaction item"
+
+  jq -e '[.output[] | select(.type == "compaction" and ((.encrypted_content // "") | length > 0))] | .[0]' \
+    "${COMPACT_RESPONSE_JSON}" > "${COMPACTION_ITEM_JSON}" || die "failed to extract compaction item"
+}
+
+write_replay_request() {
+  local model="$1"
+
+  jq -n \
+    --arg model "${model}" \
+    --arg marker "${REPLAY_MARKER}" \
+    --slurpfile compaction "${COMPACTION_ITEM_JSON}" \
+    '{
+      model: $model,
+      input: [
+        $compaction[0],
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: ("Reply with exactly " + $marker + " and no other text.")
+            }
+          ]
+        }
+      ]
+    }' > "${REPLAY_REQUEST_JSON}"
+}
+
+responses_output_text() {
+  jq -r '[.output[]? | select(.type == "message") | .content[]? | select(.type == "output_text" or .type == "text") | .text] | join("\n")' "$1"
+}
+
+assert_replay_response() {
+  local replay_text
+  replay_text="$(responses_output_text "${REPLAY_RESPONSE_JSON}")"
+
+  if [[ "${replay_text}" != *"${REPLAY_MARKER}"* ]]; then
+    printf 'expected replay response to contain %s\n' "${REPLAY_MARKER}" >&2
+    printf 'actual replay response:\n%s\n' "${replay_text}" >&2
+    die "compaction replay output mismatch"
+  fi
+
+  if [[ "${START_PROXY}" == "1" ]] && [[ -f "${PROXY_LOG}" ]]; then
+    grep -q 'rewrote compaction items' "${PROXY_LOG}" || die "proxy log did not show compaction item replay rewrite"
+  fi
+}
+
+main() {
+  require_cmd curl
+  require_cmd jq
+
+  mkdir -p "${SMOKE_DIR}"
+
+  if [[ "${START_PROXY}" == "1" ]]; then
+    start_proxy
+    wait_for_ready
+  else
+    log "Using existing proxy at ${PROXY_BASE_URL}"
+  fi
+
+  fetch_models
+
+  COMPACT_MODEL="$(pick_model "Codex/OpenAI" gpt-5.4 gpt-5.3-codex gpt-5.2-codex gpt-5.1-codex gpt-5.1 gpt-5-mini gpt-4.1 gpt-4o)"
+  log "Selected compact model: ${COMPACT_MODEL}"
+
+  log "Posting live compact request"
+  write_compact_request "${COMPACT_MODEL}"
+  post_json "/v1/responses/compact" "${COMPACT_REQUEST_JSON}" "${COMPACT_RESPONSE_JSON}"
+  assert_compact_response
+
+  log "Replaying returned compaction item through /v1/responses"
+  write_replay_request "${COMPACT_MODEL}"
+  post_json "/v1/responses" "${REPLAY_REQUEST_JSON}" "${REPLAY_RESPONSE_JSON}"
+  assert_replay_response
+
+  log "Live compaction smoke check passed."
+  log "Artifacts: ${SMOKE_DIR}"
+}
+
+main "$@"

--- a/scripts/live-compact-smoke.sh
+++ b/scripts/live-compact-smoke.sh
@@ -134,7 +134,7 @@ write_compact_request() {
           content: [
             {
               type: "input_text",
-              text: "We are testing live /v1/responses/compact through the local proxy. The task is in progress: create a compact checkpoint, then replay the returned compaction item through /v1/responses. Remember the verification marker VEKIL_COMPACTION_LIVE_SMOKE."
+              text: "We are testing live /v1/responses/compact through the local proxy. The task is in progress: create a compact checkpoint, then replay the returned compaction item through /v1/responses."
             }
           ]
         },
@@ -211,16 +211,21 @@ write_replay_request() {
 }
 
 responses_output_text() {
-  jq -r '[.output[]? | select(.type == "message") | .content[]? | select(.type == "output_text" or .type == "text") | .text] | join("\n")' "$1"
+  jq -r '
+    ([.output[]? | select(.type == "message") | .content[]? | select(.type == "output_text" or .type == "text") | .text] | join("\n"))
+    | gsub("\r"; "")
+    | sub("^[[:space:]]+"; "")
+    | sub("[[:space:]]+$"; "")
+  ' "$1"
 }
 
 assert_replay_response() {
   local replay_text
   replay_text="$(responses_output_text "${REPLAY_RESPONSE_JSON}")"
 
-  if [[ "${replay_text}" != *"${REPLAY_MARKER}"* ]]; then
-    printf 'expected replay response to contain %s\n' "${REPLAY_MARKER}" >&2
-    printf 'actual replay response:\n%s\n' "${replay_text}" >&2
+  if [[ "${replay_text}" != "${REPLAY_MARKER}" ]]; then
+    printf 'expected replay response to equal %s after trimming whitespace\n' "${REPLAY_MARKER}" >&2
+    printf 'actual normalized replay response:\n%s\n' "${replay_text}" >&2
     die "compaction replay output mismatch"
   fi
 


### PR DESCRIPTION
## Summary
- add a live `/v1/responses/compact` smoke script that validates summary output, captures the returned compaction item, and replays it through `/v1/responses`
- run the compaction smoke check in the Live Copilot Smoke workflow before CLI smoke checks
- document the new live compaction smoke coverage and redact compaction payloads from failure logs

## Tests
- `make test`
- `bash -n scripts/live-compact-smoke.sh`
- `git diff --check`
