### PR TITLE
Forward Codex response metadata headers

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -769,7 +769,7 @@ func TestHandleResponses_RoutesConfiguredAzureModelAndPreservesPriorityServiceTi
 
 func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	var gotOpenAIBeta, gotLegacySessionID, gotSessionID, gotThreadID, gotClientRequestID, gotInstallationID string
-	var gotInferenceCallID, gotTurnMetadata, gotParentThreadID, gotWindowID, gotSubagent string
+	var gotInferenceCallID, gotTurnMetadata, gotParentThreadID, gotWindowID, gotSubagent, gotMemgen string
 	var gotAttestation, gotTimingMetrics, gotTraceparent, gotTracestate string
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		gotOpenAIBeta = r.Header.Get("OpenAI-Beta")
@@ -783,6 +783,7 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 		gotParentThreadID = r.Header.Get("X-Codex-Parent-Thread-Id")
 		gotWindowID = r.Header.Get("X-Codex-Window-Id")
 		gotSubagent = r.Header.Get("X-OpenAI-Subagent")
+		gotMemgen = r.Header.Get("X-OpenAI-Memgen-Request")
 		gotAttestation = r.Header.Get("X-OAI-Attestation")
 		gotTimingMetrics = r.Header.Get("X-ResponsesAPI-Include-Timing-Metrics")
 		gotTraceparent = r.Header.Get("Traceparent")
@@ -804,6 +805,7 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	req.Header.Set("X-Codex-Parent-Thread-Id", "parent-123")
 	req.Header.Set("X-Codex-Window-Id", "thread-abc-123:2")
 	req.Header.Set("X-OpenAI-Subagent", "collab_spawn")
+	req.Header.Set("X-OpenAI-Memgen-Request", "true")
 	req.Header.Set("X-OAI-Attestation", "attestation-token")
 	req.Header.Set("X-ResponsesAPI-Include-Timing-Metrics", "true")
 	req.Header.Set("Traceparent", "00-11111111111111111111111111111111-2222222222222222-01")
@@ -850,6 +852,9 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	}
 	if gotSubagent != "collab_spawn" {
 		t.Fatalf("expected X-OpenAI-Subagent to be forwarded, got %q", gotSubagent)
+	}
+	if gotMemgen != "true" {
+		t.Fatalf("expected X-OpenAI-Memgen-Request to be forwarded, got %q", gotMemgen)
 	}
 	if gotAttestation != "attestation-token" {
 		t.Fatalf("expected X-OAI-Attestation to be forwarded, got %q", gotAttestation)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -769,6 +769,8 @@ func TestHandleResponses_RoutesConfiguredAzureModelAndPreservesPriorityServiceTi
 
 func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	var gotOpenAIBeta, gotLegacySessionID, gotSessionID, gotThreadID, gotClientRequestID, gotInstallationID string
+	var gotInferenceCallID, gotTurnMetadata, gotParentThreadID, gotWindowID, gotSubagent string
+	var gotAttestation, gotTimingMetrics, gotTraceparent, gotTracestate string
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		gotOpenAIBeta = r.Header.Get("OpenAI-Beta")
 		gotLegacySessionID = r.Header.Get("session_id")
@@ -776,6 +778,15 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 		gotThreadID = r.Header.Get("thread-id")
 		gotClientRequestID = r.Header.Get("X-Client-Request-Id")
 		gotInstallationID = r.Header.Get("X-Codex-Installation-Id")
+		gotInferenceCallID = r.Header.Get("X-Codex-Inference-Call-Id")
+		gotTurnMetadata = r.Header.Get("X-Codex-Turn-Metadata")
+		gotParentThreadID = r.Header.Get("X-Codex-Parent-Thread-Id")
+		gotWindowID = r.Header.Get("X-Codex-Window-Id")
+		gotSubagent = r.Header.Get("X-OpenAI-Subagent")
+		gotAttestation = r.Header.Get("X-OAI-Attestation")
+		gotTimingMetrics = r.Header.Get("X-ResponsesAPI-Include-Timing-Metrics")
+		gotTraceparent = r.Header.Get("Traceparent")
+		gotTracestate = r.Header.Get("Tracestate")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"resp-headers","object":"response","status":"completed"}`))
 	})
@@ -788,6 +799,15 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	req.Header.Set("thread-id", "thread-abc-123")
 	req.Header.Set("X-Client-Request-Id", "client-req-456")
 	req.Header.Set("X-Codex-Installation-Id", "install-789")
+	req.Header.Set("X-Codex-Inference-Call-Id", "inference-123")
+	req.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"turn-1"}`)
+	req.Header.Set("X-Codex-Parent-Thread-Id", "parent-123")
+	req.Header.Set("X-Codex-Window-Id", "thread-abc-123:2")
+	req.Header.Set("X-OpenAI-Subagent", "collab_spawn")
+	req.Header.Set("X-OAI-Attestation", "attestation-token")
+	req.Header.Set("X-ResponsesAPI-Include-Timing-Metrics", "true")
+	req.Header.Set("Traceparent", "00-11111111111111111111111111111111-2222222222222222-01")
+	req.Header.Set("Tracestate", "vendor=value")
 	w := httptest.NewRecorder()
 
 	handler.HandleResponses(w, req)
@@ -815,6 +835,33 @@ func TestHandleResponses_ForwardsCodexClientHeaders(t *testing.T) {
 	}
 	if gotInstallationID != "install-789" {
 		t.Fatalf("expected X-Codex-Installation-Id to be forwarded, got %q", gotInstallationID)
+	}
+	if gotInferenceCallID != "inference-123" {
+		t.Fatalf("expected X-Codex-Inference-Call-Id to be forwarded, got %q", gotInferenceCallID)
+	}
+	if gotTurnMetadata != `{"turn_id":"turn-1"}` {
+		t.Fatalf("expected X-Codex-Turn-Metadata to be forwarded, got %q", gotTurnMetadata)
+	}
+	if gotParentThreadID != "parent-123" {
+		t.Fatalf("expected X-Codex-Parent-Thread-Id to be forwarded, got %q", gotParentThreadID)
+	}
+	if gotWindowID != "thread-abc-123:2" {
+		t.Fatalf("expected X-Codex-Window-Id to be forwarded, got %q", gotWindowID)
+	}
+	if gotSubagent != "collab_spawn" {
+		t.Fatalf("expected X-OpenAI-Subagent to be forwarded, got %q", gotSubagent)
+	}
+	if gotAttestation != "attestation-token" {
+		t.Fatalf("expected X-OAI-Attestation to be forwarded, got %q", gotAttestation)
+	}
+	if gotTimingMetrics != "true" {
+		t.Fatalf("expected X-ResponsesAPI-Include-Timing-Metrics to be forwarded, got %q", gotTimingMetrics)
+	}
+	if gotTraceparent != "00-11111111111111111111111111111111-2222222222222222-01" {
+		t.Fatalf("expected Traceparent to be forwarded, got %q", gotTraceparent)
+	}
+	if gotTracestate != "vendor=value" {
+		t.Fatalf("expected Tracestate to be forwarded, got %q", gotTracestate)
 	}
 }
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -25,6 +25,7 @@ func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 
 	for _, name := range []string{
 		"X-OpenAI-Subagent",
+		"X-OpenAI-Memgen-Request",
 		"OpenAI-Beta",
 		"session_id",
 		"session-id",
@@ -32,10 +33,15 @@ func responsesExtraHeadersFromRequest(r *http.Request) http.Header {
 		"X-Client-Request-Id",
 		"X-Codex-Installation-Id",
 		"X-Codex-Beta-Features",
+		"X-Codex-Inference-Call-Id",
 		"X-Codex-Turn-State",
 		"X-Codex-Turn-Metadata",
 		"X-Codex-Parent-Thread-Id",
 		"X-Codex-Window-Id",
+		"X-OAI-Attestation",
+		"X-ResponsesAPI-Include-Timing-Metrics",
+		"Traceparent",
+		"Tracestate",
 	} {
 		for _, value := range r.Header.Values(name) {
 			if trimmed := strings.TrimSpace(value); trimmed != "" {

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -200,7 +200,25 @@ func parseResponsesWebSocketFrameType(payload []byte) (string, error) {
 
 func newResponsesWebSocketSession(conn *websocket.Conn, r *http.Request) *responsesWebSocketSession {
 	baseHeaders := make(http.Header)
-	for _, name := range []string{"X-Codex-Beta-Features", "X-Codex-Turn-Metadata", "OpenAI-Beta", "session_id", "session-id", "thread-id", "X-Client-Request-Id", "X-Codex-Installation-Id", "X-OpenAI-Subagent"} {
+	for _, name := range []string{
+		"X-Codex-Beta-Features",
+		"X-Codex-Turn-Metadata",
+		"OpenAI-Beta",
+		"session_id",
+		"session-id",
+		"thread-id",
+		"X-Client-Request-Id",
+		"X-Codex-Installation-Id",
+		"X-Codex-Inference-Call-Id",
+		"X-Codex-Parent-Thread-Id",
+		"X-Codex-Window-Id",
+		"X-OAI-Attestation",
+		"X-OpenAI-Memgen-Request",
+		"X-OpenAI-Subagent",
+		"X-ResponsesAPI-Include-Timing-Metrics",
+		"Traceparent",
+		"Tracestate",
+	} {
 		for _, value := range r.Header.Values(name) {
 			baseHeaders.Add(name, value)
 		}
@@ -483,9 +501,12 @@ func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCr
 			continue
 		}
 
+		if name := responsesWebSocketMetadataHeaderName(key); name != "" {
+			headers.Set(name, trimmed)
+			continue
+		}
+
 		switch {
-		case strings.EqualFold(key, "x-codex-turn-metadata"):
-			headers.Set("X-Codex-Turn-Metadata", trimmed)
 		case strings.HasPrefix(key, responsesWebSocketRequestHeaderPrefix):
 			name := strings.TrimSpace(strings.TrimPrefix(key, responsesWebSocketRequestHeaderPrefix))
 			if name != "" && !strings.EqualFold(name, "X-Codex-Turn-State") {
@@ -499,6 +520,33 @@ func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCr
 	}
 
 	return headers
+}
+
+func responsesWebSocketMetadataHeaderName(key string) string {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "x-codex-installation-id":
+		return "X-Codex-Installation-Id"
+	case "x-codex-inference-call-id":
+		return "X-Codex-Inference-Call-Id"
+	case "x-codex-parent-thread-id":
+		return "X-Codex-Parent-Thread-Id"
+	case "x-codex-turn-metadata":
+		return "X-Codex-Turn-Metadata"
+	case "x-codex-window-id":
+		return "X-Codex-Window-Id"
+	case "x-codex-ws-stream-request-start-ms":
+		return "X-Codex-WS-Stream-Request-Start-Ms"
+	case "x-oai-attestation":
+		return "X-OAI-Attestation"
+	case "x-openai-memgen-request":
+		return "X-OpenAI-Memgen-Request"
+	case "x-openai-subagent":
+		return "X-OpenAI-Subagent"
+	case "x-responsesapi-include-timing-metrics":
+		return "X-ResponsesAPI-Include-Timing-Metrics"
+	default:
+		return ""
+	}
 }
 
 func (s *responsesWebSocketSession) updateTurnState(headers http.Header) {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -121,6 +121,9 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		if got := r.Header.Get("X-OpenAI-Subagent"); got != "collab_spawn" {
 			t.Fatalf("expected subagent header to be forwarded, got %q", got)
 		}
+		if got := r.Header.Get("X-OpenAI-Memgen-Request"); got != "true" {
+			t.Fatalf("expected memgen header to be forwarded, got %q", got)
+		}
 		if got := r.Header.Get("X-ResponsesAPI-Include-Timing-Metrics"); got != "true" {
 			t.Fatalf("expected timing metrics header to be forwarded, got %q", got)
 		}
@@ -187,6 +190,7 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		"x-codex-window-id":                         "thread-1:3",
 		"x-codex-parent-thread-id":                  "parent-thread-1",
 		"x-openai-subagent":                         "collab_spawn",
+		"x-openai-memgen-request":                   "true",
 		"x-responsesapi-include-timing-metrics":     "true",
 		"x-codex-ws-stream-request-start-ms":        "1738888888123",
 		"ws_request_header_x-codex-turn-state":      "client-state-should-not-forward",
@@ -2332,7 +2336,7 @@ func TestHandleResponsesWebSocket_ForwardsOpenAIBetaHeader(t *testing.T) {
 
 func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *testing.T) {
 	var gotLegacySessionID, gotSessionID, gotThreadID, gotClientRequestID, gotInstallationID string
-	var gotInferenceCallID, gotParentThreadID, gotWindowID, gotSubagent, gotAttestation, gotTimingMetrics string
+	var gotInferenceCallID, gotParentThreadID, gotWindowID, gotSubagent, gotMemgen, gotAttestation, gotTimingMetrics string
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		gotLegacySessionID = r.Header.Get("session_id")
 		gotSessionID = r.Header.Get("session-id")
@@ -2343,6 +2347,7 @@ func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *test
 		gotParentThreadID = r.Header.Get("X-Codex-Parent-Thread-Id")
 		gotWindowID = r.Header.Get("X-Codex-Window-Id")
 		gotSubagent = r.Header.Get("X-OpenAI-Subagent")
+		gotMemgen = r.Header.Get("X-OpenAI-Memgen-Request")
 		gotAttestation = r.Header.Get("X-OAI-Attestation")
 		gotTimingMetrics = r.Header.Get("X-ResponsesAPI-Include-Timing-Metrics")
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -2361,6 +2366,7 @@ func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *test
 		"X-Codex-Parent-Thread-Id":              []string{"parent-123"},
 		"X-Codex-Window-Id":                     []string{"thread-123:4"},
 		"X-OpenAI-Subagent":                     []string{"collab_spawn"},
+		"X-OpenAI-Memgen-Request":               []string{"true"},
 		"X-OAI-Attestation":                     []string{"attestation-token"},
 		"X-ResponsesAPI-Include-Timing-Metrics": []string{"true"},
 	})
@@ -2408,6 +2414,9 @@ func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *test
 	}
 	if gotSubagent != "collab_spawn" {
 		t.Fatalf("expected X-OpenAI-Subagent to be forwarded upstream, got %q", gotSubagent)
+	}
+	if gotMemgen != "true" {
+		t.Fatalf("expected X-OpenAI-Memgen-Request to be forwarded upstream, got %q", gotMemgen)
 	}
 	if gotAttestation != "attestation-token" {
 		t.Fatalf("expected X-OAI-Attestation to be forwarded upstream, got %q", gotAttestation)

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -100,8 +100,32 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		if got := r.Header.Get("Traceparent"); got != "00-11111111111111111111111111111111-2222222222222222-01" {
 			t.Fatalf("expected traceparent header to be forwarded, got %q", got)
 		}
+		if got := r.Header.Get("X-Custom-Test-Telemetry"); got != "custom-value" {
+			t.Fatalf("expected custom telemetry header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-Codex-Turn-State"); got != "" {
+			t.Fatalf("expected client metadata turn state not to be forwarded, got %q", got)
+		}
 		if got := r.Header.Get("X-Codex-Turn-Metadata"); got != `{"turn_id":"turn-1"}` {
 			t.Fatalf("expected turn metadata header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-Codex-Installation-Id"); got != "install-123" {
+			t.Fatalf("expected installation id header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-Codex-Window-Id"); got != "thread-1:3" {
+			t.Fatalf("expected window id header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-Codex-Parent-Thread-Id"); got != "parent-thread-1" {
+			t.Fatalf("expected parent thread id header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-OpenAI-Subagent"); got != "collab_spawn" {
+			t.Fatalf("expected subagent header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-ResponsesAPI-Include-Timing-Metrics"); got != "true" {
+			t.Fatalf("expected timing metrics header to be forwarded, got %q", got)
+		}
+		if got := r.Header.Get("X-Codex-WS-Stream-Request-Start-Ms"); got != "1738888888123" {
+			t.Fatalf("expected websocket stream start header to be forwarded, got %q", got)
 		}
 		if got := r.Header.Get("X-Codex-Beta-Features"); got != "responses_websockets_v2" {
 			t.Fatalf("expected beta features header to be forwarded, got %q", got)
@@ -157,8 +181,16 @@ func TestHandleResponsesWebSocket_BridgesStreamingResponse(t *testing.T) {
 		},
 	})
 	request["client_metadata"] = map[string]string{
-		"ws_request_header_traceparent": "00-11111111111111111111111111111111-2222222222222222-01",
-		"x-codex-turn-metadata":         `{"turn_id":"turn-1"}`,
+		"ws_request_header_traceparent":             "00-11111111111111111111111111111111-2222222222222222-01",
+		"x-codex-turn-metadata":                     `{"turn_id":"turn-1"}`,
+		"x-codex-installation-id":                   "install-123",
+		"x-codex-window-id":                         "thread-1:3",
+		"x-codex-parent-thread-id":                  "parent-thread-1",
+		"x-openai-subagent":                         "collab_spawn",
+		"x-responsesapi-include-timing-metrics":     "true",
+		"x-codex-ws-stream-request-start-ms":        "1738888888123",
+		"ws_request_header_x-codex-turn-state":      "client-state-should-not-forward",
+		"ws_request_header_x-custom-test-telemetry": "custom-value",
 	}
 	request["initiator"] = "user"
 	request["service_tier"] = "auto"
@@ -2300,12 +2332,19 @@ func TestHandleResponsesWebSocket_ForwardsOpenAIBetaHeader(t *testing.T) {
 
 func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *testing.T) {
 	var gotLegacySessionID, gotSessionID, gotThreadID, gotClientRequestID, gotInstallationID string
+	var gotInferenceCallID, gotParentThreadID, gotWindowID, gotSubagent, gotAttestation, gotTimingMetrics string
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		gotLegacySessionID = r.Header.Get("session_id")
 		gotSessionID = r.Header.Get("session-id")
 		gotThreadID = r.Header.Get("thread-id")
 		gotClientRequestID = r.Header.Get("X-Client-Request-Id")
 		gotInstallationID = r.Header.Get("X-Codex-Installation-Id")
+		gotInferenceCallID = r.Header.Get("X-Codex-Inference-Call-Id")
+		gotParentThreadID = r.Header.Get("X-Codex-Parent-Thread-Id")
+		gotWindowID = r.Header.Get("X-Codex-Window-Id")
+		gotSubagent = r.Header.Get("X-OpenAI-Subagent")
+		gotAttestation = r.Header.Get("X-OAI-Attestation")
+		gotTimingMetrics = r.Header.Get("X-ResponsesAPI-Include-Timing-Metrics")
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = fmt.Fprint(w, "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-sess\"}}\n\n")
 		_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-sess\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n")
@@ -2313,11 +2352,17 @@ func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *test
 
 	server := startResponsesWebSocketProxyServer(t, handler)
 	conn := mustDialResponsesWebSocket(t, server, http.Header{
-		"session_id":              []string{"conv-legacy-123"},
-		"session-id":              []string{"conv-123"},
-		"thread-id":               []string{"thread-123"},
-		"X-Client-Request-Id":     []string{"req-456"},
-		"X-Codex-Installation-Id": []string{"install-789"},
+		"session_id":                            []string{"conv-legacy-123"},
+		"session-id":                            []string{"conv-123"},
+		"thread-id":                             []string{"thread-123"},
+		"X-Client-Request-Id":                   []string{"req-456"},
+		"X-Codex-Installation-Id":               []string{"install-789"},
+		"X-Codex-Inference-Call-Id":             []string{"inference-123"},
+		"X-Codex-Parent-Thread-Id":              []string{"parent-123"},
+		"X-Codex-Window-Id":                     []string{"thread-123:4"},
+		"X-OpenAI-Subagent":                     []string{"collab_spawn"},
+		"X-OAI-Attestation":                     []string{"attestation-token"},
+		"X-ResponsesAPI-Include-Timing-Metrics": []string{"true"},
 	})
 	defer func() { _ = conn.Close() }()
 
@@ -2351,6 +2396,24 @@ func TestHandleResponsesWebSocket_ForwardsSessionAndClientRequestHeaders(t *test
 	}
 	if gotInstallationID != "install-789" {
 		t.Fatalf("expected X-Codex-Installation-Id to be forwarded upstream, got %q", gotInstallationID)
+	}
+	if gotInferenceCallID != "inference-123" {
+		t.Fatalf("expected X-Codex-Inference-Call-Id to be forwarded upstream, got %q", gotInferenceCallID)
+	}
+	if gotParentThreadID != "parent-123" {
+		t.Fatalf("expected X-Codex-Parent-Thread-Id to be forwarded upstream, got %q", gotParentThreadID)
+	}
+	if gotWindowID != "thread-123:4" {
+		t.Fatalf("expected X-Codex-Window-Id to be forwarded upstream, got %q", gotWindowID)
+	}
+	if gotSubagent != "collab_spawn" {
+		t.Fatalf("expected X-OpenAI-Subagent to be forwarded upstream, got %q", gotSubagent)
+	}
+	if gotAttestation != "attestation-token" {
+		t.Fatalf("expected X-OAI-Attestation to be forwarded upstream, got %q", gotAttestation)
+	}
+	if gotTimingMetrics != "true" {
+		t.Fatalf("expected X-ResponsesAPI-Include-Timing-Metrics to be forwarded upstream, got %q", gotTimingMetrics)
 	}
 }
 


### PR DESCRIPTION
## Summary
- forward the current Codex Responses HTTP header set, including attestation, timing, trace, inference-call, parent/window, and memgen headers
- promote known Responses websocket client_metadata keys into upstream headers
- keep client-supplied websocket turn-state metadata blocked so proxy-owned turn-state remains authoritative

## Tests
- go test ./proxy/ -run 'TestHandleResponses_ForwardsCodexClientHeaders|TestHandleResponses_ZstdBody|TestHandleResponsesWebSocket_(BridgesStreamingResponse|ForwardsSessionAndClientRequestHeaders|TurnStateDeltaReplayUsesOnlyCurrentInputAndIgnoresClientTurnStateHeader)' -count=1\n- go test ./proxy/ -count=1\n- go test ./... -count=1\n- git diff --check