### PR TITLE
Default server bind to localhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /vekil .
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /vekil /vekil
+ENV HOST=0.0.0.0
 EXPOSE 1337
 ENTRYPOINT ["/vekil"]

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -181,7 +181,7 @@ func startProxy() {
 	nextSrv, err := server.New(
 		authenticator,
 		log,
-		"0.0.0.0",
+		"127.0.0.1",
 		"1337",
 		server.WithProxyOptions(proxy.WithProvidersConfig(providersCfg)),
 	)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,8 @@ Vekil supports two runtime patterns:
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
+Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.
+
 ## Copilot Header Overrides
 
 These overrides only affect Copilot-backed upstream requests.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ Vekil supports two runtime patterns:
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|
 | `--port` | `PORT` | `1337` | Listen port |
-| `--host` | `HOST` | `0.0.0.0` | Listen host |
+| `--host` | `HOST` | `127.0.0.1` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,8 @@ docker run -p 1337:1337 \
   ghcr.io/sozercan/vekil:latest
 ```
 
+The container image sets `HOST=0.0.0.0` so Docker port publishing can reach the proxy. Native binary and tray-app runs default to `127.0.0.1`; set `HOST=0.0.0.0` or pass `--host 0.0.0.0` only when you intentionally need a network-reachable listener.
+
 If you use explicit provider routing, mount your JSON or YAML config file and pass `--providers-config`:
 
 ```bash

--- a/k8s/vekil.yaml
+++ b/k8s/vekil.yaml
@@ -19,6 +19,8 @@ spec:
           ports:
             - containerPort: 1337
           env:
+            - name: HOST
+              value: "0.0.0.0"
             - name: PORT
               value: "1337"
             - name: TOKEN_DIR

--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ type serveFlags struct {
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
 	return serveFlags{
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
-		host:                            fs.String("host", getEnv("HOST", "0.0.0.0"), "Listen host"),
+		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),


### PR DESCRIPTION
## Summary
- default the server bind address to localhost in both app entry points
- update configuration docs to match the new default

## Tests
- Not run (PR creation only).