### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -36,7 +36,9 @@ var accessTokenEnvVars = []string{
 }
 
 var (
-	githubCLITokenTimeout = 5 * time.Second
+	githubCLITokenTimeout           = 5 * time.Second
+	deviceCodeOutput      io.Writer = os.Stderr
+	deviceCodeOutputMu    sync.RWMutex
 
 	githubCLICommonPaths = []string{
 		"/opt/homebrew/bin/gh",
@@ -52,6 +54,31 @@ var (
 	// but can no longer be exchanged for a Copilot token.
 	ErrInvalidAccessToken = errors.New("invalid access token")
 )
+
+// SetDeviceCodeOutput overrides where non-error device-code prompts are
+// written. It returns a restore function for scoped use.
+func SetDeviceCodeOutput(w io.Writer) func() {
+	if w == nil {
+		w = io.Discard
+	}
+
+	deviceCodeOutputMu.Lock()
+	prev := deviceCodeOutput
+	deviceCodeOutput = w
+	deviceCodeOutputMu.Unlock()
+
+	return func() {
+		deviceCodeOutputMu.Lock()
+		deviceCodeOutput = prev
+		deviceCodeOutputMu.Unlock()
+	}
+}
+
+func currentDeviceCodeOutput() io.Writer {
+	deviceCodeOutputMu.RLock()
+	defer deviceCodeOutputMu.RUnlock()
+	return deviceCodeOutput
+}
 
 // Authenticator manages GitHub OAuth and Copilot API tokens.
 // It handles the device code flow, token caching to disk, and automatic
@@ -515,7 +542,7 @@ func (a *Authenticator) deviceCodeFlow(ctx context.Context) error {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
+	_, _ = fmt.Fprintf(currentDeviceCodeOutput(), "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
 
 	return a.pollForAuthorization(ctx, dcResp)
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -1,15 +1,18 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1429,5 +1432,62 @@ func TestRefreshToken_AutoDeviceFlowReturnsTransientRefreshError(t *testing.T) {
 	}
 	if got := err.Error(); got != "copilot token request failed with status 502: gateway unavailable" {
 		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestSetDeviceCodeOutputSuppressesPrompt(t *testing.T) {
+	a := &Authenticator{
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.String() != deviceCodeURL {
+					t.Fatalf("unexpected request URL: %s", req.URL.String())
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(
+						`{"device_code":"dc_test","user_code":"ABCD-1234","verification_uri":"https://github.com/login/device","expires_in":0,"interval":0}`,
+					)),
+				}, nil
+			}),
+		},
+	}
+
+	run := func(quiet bool) string {
+		t.Helper()
+
+		old := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe(): %v", err)
+		}
+		os.Stderr = w
+
+		output := io.Writer(os.Stderr)
+		if quiet {
+			output = io.Discard
+		}
+		restore := SetDeviceCodeOutput(output)
+		err = a.deviceCodeFlow(context.Background())
+		restore()
+		if err == nil || !strings.Contains(err.Error(), "device code flow timed out") {
+			t.Fatalf("deviceCodeFlow() error = %v, want timeout", err)
+		}
+
+		_ = w.Close()
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		return buf.String()
+	}
+
+	if got := run(false); !strings.Contains(got, "Please visit https://github.com/login/device and enter code: ABCD-1234") {
+		t.Fatalf("normal output missing device-code prompt: %q", got)
+	}
+
+	if got := run(true); got != "" {
+		t.Fatalf("quiet output should suppress device-code prompt: %q", got)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ Vekil supports two runtime patterns:
 | `--host` | `HOST` | `127.0.0.1` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
+| `--quiet` | — | `false` | Suppress non-error output |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 

--- a/main.go
+++ b/main.go
@@ -215,6 +215,7 @@ type serveFlags struct {
 	host                            *string
 	tokenDir                        *string
 	providersConfigPath             *string
+	quiet                           *bool
 	logLevel                        *string
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
@@ -240,6 +241,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
@@ -258,6 +260,14 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
 	}
+}
+
+func (f serveFlags) loggerLevel() logger.Level {
+	level := logger.ParseLevel(*f.logLevel)
+	if *f.quiet && level < logger.LevelError {
+		return logger.LevelError
+	}
+	return level
 }
 
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
@@ -286,7 +296,7 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.loggerLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -374,23 +373,17 @@ func configureServeNonErrorOutput(args []string) func() {
 }
 
 func serveQuietRequested(args []string) bool {
-	for _, arg := range args {
-		switch arg {
-		case "--quiet", "-quiet":
-			return true
-		}
+	restoreOutput := setServeNonErrorOutput(io.Discard)
+	defer restoreOutput()
 
-		if strings.HasPrefix(arg, "--quiet=") || strings.HasPrefix(arg, "-quiet=") {
-			_, value, found := strings.Cut(arg, "=")
-			if !found {
-				continue
-			}
-			parsed, err := strconv.ParseBool(value)
-			return err == nil && parsed
-		}
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	serve := registerServeFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return false
 	}
 
-	return false
+	return *serve.quiet
 }
 
 func serveNonErrorWriter() io.Writer {

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 type cliCommand int
 
-var serveNonErrorOutput io.Writer = os.Stderr
+var serveNonErrorOutput io.Writer
 
 const (
 	cliCommandServe cliCommand = iota
@@ -393,6 +393,13 @@ func serveQuietRequested(args []string) bool {
 	return false
 }
 
+func serveNonErrorWriter() io.Writer {
+	if serveNonErrorOutput != nil {
+		return serveNonErrorOutput
+	}
+	return os.Stderr
+}
+
 func setServeNonErrorOutput(w io.Writer) func() {
 	if w == nil {
 		w = io.Discard
@@ -420,7 +427,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(serveNonErrorOutput, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(serveNonErrorWriter(), "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -433,7 +440,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(serveNonErrorOutput, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		_, _ = fmt.Fprintf(serveNonErrorWriter(), "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -446,7 +453,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(serveNonErrorOutput, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(serveNonErrorWriter(), "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 )
 
 type cliCommand int
+
+var serveNonErrorOutput io.Writer = os.Stderr
 
 const (
 	cliCommandServe cliCommand = iota
@@ -293,6 +296,9 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 }
 
 func runServe() {
+	restoreOutput := configureServeNonErrorOutput(os.Args[1:])
+	defer restoreOutput()
+
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -352,6 +358,54 @@ func runServe() {
 	log.Info("server stopped")
 }
 
+func configureServeNonErrorOutput(args []string) func() {
+	output := io.Writer(os.Stderr)
+	if serveQuietRequested(args) {
+		output = io.Discard
+	}
+
+	restoreServeOutput := setServeNonErrorOutput(output)
+	restoreAuthOutput := auth.SetDeviceCodeOutput(output)
+
+	return func() {
+		restoreAuthOutput()
+		restoreServeOutput()
+	}
+}
+
+func serveQuietRequested(args []string) bool {
+	for _, arg := range args {
+		switch arg {
+		case "--quiet", "-quiet":
+			return true
+		}
+
+		if strings.HasPrefix(arg, "--quiet=") || strings.HasPrefix(arg, "-quiet=") {
+			_, value, found := strings.Cut(arg, "=")
+			if !found {
+				continue
+			}
+			parsed, err := strconv.ParseBool(value)
+			return err == nil && parsed
+		}
+	}
+
+	return false
+}
+
+func setServeNonErrorOutput(w io.Writer) func() {
+	if w == nil {
+		w = io.Discard
+	}
+
+	prev := serveNonErrorOutput
+	serveNonErrorOutput = w
+
+	return func() {
+		serveNonErrorOutput = prev
+	}
+}
+
 func getEnv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -366,7 +420,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(serveNonErrorOutput, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -379,7 +433,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		_, _ = fmt.Fprintf(serveNonErrorOutput, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -392,7 +446,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(serveNonErrorOutput, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed

--- a/main_test.go
+++ b/main_test.go
@@ -230,6 +230,41 @@ func TestServeFlagsQuietSuppressesNonErrorOutput(t *testing.T) {
 	}
 }
 
+func TestConfigureServeNonErrorOutputQuietSuppressesServeWarnings(t *testing.T) {
+	const envKey = "RESPONSES_WS_ENABLED"
+	t.Setenv(envKey, "notabool")
+
+	var normal bytes.Buffer
+	restore := setServeNonErrorOutput(&normal)
+	_ = getEnvBool(envKey, false)
+	restore()
+
+	want := fmt.Sprintf("warning: ignoring invalid %s=%q", envKey, "notabool")
+	if got := normal.String(); !strings.Contains(got, want) {
+		t.Fatalf("normal output missing warning %q: %q", want, got)
+	}
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	os.Stderr = w
+
+	restore = configureServeNonErrorOutput([]string{"--quiet"})
+	_ = getEnvBool(envKey, false)
+	restore()
+
+	_ = w.Close()
+	os.Stderr = old
+
+	var quiet bytes.Buffer
+	_, _ = quiet.ReadFrom(r)
+	if got := quiet.String(); got != "" {
+		t.Fatalf("quiet output should suppress serve warning: %q", got)
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,47 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsQuietSuppressesNonErrorOutput(t *testing.T) {
+	run := func(args ...string) string {
+		t.Helper()
+		serve := parseServeFlagsForTest(t, args...)
+
+		old := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe(): %v", err)
+		}
+		os.Stderr = w
+
+		log := logger.New(serve.loggerLevel())
+		log.Info("info should be hidden only when quiet")
+		log.Error("error should still be shown")
+
+		_ = w.Close()
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		return buf.String()
+	}
+
+	normalOutput := run()
+	if !strings.Contains(normalOutput, `"msg":"info should be hidden only when quiet"`) {
+		t.Fatalf("normal output missing info log: %q", normalOutput)
+	}
+	if !strings.Contains(normalOutput, `"msg":"error should still be shown"`) {
+		t.Fatalf("normal output missing error log: %q", normalOutput)
+	}
+
+	quietOutput := run("--quiet")
+	if strings.Contains(quietOutput, `"msg":"info should be hidden only when quiet"`) {
+		t.Fatalf("quiet output should suppress info log: %q", quietOutput)
+	}
+	if !strings.Contains(quietOutput, `"msg":"error should still be shown"`) {
+		t.Fatalf("quiet output missing error log: %q", quietOutput)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -233,35 +233,51 @@ func TestServeFlagsQuietSuppressesNonErrorOutput(t *testing.T) {
 func TestConfigureServeNonErrorOutputQuietSuppressesServeWarnings(t *testing.T) {
 	const envKey = "RESPONSES_WS_ENABLED"
 	t.Setenv(envKey, "notabool")
-
-	var normal bytes.Buffer
-	restore := setServeNonErrorOutput(&normal)
-	_ = getEnvBool(envKey, false)
-	restore()
-
 	want := fmt.Sprintf("warning: ignoring invalid %s=%q", envKey, "notabool")
-	if got := normal.String(); !strings.Contains(got, want) {
-		t.Fatalf("normal output missing warning %q: %q", want, got)
+
+	tests := []struct {
+		name           string
+		args           []string
+		wantSuppressed bool
+	}{
+		{name: "default output preserved"},
+		{name: "quiet suppresses warning", args: []string{"--quiet"}, wantSuppressed: true},
+		{name: "last quiet flag wins", args: []string{"--quiet=false", "--quiet"}, wantSuppressed: true},
+		{name: "last quiet false preserves warning", args: []string{"--quiet", "--quiet=false"}},
+		{name: "double dash stops quiet parsing", args: []string{"--", "--quiet"}},
 	}
 
-	old := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe(): %v", err)
-	}
-	os.Stderr = w
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := os.Stderr
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("os.Pipe(): %v", err)
+			}
+			os.Stderr = w
 
-	restore = configureServeNonErrorOutput([]string{"--quiet"})
-	_ = getEnvBool(envKey, false)
-	restore()
+			restore := configureServeNonErrorOutput(tc.args)
+			_ = getEnvBool(envKey, false)
+			restore()
 
-	_ = w.Close()
-	os.Stderr = old
+			_ = w.Close()
+			os.Stderr = old
 
-	var quiet bytes.Buffer
-	_, _ = quiet.ReadFrom(r)
-	if got := quiet.String(); got != "" {
-		t.Fatalf("quiet output should suppress serve warning: %q", got)
+			var buf bytes.Buffer
+			_, _ = buf.ReadFrom(r)
+			got := buf.String()
+
+			if tc.wantSuppressed {
+				if got != "" {
+					t.Fatalf("warning should be suppressed: %q", got)
+				}
+				return
+			}
+
+			if !strings.Contains(got, want) {
+				t.Fatalf("warning missing %q: %q", want, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `--quiet` serve flag to suppress non-error output while preserving errors
- route serve warnings and device-code prompts through quiet-aware output handling
- add tests covering quiet behavior, including argument parsing edge cases

## Validation
- `go test ./... -count=1`

## Review
- security review approved
- quality review approved