### PR TITLE
Fix Responses compaction alignment and WebSocket checkpoint replay

### DIFF
--- a/proxy/compaction.go
+++ b/proxy/compaction.go
@@ -54,6 +54,35 @@ func rewriteSyntheticCompactionRequest(body []byte) ([]byte, int) {
 	return rewrittenBody, rewriteCount
 }
 
+func rewriteSyntheticCompactionRequestFields(requestFields map[string]json.RawMessage) (map[string]json.RawMessage, int) {
+	rawInput, ok := requestFields["input"]
+	if !ok {
+		return requestFields, 0
+	}
+
+	var input interface{}
+	if err := json.Unmarshal(rawInput, &input); err != nil {
+		return requestFields, 0
+	}
+
+	rewrittenInput, rewriteCount := rewriteSyntheticCompactionValue(input)
+	if rewriteCount == 0 {
+		return requestFields, 0
+	}
+
+	encodedInput, err := json.Marshal(rewrittenInput)
+	if err != nil {
+		return requestFields, 0
+	}
+
+	rewrittenFields := make(map[string]json.RawMessage, len(requestFields))
+	for key, value := range requestFields {
+		rewrittenFields[key] = value
+	}
+	rewrittenFields["input"] = encodedInput
+	return rewrittenFields, rewriteCount
+}
+
 // When a compacted checkpoint is restored without a remaining user turn, add a
 // small synthetic user prompt so the upstream model resumes the interrupted
 // task instead of replying with a generic "what should I work on next?".

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3902,6 +3902,27 @@ func TestCompactedResponsesAlignedPrefixLen(t *testing.T) {
 			want:     1,
 		},
 		{
+			name: "non adjacent MCP approval response preserves approval request",
+			input: []json.RawMessage{
+				msg("user", "one"),
+				raw(map[string]interface{}{
+					"type":         "mcp_approval_request",
+					"id":           "approval-1",
+					"server_label": "github",
+					"name":         "create_pull_request",
+				}),
+				msg("assistant", "thinking"),
+				raw(map[string]interface{}{
+					"type":                "mcp_approval_response",
+					"approval_request_id": "approval-1",
+					"approve":             true,
+				}),
+				msg("user", "latest"),
+			},
+			keepTail: 3,
+			want:     1,
+		},
+		{
 			name: "parallel retained outputs preserve all matching calls",
 			input: []json.RawMessage{
 				msg("user", "one"),

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3938,6 +3938,17 @@ func TestCompactedResponsesAlignedPrefixLen(t *testing.T) {
 			want:     1,
 		},
 		{
+			name: "pending function call remains available for future output",
+			input: []json.RawMessage{
+				msg("user", "one"),
+				call,
+				msg("assistant", "thinking one"),
+				msg("assistant", "thinking two"),
+			},
+			keepTail: 1,
+			want:     1,
+		},
+		{
 			name: "chat-style tool output preserves assistant tool call",
 			input: []json.RawMessage{
 				msg("user", "one"),

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3862,6 +3862,15 @@ func TestCompactedResponsesAlignedPrefixLen(t *testing.T) {
 			want:     2,
 		},
 		{
+			name: "normal message id is not treated as tool call",
+			input: []json.RawMessage{
+				raw(map[string]interface{}{"type": "message", "role": "assistant", "id": "msg-1", "content": []map[string]string{{"type": "output_text", "text": "two"}}}),
+				msg("user", "three"),
+			},
+			keepTail: 1,
+			want:     1,
+		},
+		{
 			name:     "tail starting on output includes call",
 			input:    []json.RawMessage{msg("user", "one"), call, out, msg("user", "latest")},
 			keepTail: 2,
@@ -3876,6 +3885,51 @@ func TestCompactedResponsesAlignedPrefixLen(t *testing.T) {
 		{
 			name:     "tool output chain walks backward",
 			input:    []json.RawMessage{msg("user", "one"), call, out, raw(map[string]interface{}{"type": "mcp_approval_response", "call_id": "call-1"}), msg("user", "latest")},
+			keepTail: 3,
+			want:     1,
+		},
+		{
+			name: "non adjacent output inside retained tail includes matching call",
+			input: []json.RawMessage{
+				msg("user", "one"),
+				call,
+				msg("assistant", "thinking one"),
+				msg("assistant", "thinking two"),
+				out,
+				msg("user", "latest"),
+			},
+			keepTail: 3,
+			want:     1,
+		},
+		{
+			name: "parallel retained outputs preserve all matching calls",
+			input: []json.RawMessage{
+				msg("user", "one"),
+				raw(map[string]interface{}{"type": "function_call", "call_id": "call-1", "name": "first", "arguments": "{}"}),
+				raw(map[string]interface{}{"type": "function_call", "call_id": "call-2", "name": "second", "arguments": "{}"}),
+				msg("assistant", "thinking"),
+				raw(map[string]interface{}{"type": "function_call_output", "call_id": "call-1", "output": "first done"}),
+				msg("assistant", "between"),
+				raw(map[string]interface{}{"type": "function_call_output", "call_id": "call-2", "output": "second done"}),
+				msg("user", "latest"),
+			},
+			keepTail: 4,
+			want:     1,
+		},
+		{
+			name: "chat-style tool output preserves assistant tool call",
+			input: []json.RawMessage{
+				msg("user", "one"),
+				raw(map[string]interface{}{
+					"type":       "message",
+					"role":       "assistant",
+					"tool_calls": []map[string]interface{}{{"id": "tool-1", "type": "function", "function": map[string]string{"name": "shell", "arguments": "{}"}}},
+				}),
+				msg("assistant", "thinking one"),
+				msg("assistant", "thinking two"),
+				raw(map[string]interface{}{"type": "message", "role": "tool", "tool_call_id": "tool-1", "content": "done"}),
+				msg("user", "latest"),
+			},
 			keepTail: 3,
 			want:     1,
 		},

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -1889,6 +1889,25 @@ func compactedResponsesAlignedPrefixLen(input []json.RawMessage, keepTail int) i
 	}
 
 	start := len(input) - keepTail
+	for {
+		aligned := compactedResponsesAdjacentTailStart(input, start)
+		aligned = compactedResponsesCallIDAlignedTailStart(input, aligned)
+		if aligned >= start {
+			start = aligned
+			break
+		}
+		start = aligned
+		if start <= 0 {
+			return 0
+		}
+	}
+	if start < 0 {
+		return 0
+	}
+	return start
+}
+
+func compactedResponsesAdjacentTailStart(input []json.RawMessage, start int) int {
 	for start > 0 && responsesInputItemIsToolLikeOutput(input[start]) {
 		start--
 	}
@@ -1901,13 +1920,59 @@ func compactedResponsesAlignedPrefixLen(input []json.RawMessage, keepTail int) i
 	return start
 }
 
+func compactedResponsesCallIDAlignedTailStart(input []json.RawMessage, start int) int {
+	if start <= 0 {
+		return 0
+	}
+
+	earliest := start
+	for outputIndex := start; outputIndex < len(input); outputIndex++ {
+		for _, id := range responsesInputItemToolLikeOutputIDs(input[outputIndex]) {
+			callIndex := compactedResponsesMatchingToolCallIndex(input, id, outputIndex)
+			if callIndex >= 0 && callIndex < earliest {
+				earliest = callIndex
+			}
+		}
+	}
+	return earliest
+}
+
+func compactedResponsesMatchingToolCallIndex(input []json.RawMessage, id string, before int) int {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return -1
+	}
+	if before > len(input) {
+		before = len(input)
+	}
+	for i := before - 1; i >= 0; i-- {
+		for _, callID := range responsesInputItemToolLikeCallIDs(input[i]) {
+			if callID == id {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
 func responsesInputItemIsToolLikeCall(raw json.RawMessage) bool {
 	var item map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &item); err != nil {
 		return false
 	}
+	if responsesInputItemIsToolLikeOutput(raw) {
+		return false
+	}
 
-	switch rawJSONString(item["type"]) {
+	if responsesInputItemTypeIsToolLikeCall(rawJSONString(item["type"])) {
+		return true
+	}
+
+	return len(responsesInputItemToolLikeCallIDsFromItem(item)) > 0
+}
+
+func responsesInputItemTypeIsToolLikeCall(itemType string) bool {
+	switch itemType {
 	case "function_call",
 		"computer_call",
 		"local_shell_call",
@@ -1915,8 +1980,7 @@ func responsesInputItemIsToolLikeCall(raw json.RawMessage) bool {
 		"code_interpreter_call", "image_generation_call", "web_search_call":
 		return true
 	}
-
-	return rawJSONHasNonEmptyValue(item["call_id"]) || rawJSONHasNonEmptyValue(item["tool_call_id"])
+	return false
 }
 
 func responsesInputItemIsToolLikeOutput(raw json.RawMessage) bool {
@@ -1937,6 +2001,64 @@ func responsesInputItemIsToolLikeOutput(raw json.RawMessage) bool {
 		return true
 	}
 	return false
+}
+
+func responsesInputItemToolLikeOutputIDs(raw json.RawMessage) []string {
+	if !responsesInputItemIsToolLikeOutput(raw) {
+		return nil
+	}
+	var item map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil
+	}
+	return responsesInputItemDirectCallIDsFromItem(item)
+}
+
+func responsesInputItemToolLikeCallIDs(raw json.RawMessage) []string {
+	var item map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil
+	}
+	if responsesInputItemIsToolLikeOutput(raw) {
+		return nil
+	}
+	return responsesInputItemToolLikeCallIDsFromItem(item)
+}
+
+func responsesInputItemToolLikeCallIDsFromItem(item map[string]json.RawMessage) []string {
+	ids := responsesInputItemDirectCallIDsFromItem(item)
+	if responsesInputItemTypeIsToolLikeCall(rawJSONString(item["type"])) {
+		ids = appendUniqueNonEmptyID(ids, rawJSONString(item["id"]))
+	}
+
+	var toolCalls []map[string]json.RawMessage
+	if err := json.Unmarshal(item["tool_calls"], &toolCalls); err == nil {
+		for _, toolCall := range toolCalls {
+			ids = appendUniqueNonEmptyID(ids, rawJSONString(toolCall["id"]))
+		}
+	}
+
+	return ids
+}
+
+func responsesInputItemDirectCallIDsFromItem(item map[string]json.RawMessage) []string {
+	var ids []string
+	ids = appendUniqueNonEmptyID(ids, rawJSONString(item["call_id"]))
+	ids = appendUniqueNonEmptyID(ids, rawJSONString(item["tool_call_id"]))
+	return ids
+}
+
+func appendUniqueNonEmptyID(ids []string, id string) []string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ids
+	}
+	for _, existing := range ids {
+		if existing == id {
+			return ids
+		}
+	}
+	return append(ids, id)
 }
 
 func compactedResponsesRetryKeepTailSchedule(inputItems int, configuredKeepTail int) []int {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -1892,6 +1892,7 @@ func compactedResponsesAlignedPrefixLen(input []json.RawMessage, keepTail int) i
 	for {
 		aligned := compactedResponsesAdjacentTailStart(input, start)
 		aligned = compactedResponsesCallIDAlignedTailStart(input, aligned)
+		aligned = compactedResponsesOpenToolCallAlignedTailStart(input, aligned)
 		if aligned >= start {
 			start = aligned
 			break
@@ -1935,6 +1936,64 @@ func compactedResponsesCallIDAlignedTailStart(input []json.RawMessage, start int
 		}
 	}
 	return earliest
+}
+
+// compactedResponsesOpenToolCallAlignedTailStart keeps pending client-output
+// calls raw when no matching output has appeared yet. WebSocket sessions can
+// compact immediately after a function_call response, before the client sends
+// function_call_output on the next frame; summarizing that call would orphan the
+// future output.
+func compactedResponsesOpenToolCallAlignedTailStart(input []json.RawMessage, start int) int {
+	if start <= 0 {
+		return 0
+	}
+
+	earliest := start
+	for callIndex := 0; callIndex < start && callIndex < len(input); callIndex++ {
+		callIDs := responsesInputItemPendingOutputCallIDs(input[callIndex])
+		if len(callIDs) == 0 {
+			continue
+		}
+		if responsesInputHasToolLikeOutputForAll(input, callIDs, callIndex+1) {
+			continue
+		}
+		if callIndex < earliest {
+			earliest = callIndex
+		}
+	}
+	return earliest
+}
+
+func responsesInputHasToolLikeOutputForAll(input []json.RawMessage, ids []string, start int) bool {
+	if len(ids) == 0 {
+		return true
+	}
+	matched := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			matched[id] = false
+		}
+	}
+	if len(matched) == 0 {
+		return true
+	}
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(input); i++ {
+		for _, outputID := range responsesInputItemToolLikeOutputIDs(input[i]) {
+			if _, ok := matched[outputID]; ok {
+				matched[outputID] = true
+			}
+		}
+	}
+	for _, ok := range matched {
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func compactedResponsesMatchingToolCallIndex(input []json.RawMessage, id string, before int) int {
@@ -2012,6 +2071,42 @@ func responsesInputItemToolLikeOutputIDs(raw json.RawMessage) []string {
 		return nil
 	}
 	return responsesInputItemDirectCallIDsFromItem(item)
+}
+
+// responsesInputItemPendingOutputCallIDs returns IDs for calls that must stay
+// available until a later client-provided output item resolves them. Built-in
+// Responses tool calls that do not have client output items are intentionally
+// excluded so old web/search/code-interpreter items can still be compacted.
+func responsesInputItemPendingOutputCallIDs(raw json.RawMessage) []string {
+	var item map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil
+	}
+	if responsesInputItemIsToolLikeOutput(raw) {
+		return nil
+	}
+
+	switch rawJSONString(item["type"]) {
+	case "function_call", "computer_call", "local_shell_call":
+		ids := responsesInputItemDirectCallIDsFromItem(item)
+		if len(ids) == 0 {
+			ids = appendUniqueNonEmptyID(ids, rawJSONString(item["id"]))
+		}
+		return ids
+	case "mcp_approval_request":
+		return appendUniqueNonEmptyID(nil, rawJSONString(item["id"]))
+	}
+
+	var toolCalls []map[string]json.RawMessage
+	if err := json.Unmarshal(item["tool_calls"], &toolCalls); err == nil {
+		var ids []string
+		for _, toolCall := range toolCalls {
+			ids = appendUniqueNonEmptyID(ids, rawJSONString(toolCall["id"]))
+		}
+		return ids
+	}
+
+	return nil
 }
 
 func responsesInputItemToolLikeCallIDs(raw json.RawMessage) []string {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -522,6 +522,14 @@ func (h *ProxyHandler) compactLearnedTargetKeyForRequest(requestFields map[strin
 }
 
 func (h *ProxyHandler) compactResponsesRequestWithBudget(ctx context.Context, requestFields map[string]json.RawMessage, extraHeaders http.Header, budget *compactBudget) (string, *http.Response, error) {
+	if rewrittenFields, rewriteCount := rewriteSyntheticCompactionRequestFields(requestFields); rewriteCount > 0 {
+		requestFields = rewrittenFields
+		h.log.Debug("rewrote compaction items",
+			logger.F("endpoint", "responses/compact/internal"),
+			logger.F("count", rewriteCount),
+		)
+	}
+
 	targetBodySize := h.effectiveCompactChunkBodyBytes()
 	learnedTarget, learned := h.learnedCompactTargetForRequest(requestFields, targetBodySize)
 	if learned {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -2045,6 +2045,7 @@ func responsesInputItemDirectCallIDsFromItem(item map[string]json.RawMessage) []
 	var ids []string
 	ids = appendUniqueNonEmptyID(ids, rawJSONString(item["call_id"]))
 	ids = appendUniqueNonEmptyID(ids, rawJSONString(item["tool_call_id"]))
+	ids = appendUniqueNonEmptyID(ids, rawJSONString(item["approval_request_id"]))
 	return ids
 }
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -1935,12 +1935,18 @@ func compactedResponsesCallIDAlignedTailStart(input []json.RawMessage, start int
 	}
 
 	earliest := start
-	for outputIndex := start; outputIndex < len(input); outputIndex++ {
-		for _, id := range responsesInputItemToolLikeOutputIDs(input[outputIndex]) {
-			callIndex := compactedResponsesMatchingToolCallIndex(input, id, outputIndex)
-			if callIndex >= 0 && callIndex < earliest {
-				earliest = callIndex
+	latestCallIndexByID := make(map[string]int)
+	for itemIndex, raw := range input {
+		if itemIndex >= start {
+			for _, id := range responsesInputItemToolLikeOutputIDs(raw) {
+				if callIndex, ok := latestCallIndexByID[id]; ok && callIndex < earliest {
+					earliest = callIndex
+				}
 			}
+		}
+
+		for _, id := range responsesInputItemToolLikeCallIDs(raw) {
+			latestCallIndexByID[id] = itemIndex
 		}
 	}
 	return earliest
@@ -2002,24 +2008,6 @@ func responsesInputHasToolLikeOutputForAll(input []json.RawMessage, ids []string
 		}
 	}
 	return true
-}
-
-func compactedResponsesMatchingToolCallIndex(input []json.RawMessage, id string, before int) int {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return -1
-	}
-	if before > len(input) {
-		before = len(input)
-	}
-	for i := before - 1; i >= 0; i-- {
-		for _, callID := range responsesInputItemToolLikeCallIDs(input[i]) {
-			if callID == id {
-				return i
-			}
-		}
-	}
-	return -1
 }
 
 func responsesInputItemIsToolLikeCall(raw json.RawMessage) bool {
@@ -2105,13 +2093,15 @@ func responsesInputItemPendingOutputCallIDs(raw json.RawMessage) []string {
 		return appendUniqueNonEmptyID(nil, rawJSONString(item["id"]))
 	}
 
-	var toolCalls []map[string]json.RawMessage
-	if err := json.Unmarshal(item["tool_calls"], &toolCalls); err == nil {
-		var ids []string
-		for _, toolCall := range toolCalls {
-			ids = appendUniqueNonEmptyID(ids, rawJSONString(toolCall["id"]))
+	if rawJSONHasNonEmptyValue(item["tool_calls"]) {
+		var toolCalls []map[string]json.RawMessage
+		if err := json.Unmarshal(item["tool_calls"], &toolCalls); err == nil {
+			var ids []string
+			for _, toolCall := range toolCalls {
+				ids = appendUniqueNonEmptyID(ids, rawJSONString(toolCall["id"]))
+			}
+			return ids
 		}
-		return ids
 	}
 
 	return nil
@@ -2134,10 +2124,12 @@ func responsesInputItemToolLikeCallIDsFromItem(item map[string]json.RawMessage) 
 		ids = appendUniqueNonEmptyID(ids, rawJSONString(item["id"]))
 	}
 
-	var toolCalls []map[string]json.RawMessage
-	if err := json.Unmarshal(item["tool_calls"], &toolCalls); err == nil {
-		for _, toolCall := range toolCalls {
-			ids = appendUniqueNonEmptyID(ids, rawJSONString(toolCall["id"]))
+	if rawJSONHasNonEmptyValue(item["tool_calls"]) {
+		var toolCalls []map[string]json.RawMessage
+		if err := json.Unmarshal(item["tool_calls"], &toolCalls); err == nil {
+			for _, toolCall := range toolCalls {
+				ids = appendUniqueNonEmptyID(ids, rawJSONString(toolCall["id"]))
+			}
 		}
 	}
 

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -548,7 +548,7 @@ func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.
 		return result, false, nil
 	}
 
-	prefixLen := len(s.historyItems) - cfg.AutoCompactKeepTail
+	prefixLen := compactedResponsesAlignedPrefixLen(s.historyItems, cfg.AutoCompactKeepTail)
 	if prefixLen <= 0 {
 		return result, false, nil
 	}

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -621,6 +622,86 @@ func TestHandleResponsesWebSocket_AutoCompactsLongHistory(t *testing.T) {
 	}
 	if got := inputTextFromMessage(t, secondTurnInput[3]); got != "second turn" {
 		t.Fatalf("expected latest user turn to be preserved, got %q", got)
+	}
+}
+
+func TestResponsesWebSocketCompactHistoryKeepsToolPairsAcrossBoundary(t *testing.T) {
+	raw := func(v interface{}) json.RawMessage {
+		t.Helper()
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to marshal raw message: %v", err)
+		}
+		return b
+	}
+	msg := func(role, text string) json.RawMessage {
+		return raw(map[string]interface{}{
+			"type":    "message",
+			"role":    role,
+			"content": []map[string]string{{"type": "input_text", "text": text}},
+		})
+	}
+
+	var compactInput []map[string]interface{}
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream request body: %v", err)
+		}
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Fatalf("failed to decode upstream request body: %v", err)
+		}
+		compactInput = upstreamInputItems(t, body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"comp-tool-pair","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checkpoint summary"}]}]}`)
+	})
+	handler.responsesWS = ResponsesWebSocketConfig{
+		AutoCompactMaxItems: 3,
+		AutoCompactMaxBytes: 1 << 20,
+		AutoCompactKeepTail: 2,
+	}
+
+	session := &responsesWebSocketSession{
+		ctx: context.Background(),
+		historyItems: []json.RawMessage{
+			msg("user", "run a command"),
+			raw(map[string]interface{}{"type": "function_call", "call_id": "call-1", "name": "shell", "arguments": "{}"}),
+			msg("assistant", "thinking between call and output"),
+			raw(map[string]interface{}{"type": "function_call_output", "call_id": "call-1", "output": "done"}),
+			msg("assistant", "command finished"),
+		},
+	}
+	request := &responsesWebSocketCreateRequest{Model: "gpt-5.4"}
+
+	_, compacted, err := session.compactHistory(handler, context.Background(), request, false)
+	if err != nil {
+		t.Fatalf("compactHistory failed: %v", err)
+	}
+	if !compacted {
+		t.Fatal("expected websocket history to compact")
+	}
+
+	if len(compactInput) != 1 {
+		t.Fatalf("expected only pre-pair history to be compacted, got %d items: %#v", len(compactInput), compactInput)
+	}
+	if got := inputTextFromMessage(t, compactInput[0]); got != "run a command" {
+		t.Fatalf("expected compacted prefix to contain first user message, got %q", got)
+	}
+
+	compactedItems := decodeRawMessagesForTest(t, session.historyItems)
+	if len(compactedItems) != 5 {
+		t.Fatalf("expected checkpoint plus intact call/output tail, got %d items: %#v", len(compactedItems), compactedItems)
+	}
+	if got := requireMessageTextWithRole(t, compactedItems[0], "developer"); !strings.Contains(got, "checkpoint summary") {
+		t.Fatalf("expected checkpoint summary in compacted history, got %q", got)
+	}
+	if compactedItems[1]["type"] != "function_call" || compactedItems[1]["call_id"] != "call-1" {
+		t.Fatalf("expected retained function_call for call-1, got %#v", compactedItems[1])
+	}
+	if compactedItems[3]["type"] != "function_call_output" || compactedItems[3]["call_id"] != "call-1" {
+		t.Fatalf("expected retained function_call_output for call-1, got %#v", compactedItems[3])
 	}
 }
 
@@ -1695,6 +1776,17 @@ func upstreamInputItems(t *testing.T, body map[string]interface{}) []map[string]
 		items[idx] = item
 	}
 	return items
+}
+
+func decodeRawMessagesForTest(t *testing.T, items []json.RawMessage) []map[string]interface{} {
+	t.Helper()
+	decoded := make([]map[string]interface{}, len(items))
+	for idx, raw := range items {
+		if err := json.Unmarshal(raw, &decoded[idx]); err != nil {
+			t.Fatalf("failed to decode raw message %d: %v", idx, err)
+		}
+	}
+	return decoded
 }
 
 func inputTextFromMessage(t *testing.T, item map[string]interface{}) string {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -625,6 +625,82 @@ func TestHandleResponsesWebSocket_AutoCompactsLongHistory(t *testing.T) {
 	}
 }
 
+func TestResponsesWebSocketCompactHistoryRewritesPriorSyntheticCheckpoint(t *testing.T) {
+	raw := func(v interface{}) json.RawMessage {
+		t.Helper()
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to marshal raw message: %v", err)
+		}
+		return b
+	}
+	msg := func(role, text string) json.RawMessage {
+		return raw(map[string]interface{}{
+			"type":    "message",
+			"role":    role,
+			"content": []map[string]string{{"type": "input_text", "text": text}},
+		})
+	}
+
+	priorSummary := "prior proxy-owned checkpoint"
+	var compactInput []map[string]interface{}
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream request body: %v", err)
+		}
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Fatalf("failed to decode upstream request body: %v", err)
+		}
+		compactInput = upstreamInputItems(t, body)
+		for _, item := range compactInput {
+			if item["type"] == "compaction" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = fmt.Fprint(w, `{"error":{"message":"encrypted content could not be verified","code":"invalid_request_body"}}`)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"comp-prior-checkpoint","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"merged checkpoint summary"}]}]}`)
+	})
+	handler.responsesWS = ResponsesWebSocketConfig{
+		AutoCompactMaxItems: 2,
+		AutoCompactMaxBytes: 1 << 20,
+		AutoCompactKeepTail: 1,
+	}
+
+	session := &responsesWebSocketSession{
+		ctx: context.Background(),
+		historyItems: []json.RawMessage{
+			raw(map[string]interface{}{"type": "compaction", "encrypted_content": encodeSyntheticCompaction(priorSummary)}),
+			msg("user", "after checkpoint"),
+			msg("assistant", "latest answer"),
+		},
+	}
+	request := &responsesWebSocketCreateRequest{Model: "gpt-5.4"}
+
+	_, compacted, err := session.compactHistory(handler, context.Background(), request, false)
+	if err != nil {
+		t.Fatalf("compactHistory failed: %v", err)
+	}
+	if !compacted {
+		t.Fatal("expected websocket history to compact")
+	}
+
+	if len(compactInput) != 2 {
+		t.Fatalf("expected prior checkpoint plus pre-tail message in compact request, got %d items: %#v", len(compactInput), compactInput)
+	}
+	if got := requireMessageTextWithRole(t, compactInput[0], "developer"); !strings.Contains(got, priorSummary) {
+		t.Fatalf("expected prior synthetic checkpoint to be rewritten before upstream compaction, got %q", got)
+	}
+	if got := inputTextFromMessage(t, compactInput[1]); got != "after checkpoint" {
+		t.Fatalf("expected pre-tail user message to be preserved, got %q", got)
+	}
+}
+
 func TestResponsesWebSocketCompactHistoryKeepsToolPairsAcrossBoundary(t *testing.T) {
 	raw := func(v interface{}) json.RawMessage {
 		t.Helper()


### PR DESCRIPTION
## Summary
- Align Responses 413 fallback compaction by tool/function call IDs instead of adjacency alone
- Preserve matching tool/function calls when retained tail contains outputs with `call_id` / `tool_call_id`
- Preserve MCP approval request/result alignment during compaction
- Fix WebSocket session compaction so tool-call pairs are kept together across compaction boundaries
- Rewrite proxy-owned synthetic `vekil.compaction.v1:...` checkpoints during internal WebSocket auto-compaction requests before sending them upstream
- Prevent upstream from receiving raw proxy-owned checkpoint encrypted content and rejecting it with `encrypted content could not be verified`

## Tests
- `go test ./proxy/ -run 'TestResponsesWebSocketCompactHistoryRewritesPriorSyntheticCheckpoint|TestResponsesWebSocketCompactHistoryKeepsToolPairsAcrossBoundary|TestCompactedResponsesAlignedPrefixLen' -count=1 -v`
- `go test ./proxy/`
- `make`
