### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,6 +212,7 @@ func runLogout(args []string) {
 
 type serveFlags struct {
 	port                            *string
+	quiet                           *bool
 	host                            *string
 	tokenDir                        *string
 	providersConfigPath             *string
@@ -237,6 +238,7 @@ type serveFlags struct {
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
 	return serveFlags{
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
@@ -282,11 +284,18 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+func (f serveFlags) loggerLevel() logger.Level {
+	if f.quiet != nil && *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.loggerLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,41 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsQuietSuppressesInfoLogs(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet", "--log-level", "debug")
+	if got := serve.loggerLevel(); got != logger.LevelError {
+		t.Fatalf("loggerLevel() = %v, want %v", got, logger.LevelError)
+	}
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	log := logger.New(serve.loggerLevel())
+	log.Info("suppressed info")
+	log.Error("visible error")
+
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	output := buf.String()
+	if strings.Contains(output, "suppressed info") {
+		t.Fatalf("quiet logger emitted info log: %q", output)
+	}
+	if !strings.Contains(output, "visible error") {
+		t.Fatalf("quiet logger did not emit error log: %q", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `--quiet` flag for vekil serve mode to suppress non-error output
- preserve error output by forcing error log level when `--quiet` is set
- add a test that exercises the flag behavior

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- `go build -o /tmp/vekil .`

## Review
- security review approved
- quality review approved