### PR TITLE
fix: scope Copilot headers by endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,9 @@ These overrides only affect Copilot-backed upstream requests.
 | `--copilot-editor-version` | `COPILOT_EDITOR_VERSION` | `vscode/1.95.0` | Upstream `editor-version` header |
 | `--copilot-plugin-version` | `COPILOT_PLUGIN_VERSION` | `copilot-chat/0.26.7` | Upstream `editor-plugin-version` header |
 | `--copilot-user-agent` | `COPILOT_USER_AGENT` | `GitHubCopilotChat/0.26.7` | Upstream `user-agent` header |
-| `--copilot-github-api-version` | `COPILOT_GITHUB_API_VERSION` | `2025-04-01` | Upstream `x-github-api-version` header |
+| `--copilot-integration-id` | `COPILOT_INTEGRATION_ID` | `vscode-chat` | Upstream `copilot-integration-id` header |
+| `--copilot-github-api-version` | `COPILOT_GITHUB_API_VERSION` | `2025-05-01` | Upstream `x-github-api-version` header |
+| `--copilot-openai-intent` | `COPILOT_OPENAI_INTENT` | unset (`conversation-panel` for chat/responses) | Upstream `openai-intent` header |
 
 ## Provider Authentication
 
@@ -156,6 +158,32 @@ providers:
     include_models:
       - gpt-5.5
 ```
+
+### Copilot Provider Header Profiles
+
+`type: copilot` providers can define a `headers` block with a provider-wide `default` profile and endpoint-specific `chat_completions` and `responses` profiles. Endpoint-specific values override `headers.default`, which overrides the global Copilot header flags/environment variables, which then fall back to the built-in defaults. Omitted fields inherit from the lower-precedence profile. The built-in `openai-intent: conversation-panel` fallback is endpoint-aware: it is applied to upstream `/chat/completions` and `/responses` calls, while upstream `/models` calls send `openai-intent` only when you configure it explicitly through `--copilot-openai-intent`, `COPILOT_OPENAI_INTENT`, or a provider header profile.
+
+```yaml
+providers:
+  - id: copilot
+    type: copilot
+    default: true
+    headers:
+      default:
+        editor_version: vscode/1.95.0
+        editor_plugin_version: copilot-chat/0.26.7
+        user_agent: GitHubCopilotChat/0.26.7
+        copilot_integration_id: vscode-chat
+        github_api_version: "2025-05-01"
+      chat_completions:
+        openai_intent: conversation-panel
+      responses:
+        openai_intent: agent-mode
+```
+
+Supported header fields are `editor_version`, `editor_plugin_version`, `user_agent`, `copilot_integration_id`, `github_api_version`, and `openai_intent`. The `chat_completions` profile applies only to upstream `/chat/completions` calls, and the `responses` profile applies only to upstream `/responses` calls. Other Copilot upstream requests, including `/models` and readiness probes, use `headers.default` plus global/default fallback values for non-intent headers. `/models` omits `openai-intent` unless it is explicitly configured globally or in `headers.default`; put `openai_intent` in endpoint-specific profiles if you only want it on chat/response requests.
+
+Copilot header profiles only apply to `type: copilot` providers. Non-Copilot providers do not receive configured Copilot headers, and the proxy strips Copilot-identifying client headers such as `authorization`, `editor-version`, `editor-plugin-version`, `user-agent`, `copilot-integration-id`, `x-github-api-version`, `x-request-id`, and `openai-intent` before applying provider-specific authentication.
 
 Routing rules:
 

--- a/main.go
+++ b/main.go
@@ -210,34 +210,85 @@ func runLogout(args []string) {
 	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 }
 
+type serveFlags struct {
+	port                          *string
+	host                          *string
+	tokenDir                      *string
+	providersConfigPath           *string
+	logLevel                      *string
+	streamingUpstreamTimeout      *time.Duration
+	copilotEditorVersion          *string
+	copilotPluginVersion          *string
+	copilotUserAgent              *string
+	copilotIntegrationID          *string
+	copilotGitHubAPIVersion       *string
+	copilotOpenAIIntent           *string
+	responsesWSTurnStateDelta     *bool
+	responsesWSDisableAutoCompact *bool
+	responsesWSCompactMaxItems    *int
+	responsesWSCompactMaxBytes    *int
+	responsesWSCompactKeepTail    *int
+	compactUpstreamChunkBytes     *int
+	compactUpstreamMaxAttempts    *int
+}
+
+func registerServeFlags(fs *flag.FlagSet) serveFlags {
+	return serveFlags{
+		port:                          fs.String("port", getEnv("PORT", "1337"), "Listen port"),
+		host:                          fs.String("host", getEnv("HOST", "0.0.0.0"), "Listen host"),
+		tokenDir:                      fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
+		providersConfigPath:           fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
+		logLevel:                      fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		streamingUpstreamTimeout:      fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
+		copilotEditorVersion:          fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
+		copilotPluginVersion:          fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
+		copilotUserAgent:              fs.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header"),
+		copilotIntegrationID:          fs.String("copilot-integration-id", getEnv("COPILOT_INTEGRATION_ID", ""), "Upstream Copilot copilot-integration-id header"),
+		copilotGitHubAPIVersion:       fs.String("copilot-github-api-version", getEnv("COPILOT_GITHUB_API_VERSION", ""), "Upstream Copilot x-github-api-version header"),
+		copilotOpenAIIntent:           fs.String("copilot-openai-intent", getEnv("COPILOT_OPENAI_INTENT", ""), "Upstream Copilot openai-intent header"),
+		responsesWSTurnStateDelta:     fs.Bool("responses-ws-turn-state-delta", getEnvBool("RESPONSES_WS_TURN_STATE_DELTA", false), "Attempt delta-only replay when upstream returns X-Codex-Turn-State"),
+		responsesWSDisableAutoCompact: fs.Bool("responses-ws-disable-auto-compact", getEnvBool("RESPONSES_WS_DISABLE_AUTO_COMPACT", false), "Disable automatic websocket-session history compaction"),
+		responsesWSCompactMaxItems:    fs.Int("responses-ws-auto-compact-max-items", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_ITEMS", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxItems), "Auto-compact websocket session history after this many items"),
+		responsesWSCompactMaxBytes:    fs.Int("responses-ws-auto-compact-max-bytes", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_BYTES", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxBytes), "Auto-compact websocket session history after this many raw bytes"),
+		responsesWSCompactKeepTail:    fs.Int("responses-ws-auto-compact-keep-tail", getEnvInt("RESPONSES_WS_AUTO_COMPACT_KEEP_TAIL", proxy.DefaultResponsesWebSocketConfig().AutoCompactKeepTail), "When auto-compacting websocket history, keep this many most recent items verbatim"),
+		compactUpstreamChunkBytes:     fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
+		compactUpstreamMaxAttempts:    fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+	}
+}
+
+func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
+	return proxy.CopilotHeaderConfig{
+		EditorVersion:       *f.copilotEditorVersion,
+		EditorPluginVersion: *f.copilotPluginVersion,
+		UserAgent:           *f.copilotUserAgent,
+		IntegrationID:       *f.copilotIntegrationID,
+		GitHubAPIVersion:    *f.copilotGitHubAPIVersion,
+		OpenAIIntent:        *f.copilotOpenAIIntent,
+	}
+}
+
+func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
+	return proxy.ResponsesWebSocketConfig{
+		TurnStateDelta:      *f.responsesWSTurnStateDelta,
+		DisableAutoCompact:  *f.responsesWSDisableAutoCompact,
+		AutoCompactMaxItems: *f.responsesWSCompactMaxItems,
+		AutoCompactMaxBytes: *f.responsesWSCompactMaxBytes,
+		AutoCompactKeepTail: *f.responsesWSCompactKeepTail,
+	}
+}
+
 func runServe() {
-	port := flag.String("port", getEnv("PORT", "1337"), "Listen port")
-	host := flag.String("host", getEnv("HOST", "0.0.0.0"), "Listen host")
-	tokenDir := flag.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	providersConfigPath := flag.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration")
-	logLevel := flag.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level")
-	streamingUpstreamTimeout := flag.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests")
-	copilotEditorVersion := flag.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header")
-	copilotPluginVersion := flag.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header")
-	copilotUserAgent := flag.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header")
-	copilotGitHubAPIVersion := flag.String("copilot-github-api-version", getEnv("COPILOT_GITHUB_API_VERSION", ""), "Upstream Copilot x-github-api-version header")
-	responsesWSTurnStateDelta := flag.Bool("responses-ws-turn-state-delta", getEnvBool("RESPONSES_WS_TURN_STATE_DELTA", false), "Attempt delta-only replay when upstream returns X-Codex-Turn-State")
-	responsesWSDisableAutoCompact := flag.Bool("responses-ws-disable-auto-compact", getEnvBool("RESPONSES_WS_DISABLE_AUTO_COMPACT", false), "Disable automatic websocket-session history compaction")
-	responsesWSCompactMaxItems := flag.Int("responses-ws-auto-compact-max-items", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_ITEMS", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxItems), "Auto-compact websocket session history after this many items")
-	responsesWSCompactMaxBytes := flag.Int("responses-ws-auto-compact-max-bytes", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_BYTES", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxBytes), "Auto-compact websocket session history after this many raw bytes")
-	responsesWSCompactKeepTail := flag.Int("responses-ws-auto-compact-keep-tail", getEnvInt("RESPONSES_WS_AUTO_COMPACT_KEEP_TAIL", proxy.DefaultResponsesWebSocketConfig().AutoCompactKeepTail), "When auto-compacting websocket history, keep this many most recent items verbatim")
-	compactUpstreamChunkBytes := flag.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor")
-	compactUpstreamMaxAttempts := flag.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy")
+	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*logLevel))
+	log := logger.New(logger.ParseLevel(*serve.logLevel))
 
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
+	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
 		log.Fatal("failed to initialize authenticator", logger.Err(err))
 	}
 
-	providersCfg, err := proxy.LoadProvidersConfigFile(*providersConfigPath)
+	providersCfg, err := proxy.LoadProvidersConfigFile(*serve.providersConfigPath)
 	if err != nil {
 		log.Fatal("failed to load providers config", logger.Err(err))
 	}
@@ -254,24 +305,13 @@ func runServe() {
 	srv, err := server.New(
 		authenticator,
 		log,
-		*host,
-		*port,
-		server.WithStreamingUpstreamTimeout(*streamingUpstreamTimeout),
-		server.WithCopilotHeaderConfig(proxy.CopilotHeaderConfig{
-			EditorVersion:       *copilotEditorVersion,
-			EditorPluginVersion: *copilotPluginVersion,
-			UserAgent:           *copilotUserAgent,
-			GitHubAPIVersion:    *copilotGitHubAPIVersion,
-		}),
-		server.WithResponsesWebSocketConfig(proxy.ResponsesWebSocketConfig{
-			TurnStateDelta:      *responsesWSTurnStateDelta,
-			DisableAutoCompact:  *responsesWSDisableAutoCompact,
-			AutoCompactMaxItems: *responsesWSCompactMaxItems,
-			AutoCompactMaxBytes: *responsesWSCompactMaxBytes,
-			AutoCompactKeepTail: *responsesWSCompactKeepTail,
-		}),
-		server.WithCompactUpstreamChunkBytes(*compactUpstreamChunkBytes),
-		server.WithCompactUpstreamMaxAttempts(*compactUpstreamMaxAttempts),
+		*serve.host,
+		*serve.port,
+		server.WithStreamingUpstreamTimeout(*serve.streamingUpstreamTimeout),
+		server.WithCopilotHeaderConfig(serve.copilotHeaderConfig()),
+		server.WithResponsesWebSocketConfig(serve.responsesWebSocketConfig()),
+		server.WithCompactUpstreamChunkBytes(*serve.compactUpstreamChunkBytes),
+		server.WithCompactUpstreamMaxAttempts(*serve.compactUpstreamMaxAttempts),
 		server.WithProxyOptions(proxy.WithProvidersConfig(providersCfg)),
 	)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -116,6 +118,50 @@ func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	want := fmt.Sprintf("warning: ignoring invalid %s=%q", envKey, "not-a-bool")
 	if !bytes.Contains([]byte(output), []byte(want)) {
 		t.Errorf("expected stderr to contain %q, got %q", want, output)
+	}
+}
+
+func parseServeFlagsForTest(t *testing.T, args ...string) serveFlags {
+	t.Helper()
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	serve := registerServeFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse serve flags: %v", err)
+	}
+	return serve
+}
+
+func TestServeFlagsCopilotHeaderEnvDefaults(t *testing.T) {
+	t.Setenv("COPILOT_INTEGRATION_ID", "env-integration")
+	t.Setenv("COPILOT_OPENAI_INTENT", "env-intent")
+
+	serve := parseServeFlagsForTest(t)
+	cfg := serve.copilotHeaderConfig()
+
+	if cfg.IntegrationID != "env-integration" {
+		t.Fatalf("IntegrationID = %q, want env-integration", cfg.IntegrationID)
+	}
+	if cfg.OpenAIIntent != "env-intent" {
+		t.Fatalf("OpenAIIntent = %q, want env-intent", cfg.OpenAIIntent)
+	}
+}
+
+func TestServeFlagsCopilotHeaderCLIOverridesEnv(t *testing.T) {
+	t.Setenv("COPILOT_INTEGRATION_ID", "env-integration")
+	t.Setenv("COPILOT_OPENAI_INTENT", "env-intent")
+
+	serve := parseServeFlagsForTest(t,
+		"--copilot-integration-id", "cli-integration",
+		"--copilot-openai-intent", "cli-intent",
+	)
+	cfg := serve.copilotHeaderConfig()
+
+	if cfg.IntegrationID != "cli-integration" {
+		t.Fatalf("IntegrationID = %q, want cli-integration", cfg.IntegrationID)
+	}
+	if cfg.OpenAIIntent != "cli-intent" {
+		t.Fatalf("OpenAIIntent = %q, want cli-intent", cfg.OpenAIIntent)
 	}
 }
 

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -157,7 +157,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 			logger.F("endpoint", "anthropic"),
 			logger.F("status", resp.StatusCode),
 			logger.F("body", string(errBody)),
-			logger.F("request", string(oaiBody)),
+			logger.F("request_bytes", len(oaiBody)),
 		)
 		writeAnthropicError(w, resp.StatusCode, "api_error", fmt.Sprintf("upstream error (%d)", resp.StatusCode))
 		return

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -99,7 +99,12 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		h.log.Error("upstream error", logger.F("endpoint", "gemini"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)), logger.F("request", string(oaiBody)))
+		h.log.Error("upstream error",
+			logger.F("endpoint", "gemini"),
+			logger.F("status", resp.StatusCode),
+			logger.F("body", string(errBody)),
+			logger.F("request_bytes", len(oaiBody)),
+		)
 		writeGeminiError(w, resp.StatusCode, mapGeminiUpstreamStatus(resp.StatusCode), fmt.Sprintf("upstream error (%d)", resp.StatusCode))
 		return
 	}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -51,7 +51,7 @@ const (
 	defaultCopilotEditorPluginVersion = "copilot-chat/0.26.7"
 	defaultCopilotUserAgent           = "GitHubCopilotChat/0.26.7"
 	defaultCopilotIntegrationID       = "vscode-chat"
-	defaultCopilotGitHubAPIVersion    = "2025-04-01"
+	defaultCopilotGitHubAPIVersion    = "2025-05-01"
 	defaultCopilotOpenAIIntent        = "conversation-panel"
 	defaultResponsesWSCompactMaxItems = 48
 	defaultResponsesWSCompactMaxBytes = 256 << 10
@@ -99,12 +99,21 @@ func (e *requestBodyError) Unwrap() error {
 // CopilotHeaderConfig controls the synthetic editor-identifying headers sent to
 // the upstream Copilot backend. Empty fields fall back to project defaults.
 type CopilotHeaderConfig struct {
-	EditorVersion       string
-	EditorPluginVersion string
-	UserAgent           string
-	IntegrationID       string
-	GitHubAPIVersion    string
-	OpenAIIntent        string
+	EditorVersion       string `json:"editor_version,omitempty" yaml:"editor_version,omitempty"`
+	EditorPluginVersion string `json:"editor_plugin_version,omitempty" yaml:"editor_plugin_version,omitempty"`
+	UserAgent           string `json:"user_agent,omitempty" yaml:"user_agent,omitempty"`
+	IntegrationID       string `json:"copilot_integration_id,omitempty" yaml:"copilot_integration_id,omitempty"`
+	GitHubAPIVersion    string `json:"github_api_version,omitempty" yaml:"github_api_version,omitempty"`
+	OpenAIIntent        string `json:"openai_intent,omitempty" yaml:"openai_intent,omitempty"`
+}
+
+// CopilotHeaderProfilesConfig allows provider config to override Copilot header
+// profiles globally for the provider or for a specific upstream endpoint. Empty
+// fields inherit from the provider default profile and then the project defaults.
+type CopilotHeaderProfilesConfig struct {
+	Default         CopilotHeaderConfig `json:"default,omitempty" yaml:"default,omitempty"`
+	ChatCompletions CopilotHeaderConfig `json:"chat_completions,omitempty" yaml:"chat_completions,omitempty"`
+	Responses       CopilotHeaderConfig `json:"responses,omitempty" yaml:"responses,omitempty"`
 }
 
 // ResponsesWebSocketConfig controls websocket-session state management for
@@ -159,6 +168,43 @@ func (c CopilotHeaderConfig) withDefaults() CopilotHeaderConfig {
 	return c
 }
 
+func mergeCopilotHeaderConfig(base, override CopilotHeaderConfig) CopilotHeaderConfig {
+	if override.EditorVersion != "" {
+		base.EditorVersion = override.EditorVersion
+	}
+	if override.EditorPluginVersion != "" {
+		base.EditorPluginVersion = override.EditorPluginVersion
+	}
+	if override.UserAgent != "" {
+		base.UserAgent = override.UserAgent
+	}
+	if override.IntegrationID != "" {
+		base.IntegrationID = override.IntegrationID
+	}
+	if override.GitHubAPIVersion != "" {
+		base.GitHubAPIVersion = override.GitHubAPIVersion
+	}
+	if override.OpenAIIntent != "" {
+		base.OpenAIIntent = override.OpenAIIntent
+	}
+	return base
+}
+
+func (c CopilotHeaderProfilesConfig) profileForEndpointRaw(endpoint string, base CopilotHeaderConfig) CopilotHeaderConfig {
+	profile := mergeCopilotHeaderConfig(base, c.Default)
+	switch strings.TrimSpace(endpoint) {
+	case "/chat/completions":
+		profile = mergeCopilotHeaderConfig(profile, c.ChatCompletions)
+	case "/responses":
+		profile = mergeCopilotHeaderConfig(profile, c.Responses)
+	}
+	return profile
+}
+
+func (c CopilotHeaderProfilesConfig) profileForEndpoint(endpoint string, base CopilotHeaderConfig) CopilotHeaderConfig {
+	return c.profileForEndpointRaw(endpoint, base).withDefaults()
+}
+
 func (c ResponsesWebSocketConfig) withDefaults() ResponsesWebSocketConfig {
 	defaults := DefaultResponsesWebSocketConfig()
 	if c.AutoCompactMaxItems <= 0 {
@@ -202,10 +248,12 @@ type ProxyHandler struct {
 type Option func(*ProxyHandler)
 
 // WithCopilotHeaderConfig overrides the synthetic Copilot-identifying headers
-// used for upstream requests.
+// used for upstream requests. The raw override values are retained so endpoint-
+// scoped header logic can distinguish an explicitly configured OpenAI intent
+// from the built-in chat/responses default.
 func WithCopilotHeaderConfig(cfg CopilotHeaderConfig) Option {
 	return func(h *ProxyHandler) {
-		h.copilotHeaders = cfg.withDefaults()
+		h.copilotHeaders = cfg
 	}
 }
 
@@ -291,8 +339,11 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 				TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
 			},
 		},
-		copilotURL:               "https://api.githubcopilot.com",
-		copilotHeaders:           DefaultCopilotHeaderConfig(),
+		copilotURL: "https://api.githubcopilot.com",
+		// Keep global Copilot header overrides empty by default. Header application
+		// fills built-in defaults per endpoint, and /models must not inherit the
+		// built-in openai-intent value.
+		copilotHeaders:           CopilotHeaderConfig{},
 		responsesWS:              DefaultResponsesWebSocketConfig(),
 		streamingUpstreamTimeout: streamingUpstreamTimeout,
 		log:                      log,
@@ -369,8 +420,60 @@ func setCopilotHeadersWithConfig(req *http.Request, token string, cfg CopilotHea
 	req.Header.Set("Content-Type", "application/json")
 }
 
+func clearCopilotHeaders(headers http.Header) {
+	for _, header := range []string{
+		"Authorization",
+		"editor-version",
+		"editor-plugin-version",
+		"user-agent",
+		"copilot-integration-id",
+		"x-github-api-version",
+		"x-request-id",
+		"openai-intent",
+	} {
+		headers.Del(header)
+	}
+}
+
 func (h *ProxyHandler) setCopilotHeaders(req *http.Request, token string) {
 	setCopilotHeadersWithConfig(req, token, h.copilotHeaders)
+}
+
+func copilotEndpointUsesDefaultOpenAIIntent(endpoint string) bool {
+	switch strings.TrimSpace(endpoint) {
+	case "/chat/completions", "/responses":
+		return true
+	default:
+		return false
+	}
+}
+
+func setCopilotHeadersForEndpoint(req *http.Request, token string, cfg CopilotHeaderConfig, endpoint string) {
+	explicitOpenAIIntent := cfg.OpenAIIntent != ""
+	cfg = cfg.withDefaults()
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("editor-version", cfg.EditorVersion)
+	req.Header.Set("editor-plugin-version", cfg.EditorPluginVersion)
+	req.Header.Set("user-agent", cfg.UserAgent)
+	req.Header.Set("copilot-integration-id", cfg.IntegrationID)
+	req.Header.Set("x-github-api-version", cfg.GitHubAPIVersion)
+	req.Header.Set("x-request-id", uuid.New().String())
+	if explicitOpenAIIntent || copilotEndpointUsesDefaultOpenAIIntent(endpoint) {
+		req.Header.Set("openai-intent", cfg.OpenAIIntent)
+	} else {
+		req.Header.Del("openai-intent")
+	}
+	if req.Method != http.MethodGet {
+		req.Header.Set("Content-Type", "application/json")
+	}
+}
+
+func (h *ProxyHandler) setCopilotHeadersForProvider(req *http.Request, token string, provider *providerRuntime, endpoint string) {
+	cfg := h.copilotHeaders
+	if provider != nil && provider.kind == providerTypeCopilot {
+		cfg = provider.headerProfiles.profileForEndpointRaw(endpoint, cfg)
+	}
+	setCopilotHeadersForEndpoint(req, token, cfg, endpoint)
 }
 
 var hopByHopHeaders = map[string]struct{}{
@@ -505,7 +608,7 @@ func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *pr
 		if err != nil {
 			return nil, fmt.Errorf("failed to create upstream probe request: %w", err)
 		}
-		h.setCopilotHeaders(req, token)
+		h.setCopilotHeadersForProvider(req, token, provider, "/models")
 		return req, nil
 	case providerTypeAzureOpenAI:
 		fullURL, err := h.providerRequestURL(provider, "/models", "")

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3961,7 +3961,7 @@ func TestSetCopilotHeaders(t *testing.T) {
 		{"editor-plugin-version", "copilot-chat/0.26.7"},
 		{"user-agent", "GitHubCopilotChat/0.26.7"},
 		{"copilot-integration-id", "vscode-chat"},
-		{"x-github-api-version", "2025-04-01"},
+		{"x-github-api-version", "2025-05-01"},
 		{"openai-intent", "conversation-panel"},
 		{"Content-Type", "application/json"},
 	}
@@ -4007,6 +4007,330 @@ func TestSetCopilotHeadersWithConfig(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("header %q: expected %q, got %q", tt.header, tt.expected, got)
 		}
+	}
+}
+
+func TestCopilotHeaderProfilesConfigProfileForEndpointRawDoesNotApplyDefaults(t *testing.T) {
+	profiles := CopilotHeaderProfilesConfig{
+		Default: CopilotHeaderConfig{
+			UserAgent: "provider-agent",
+		},
+	}
+	base := CopilotHeaderConfig{
+		EditorVersion: "base-editor",
+	}
+
+	raw := profiles.profileForEndpointRaw("/models", base)
+	if raw.EditorVersion != "base-editor" {
+		t.Fatalf("raw EditorVersion = %q, want base-editor", raw.EditorVersion)
+	}
+	if raw.UserAgent != "provider-agent" {
+		t.Fatalf("raw UserAgent = %q, want provider-agent", raw.UserAgent)
+	}
+	if raw.OpenAIIntent != "" {
+		t.Fatalf("raw OpenAIIntent = %q, want empty", raw.OpenAIIntent)
+	}
+
+	withDefaults := profiles.profileForEndpoint("/models", base)
+	if withDefaults.OpenAIIntent != defaultCopilotOpenAIIntent {
+		t.Fatalf("defaulted OpenAIIntent = %q, want %q", withDefaults.OpenAIIntent, defaultCopilotOpenAIIntent)
+	}
+}
+
+func TestCopilotHeaderProfilesConfigProfileForEndpoint(t *testing.T) {
+	base := CopilotHeaderConfig{
+		EditorVersion:       "base-editor",
+		EditorPluginVersion: "base-plugin",
+		UserAgent:           "base-agent",
+		IntegrationID:       "base-integration",
+		GitHubAPIVersion:    "base-api",
+		OpenAIIntent:        "base-intent",
+	}
+	profiles := CopilotHeaderProfilesConfig{
+		Default: CopilotHeaderConfig{
+			UserAgent:     "provider-agent",
+			IntegrationID: "provider-integration",
+		},
+		ChatCompletions: CopilotHeaderConfig{
+			EditorVersion: "chat-editor",
+			OpenAIIntent:  "chat-intent",
+		},
+		Responses: CopilotHeaderConfig{
+			EditorVersion: "responses-editor",
+			OpenAIIntent:  "responses-intent",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		endpoint   string
+		wantEditor string
+		wantIntent string
+	}{
+		{name: "chat completions profile", endpoint: "/chat/completions", wantEditor: "chat-editor", wantIntent: "chat-intent"},
+		{name: "responses profile", endpoint: "/responses", wantEditor: "responses-editor", wantIntent: "responses-intent"},
+		{name: "models use provider default profile", endpoint: "/models", wantEditor: "base-editor", wantIntent: "base-intent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := profiles.profileForEndpoint(tt.endpoint, base)
+			if got.EditorVersion != tt.wantEditor {
+				t.Fatalf("EditorVersion = %q, want %q", got.EditorVersion, tt.wantEditor)
+			}
+			if got.OpenAIIntent != tt.wantIntent {
+				t.Fatalf("OpenAIIntent = %q, want %q", got.OpenAIIntent, tt.wantIntent)
+			}
+			if got.UserAgent != "provider-agent" {
+				t.Fatalf("UserAgent = %q, want provider-agent", got.UserAgent)
+			}
+			if got.IntegrationID != "provider-integration" {
+				t.Fatalf("IntegrationID = %q, want provider-integration", got.IntegrationID)
+			}
+			if got.EditorPluginVersion != "base-plugin" {
+				t.Fatalf("EditorPluginVersion = %q, want base-plugin", got.EditorPluginVersion)
+			}
+			if got.GitHubAPIVersion != "base-api" {
+				t.Fatalf("GitHubAPIVersion = %q, want base-api", got.GitHubAPIVersion)
+			}
+		})
+	}
+}
+
+func TestNewProviderJSONRequest_UsesConfiguredCopilotHeaderProfiles(t *testing.T) {
+	handler := &ProxyHandler{
+		auth: auth.NewTestAuthenticator("test-token"),
+		copilotHeaders: CopilotHeaderConfig{
+			EditorVersion:       "base-editor",
+			EditorPluginVersion: "base-plugin",
+			UserAgent:           "base-agent",
+			IntegrationID:       "base-integration",
+			GitHubAPIVersion:    "base-api",
+			OpenAIIntent:        "base-intent",
+		},
+	}
+	provider := &providerRuntime{
+		id:      "copilot",
+		kind:    providerTypeCopilot,
+		baseURL: "https://copilot.example.test",
+		headerProfiles: CopilotHeaderProfilesConfig{
+			Default: CopilotHeaderConfig{
+				UserAgent:     "provider-agent",
+				IntegrationID: "provider-integration",
+			},
+			ChatCompletions: CopilotHeaderConfig{
+				EditorVersion: "chat-editor",
+				OpenAIIntent:  "chat-intent",
+			},
+			Responses: CopilotHeaderConfig{
+				EditorVersion: "responses-editor",
+				OpenAIIntent:  "responses-intent",
+			},
+		},
+	}
+
+	tests := []struct {
+		path       string
+		wantEditor string
+		wantIntent string
+	}{
+		{path: "/chat/completions", wantEditor: "chat-editor", wantIntent: "chat-intent"},
+		{path: "/responses", wantEditor: "responses-editor", wantIntent: "responses-intent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, tt.path, []byte(`{"model":"gpt-test"}`), nil, "")
+			if err != nil {
+				t.Fatalf("newProviderJSONRequest() error = %v", err)
+			}
+			if got := req.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Fatalf("Authorization = %q, want bearer token", got)
+			}
+			if got := req.Header.Get("editor-version"); got != tt.wantEditor {
+				t.Fatalf("editor-version = %q, want %q", got, tt.wantEditor)
+			}
+			if got := req.Header.Get("openai-intent"); got != tt.wantIntent {
+				t.Fatalf("openai-intent = %q, want %q", got, tt.wantIntent)
+			}
+			if got := req.Header.Get("user-agent"); got != "provider-agent" {
+				t.Fatalf("user-agent = %q, want provider-agent", got)
+			}
+			if got := req.Header.Get("copilot-integration-id"); got != "provider-integration" {
+				t.Fatalf("copilot-integration-id = %q, want provider-integration", got)
+			}
+			if got := req.Header.Get("editor-plugin-version"); got != "base-plugin" {
+				t.Fatalf("editor-plugin-version = %q, want base-plugin", got)
+			}
+			if got := req.Header.Get("x-github-api-version"); got != "base-api" {
+				t.Fatalf("x-github-api-version = %q, want base-api", got)
+			}
+		})
+	}
+}
+
+func TestNewProviderJSONRequest_CopilotModelsOmitsIntentAndContentTypeByDefault(t *testing.T) {
+	handler := &ProxyHandler{
+		auth: auth.NewTestAuthenticator("test-token"),
+	}
+	provider := &providerRuntime{
+		id:      "copilot",
+		kind:    providerTypeCopilot,
+		baseURL: "https://copilot.example.test",
+	}
+
+	req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodGet, "/models", nil, nil, "")
+	if err != nil {
+		t.Fatalf("newProviderJSONRequest() error = %v", err)
+	}
+
+	tests := []struct {
+		header   string
+		expected string
+	}{
+		{"Authorization", "Bearer test-token"},
+		{"editor-version", defaultCopilotEditorVersion},
+		{"editor-plugin-version", defaultCopilotEditorPluginVersion},
+		{"user-agent", defaultCopilotUserAgent},
+		{"copilot-integration-id", defaultCopilotIntegrationID},
+		{"x-github-api-version", defaultCopilotGitHubAPIVersion},
+	}
+	for _, tt := range tests {
+		if got := req.Header.Get(tt.header); got != tt.expected {
+			t.Fatalf("%s = %q, want %q", tt.header, got, tt.expected)
+		}
+	}
+	if got := req.Header.Get("x-request-id"); got == "" {
+		t.Fatal("x-request-id = empty, want generated UUID")
+	}
+	if got := req.Header.Get("openai-intent"); got != "" {
+		t.Fatalf("openai-intent = %q, want omitted for default /models", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "" {
+		t.Fatalf("Content-Type = %q, want omitted for GET /models", got)
+	}
+}
+
+func TestNewProviderJSONRequest_CopilotModelsKeepsExplicitIntent(t *testing.T) {
+	tests := []struct {
+		name           string
+		copilotHeaders CopilotHeaderConfig
+		headerProfiles CopilotHeaderProfilesConfig
+		wantIntent     string
+	}{
+		{
+			name: "global config",
+			copilotHeaders: CopilotHeaderConfig{
+				OpenAIIntent: "global-intent",
+			},
+			wantIntent: "global-intent",
+		},
+		{
+			name: "provider default profile",
+			headerProfiles: CopilotHeaderProfilesConfig{
+				Default: CopilotHeaderConfig{
+					OpenAIIntent: "provider-intent",
+				},
+			},
+			wantIntent: "provider-intent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &ProxyHandler{
+				auth:           auth.NewTestAuthenticator("test-token"),
+				copilotHeaders: tt.copilotHeaders,
+			}
+			provider := &providerRuntime{
+				id:             "copilot",
+				kind:           providerTypeCopilot,
+				baseURL:        "https://copilot.example.test",
+				headerProfiles: tt.headerProfiles,
+			}
+
+			req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodGet, "/models", nil, nil, "")
+			if err != nil {
+				t.Fatalf("newProviderJSONRequest() error = %v", err)
+			}
+			if got := req.Header.Get("openai-intent"); got != tt.wantIntent {
+				t.Fatalf("openai-intent = %q, want %q", got, tt.wantIntent)
+			}
+			if got := req.Header.Get("Content-Type"); got != "" {
+				t.Fatalf("Content-Type = %q, want omitted for GET /models", got)
+			}
+		})
+	}
+}
+
+func TestNewProviderJSONRequest_CopilotChatAndResponsesUseDefaultIntent(t *testing.T) {
+	handler := &ProxyHandler{
+		auth: auth.NewTestAuthenticator("test-token"),
+	}
+	provider := &providerRuntime{
+		id:      "copilot",
+		kind:    providerTypeCopilot,
+		baseURL: "https://copilot.example.test",
+	}
+
+	for _, path := range []string{"/chat/completions", "/responses"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, path, []byte(`{"model":"gpt-test"}`), nil, "")
+			if err != nil {
+				t.Fatalf("newProviderJSONRequest() error = %v", err)
+			}
+			if got := req.Header.Get("openai-intent"); got != defaultCopilotOpenAIIntent {
+				t.Fatalf("openai-intent = %q, want %q", got, defaultCopilotOpenAIIntent)
+			}
+			if got := req.Header.Get("Content-Type"); got != "application/json" {
+				t.Fatalf("Content-Type = %q, want application/json", got)
+			}
+		})
+	}
+}
+
+func TestNewProviderJSONRequest_StripsClientCopilotHeadersForAzure(t *testing.T) {
+	handler := &ProxyHandler{}
+	provider := &providerRuntime{
+		id:      "azure",
+		kind:    providerTypeAzureOpenAI,
+		baseURL: "https://azure.example.test/openai/v1",
+		apiKey:  "azure-key",
+	}
+
+	req, err := handler.newProviderJSONRequest(
+		context.Background(),
+		provider,
+		http.MethodPost,
+		"/responses",
+		[]byte(`{"model":"gpt-test"}`),
+		http.Header{
+			"Authorization":          []string{"Bearer client-copilot-token"},
+			"editor-version":         []string{"client-editor"},
+			"editor-plugin-version":  []string{"client-plugin"},
+			"user-agent":             []string{"client-agent"},
+			"copilot-integration-id": []string{"client-integration"},
+			"x-github-api-version":   []string{"client-api"},
+			"x-request-id":           []string{"client-request-id"},
+			"openai-intent":          []string{"client-intent"},
+			"Traceparent":            []string{"00-11111111111111111111111111111111-2222222222222222-01"},
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("newProviderJSONRequest() error = %v", err)
+	}
+
+	for _, header := range []string{"Authorization", "editor-version", "editor-plugin-version", "user-agent", "copilot-integration-id", "x-github-api-version", "x-request-id", "openai-intent"} {
+		if got := req.Header.Get(header); got != "" {
+			t.Fatalf("%s = %q, want stripped for Azure", header, got)
+		}
+	}
+	if got := req.Header.Get("api-key"); got != "azure-key" {
+		t.Fatalf("api-key = %q, want azure-key", got)
+	}
+	if got := req.Header.Get("Traceparent"); got != "00-11111111111111111111111111111111-2222222222222222-01" {
+		t.Fatalf("Traceparent = %q, want passthrough trace header", got)
 	}
 }
 

--- a/proxy/logging_safety_test.go
+++ b/proxy/logging_safety_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestProxyLogsDoNotIncludeRequestBodies(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read proxy package directory: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		path := filepath.Join(".", name)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isLoggerFieldCall(call) || len(call.Args) == 0 {
+				return true
+			}
+
+			key, ok := stringLiteralValue(call.Args[0])
+			if !ok {
+				return true
+			}
+
+			switch key {
+			case "prompt", "request", "request_body":
+				t.Errorf("%s logs sensitive field %q; log safe metadata such as byte counts instead", fset.Position(call.Pos()), key)
+			case "body":
+				if len(call.Args) > 1 && stringifiesRequestBodyVariable(call.Args[1]) {
+					t.Errorf("%s logs request body bytes under field %q; log safe metadata such as byte counts instead", fset.Position(call.Pos()), key)
+				}
+			}
+			return true
+		})
+	}
+}
+
+func isLoggerFieldCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "F" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == "logger"
+}
+
+func stringLiteralValue(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func stringifiesRequestBodyVariable(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return false
+	}
+	fn, ok := call.Fun.(*ast.Ident)
+	if !ok || fn.Name != "string" {
+		return false
+	}
+	ident, ok := call.Args[0].(*ast.Ident)
+	if !ok {
+		return false
+	}
+	switch ident.Name {
+	case "body", "oaiBody", "reqBody", "requestBody", "rawBody":
+		return true
+	default:
+		return false
+	}
+}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -35,16 +35,17 @@ type ProvidersConfig struct {
 
 // ProviderConfig configures one upstream provider instance.
 type ProviderConfig struct {
-	ID            string                `json:"id" yaml:"id"`
-	Type          string                `json:"type" yaml:"type"`
-	Default       bool                  `json:"default,omitempty" yaml:"default,omitempty"`
-	IncludeModels []string              `json:"include_models,omitempty" yaml:"include_models,omitempty"`
-	ExcludeModels []string              `json:"exclude_models,omitempty" yaml:"exclude_models,omitempty"`
-	BaseURL       string                `json:"base_url,omitempty" yaml:"base_url,omitempty"`
-	APIKey        string                `json:"api_key,omitempty" yaml:"api_key,omitempty"`
-	APIKeyEnv     string                `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
-	APIVersion    string                `json:"api_version,omitempty" yaml:"api_version,omitempty"`
-	Models        []ProviderModelConfig `json:"models,omitempty" yaml:"models,omitempty"`
+	ID            string                      `json:"id" yaml:"id"`
+	Type          string                      `json:"type" yaml:"type"`
+	Default       bool                        `json:"default,omitempty" yaml:"default,omitempty"`
+	IncludeModels []string                    `json:"include_models,omitempty" yaml:"include_models,omitempty"`
+	ExcludeModels []string                    `json:"exclude_models,omitempty" yaml:"exclude_models,omitempty"`
+	BaseURL       string                      `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	APIKey        string                      `json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	APIKeyEnv     string                      `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
+	APIVersion    string                      `json:"api_version,omitempty" yaml:"api_version,omitempty"`
+	Headers       CopilotHeaderProfilesConfig `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Models        []ProviderModelConfig       `json:"models,omitempty" yaml:"models,omitempty"`
 }
 
 // ProviderModelConfig maps a public model ID exposed by this proxy to the
@@ -63,18 +64,19 @@ type ProviderModelConfig struct {
 }
 
 type providerRuntime struct {
-	id            string
-	kind          providerType
-	isDefault     bool
-	baseURL       string
-	apiKey        string
-	apiVersion    string
-	includeModels map[string]struct{}
-	excludeModels map[string]struct{}
-	staticModels  map[string]providerModel
-	staticConfigs map[string]ProviderModelConfig
-	staticOrder   []string
-	codexAuth     *openAICodexAuth
+	id             string
+	kind           providerType
+	isDefault      bool
+	baseURL        string
+	apiKey         string
+	apiVersion     string
+	includeModels  map[string]struct{}
+	excludeModels  map[string]struct{}
+	staticModels   map[string]providerModel
+	staticConfigs  map[string]ProviderModelConfig
+	staticOrder    []string
+	codexAuth      *openAICodexAuth
+	headerProfiles CopilotHeaderProfilesConfig
 }
 
 type providerModel struct {
@@ -476,6 +478,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string) (*provid
 	switch kind {
 	case providerTypeCopilot:
 		runtime.baseURL = strings.TrimRight(defaultCopilotURL, "/")
+		runtime.headerProfiles = cfg.Headers
 	case providerTypeAzureOpenAI:
 		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
 		if baseURL == "" {
@@ -877,7 +880,7 @@ func appendRawQuery(rawURL, rawQuery string) string {
 	return rawURL + separator + rawQuery
 }
 
-func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *providerRuntime) error {
+func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *providerRuntime, endpoint string) error {
 	if provider == nil {
 		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
 	}
@@ -888,11 +891,13 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 		if err != nil {
 			return &providerRequestError{statusCode: http.StatusInternalServerError, err: err}
 		}
-		h.setCopilotHeaders(req, token)
+		h.setCopilotHeadersForProvider(req, token, provider, endpoint)
 	case providerTypeAzureOpenAI:
+		clearCopilotHeaders(req.Header)
 		req.Header.Set("api-key", provider.apiKey)
 		req.Header.Set("Content-Type", "application/json")
 	case providerTypeOpenAICodex:
+		clearCopilotHeaders(req.Header)
 		if provider.codexAuth == nil {
 			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no OpenAI Codex auth configured", provider.id)}
 		}
@@ -932,7 +937,7 @@ func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *pro
 	if len(extraHeaders) > 0 {
 		mergeHeaderValues(req.Header, extraHeaders)
 	}
-	if err := h.applyProviderHeaders(req, provider); err != nil {
+	if err := h.applyProviderHeaders(req, provider, path); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -249,6 +249,118 @@ func TestLoadProvidersConfigFileYAML(t *testing.T) {
 	}
 }
 
+func TestLoadProvidersConfigFileCopilotHeaderProfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ext  string
+		body string
+	}{
+		{
+			name: "json",
+			ext:  ".json",
+			body: `{
+  "providers": [
+    {
+      "id": "copilot",
+      "type": "copilot",
+      "default": true,
+      "headers": {
+        "default": {
+          "editor_version": "default-editor",
+          "copilot_integration_id": "default-integration"
+        },
+        "chat_completions": {
+          "user_agent": "chat-agent",
+          "openai_intent": "chat-intent"
+        },
+        "responses": {
+          "editor_version": "responses-editor",
+          "github_api_version": "responses-api"
+        }
+      }
+    }
+  ]
+}`,
+		},
+		{
+			name: "yaml",
+			ext:  ".yaml",
+			body: `providers:
+  - id: copilot
+    type: copilot
+    default: true
+    headers:
+      default:
+        editor_version: default-editor
+        copilot_integration_id: default-integration
+      chat_completions:
+        user_agent: chat-agent
+        openai_intent: chat-intent
+      responses:
+        editor_version: responses-editor
+        github_api_version: responses-api
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			providersPath := filepath.Join(t.TempDir(), "providers"+tt.ext)
+			if err := os.WriteFile(providersPath, []byte(tt.body), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			cfg, err := LoadProvidersConfigFile(providersPath)
+			if err != nil {
+				t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+			}
+			if len(cfg.Providers) != 1 {
+				t.Fatalf("providers count = %d, want 1", len(cfg.Providers))
+			}
+
+			headers := cfg.Providers[0].Headers
+			if headers.Default.EditorVersion != "default-editor" {
+				t.Fatalf("default editor_version = %q, want default-editor", headers.Default.EditorVersion)
+			}
+			if headers.Default.IntegrationID != "default-integration" {
+				t.Fatalf("default copilot_integration_id = %q, want default-integration", headers.Default.IntegrationID)
+			}
+			if headers.ChatCompletions.UserAgent != "chat-agent" {
+				t.Fatalf("chat user_agent = %q, want chat-agent", headers.ChatCompletions.UserAgent)
+			}
+			if headers.ChatCompletions.OpenAIIntent != "chat-intent" {
+				t.Fatalf("chat openai_intent = %q, want chat-intent", headers.ChatCompletions.OpenAIIntent)
+			}
+			if headers.Responses.EditorVersion != "responses-editor" {
+				t.Fatalf("responses editor_version = %q, want responses-editor", headers.Responses.EditorVersion)
+			}
+			if headers.Responses.GitHubAPIVersion != "responses-api" {
+				t.Fatalf("responses github_api_version = %q, want responses-api", headers.Responses.GitHubAPIVersion)
+			}
+
+			handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+			providers, _, defaultProviderID, err := handler.buildProviders(cfg)
+			if err != nil {
+				t.Fatalf("buildProviders() error = %v", err)
+			}
+			if defaultProviderID != "copilot" {
+				t.Fatalf("default provider = %q, want copilot", defaultProviderID)
+			}
+			runtime := providers["copilot"]
+			if runtime == nil {
+				t.Fatal("expected copilot runtime")
+			}
+			if runtime.headerProfiles.Responses.EditorVersion != "responses-editor" {
+				t.Fatalf("runtime responses editor_version = %q, want responses-editor", runtime.headerProfiles.Responses.EditorVersion)
+			}
+		})
+	}
+}
+
 func TestLoadProvidersConfigFileRejectsEmptyBody(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #95.

## Summary
- Scope Copilot default headers by endpoint so model/readiness probes no longer send the built-in `openai-intent` or hardcoded JSON `Content-Type`.
- Preserve Copilot defaults for chat completions and responses while adding configurable integration ID / intent and provider header profiles.
- Strip Copilot-identifying headers for non-Copilot providers and update configuration docs.
- Add/expand tests for header behavior, config loading, non-Copilot stripping, and logging safety.

## Testing
- `git diff --check`
- `go test -count=1 ./...`
