### PR TITLE
fix: ignore websocket initiator metadata

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -116,13 +116,18 @@ Streaming Responses requests preserve upstream headers and are otherwise passed 
 
 `GET /v1/responses` upgrades to a websocket bridge for Codex-style clients. The proxy:
 
-- accepts `response.create` frames
+- accepts `response.create` frames, including websocket-only top-level fields such as `client_metadata` and `initiator`
+- uses supported `client_metadata` values to derive request headers, then strips websocket-only metadata before forwarding upstream
 - handles warmup and incremental follow-up requests locally
 - forwards the active turn to upstream HTTP `/responses`
 - relays streamed JSON events back as websocket text frames
 
 Websocket bridge behavior:
 
+- each websocket session is serialized: one active turn is processed at a time
+- Vekil does not multiplex turns or implement Copilot-style request superseding
+- closing the websocket ends the session; once Vekil observes the disconnect, it stops relaying and closes the upstream response body
+- upstream requests use the proxy streaming timeout rather than websocket/client-disconnect cancellation
 - history is stored append-only in memory
 - long sessions are auto-compacted into one proxy-owned checkpoint plus a recent tail
 - optional turn-state delta replay can be enabled with `--responses-ws-turn-state-delta`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,6 +217,7 @@ Important:
 
 - This websocket bridge is proxy-owned and still forwards upstream over HTTP `/responses`.
 - It is separate from Azure OpenAI's native `/realtime` websocket and WebRTC APIs.
+- Each websocket session is serialized: one active turn is processed at a time. Vekil does not multiplex turns or implement Copilot-style request superseding. Closing the websocket ends the session; once Vekil observes the disconnect, it stops relaying and closes the upstream response body while the upstream request context remains governed by the proxy streaming timeout.
 
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -203,13 +203,13 @@ func prepareResponsesWebSocketRequest(raw map[string]json.RawMessage) (string, [
 	keys := make([]string, 0, len(raw))
 	for key, value := range raw {
 		switch key {
-		case "type", "input", "previous_response_id", "generate", "client_metadata":
+		case "type", "input", "previous_response_id", "generate", "client_metadata", "initiator":
 		default:
 			signatureBody[key] = value
 		}
 
 		switch key {
-		case "type", "input", "previous_response_id", "generate", "client_metadata", "stream":
+		case "type", "input", "previous_response_id", "generate", "client_metadata", "initiator", "stream":
 		default:
 			keys = append(keys, key)
 		}

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -33,6 +33,59 @@ func TestHandleResponsesWebSocket_UpgradeRequiredWithoutUpgradeHeaders(t *testin
 	}
 }
 
+func TestResponsesWebSocketCreateRequest_IgnoresInitiatorForSignatureAndUpstream(t *testing.T) {
+	base := map[string]interface{}{
+		"type":                 "response.create",
+		"model":                "gpt-5.4",
+		"instructions":         "You are helpful",
+		"input":                []interface{}{},
+		"previous_response_id": "resp-previous",
+		"generate":             true,
+		"client_metadata": map[string]string{
+			"x-codex-turn-metadata": `{"turn_id":"turn-1"}`,
+		},
+		"initiator": "user",
+		"stream":    true,
+	}
+
+	withUserInitiator, err := json.Marshal(base)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+	base["initiator"] = "agent"
+	withAgentInitiator, err := json.Marshal(base)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	userRequest, err := parseResponsesWebSocketCreateRequest(withUserInitiator)
+	if err != nil {
+		t.Fatalf("failed to parse user-initiated request: %v", err)
+	}
+	agentRequest, err := parseResponsesWebSocketCreateRequest(withAgentInitiator)
+	if err != nil {
+		t.Fatalf("failed to parse agent-initiated request: %v", err)
+	}
+
+	if userRequest.signature() != agentRequest.signature() {
+		t.Fatalf("expected initiator not to affect websocket request signature, got %q vs %q", userRequest.signature(), agentRequest.signature())
+	}
+
+	body, err := userRequest.upstreamBody(nil)
+	if err != nil {
+		t.Fatalf("failed to build upstream body: %v", err)
+	}
+	var upstream map[string]json.RawMessage
+	if err := json.Unmarshal(body, &upstream); err != nil {
+		t.Fatalf("failed to decode upstream body: %v", err)
+	}
+	for _, key := range []string{"initiator", "client_metadata", "previous_response_id", "generate", "type"} {
+		if _, ok := upstream[key]; ok {
+			t.Fatalf("upstream request should not include websocket field %q", key)
+		}
+	}
+}
+
 func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 	var upstreamRequests atomic.Int32
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
@@ -66,6 +119,9 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		}
 		if _, ok := body["client_metadata"]; ok {
 			t.Fatalf("upstream request should not include websocket client metadata")
+		}
+		if _, ok := body["initiator"]; ok {
+			t.Fatalf("upstream request should not include websocket initiator field")
 		}
 		if _, ok := body["previous_response_id"]; ok {
 			t.Fatalf("upstream request should not include websocket previous_response_id")
@@ -103,6 +159,7 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		"ws_request_header_traceparent": "00-11111111111111111111111111111111-2222222222222222-01",
 		"x-codex-turn-metadata":         `{"turn_id":"turn-1"}`,
 	}
+	request["initiator"] = "user"
 	request["service_tier"] = "auto"
 
 	if err := conn.WriteJSON(request); err != nil {


### PR DESCRIPTION
## Summary
- treat Copilot `initiator` as WebSocket-only metadata
- exclude `initiator` from follow-up request signatures
- strip `initiator` before forwarding WebSocket turns upstream to HTTP `/responses`
- document serialized WebSocket turn behavior and cancellation semantics

## Testing
- `go test ./proxy/ -run 'TestResponsesWebSocketCreateRequest_IgnoresInitiatorForSignatureAndUpstream|TestHandleResponsesWebSocket_BridgesStreamingResponse' -count=1`
- `go test ./... -count=1`
