### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type serverMetrics struct {
+	requestsTotal atomic.Int64
+	inFlight      atomic.Int64
+}
+
+func (m *serverMetrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.requestsTotal.Add(1)
+		m.inFlight.Add(1)
+		defer m.inFlight.Add(-1)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *serverMetrics) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w, "# HELP vekil_http_requests_total Total HTTP requests handled by Vekil.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", m.requestsTotal.Load())
+	_, _ = fmt.Fprintf(w, "# HELP vekil_http_in_flight_requests Current in-flight HTTP requests handled by Vekil.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_in_flight_requests gauge\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_in_flight_requests %d\n", m.inFlight.Load())
+}

--- a/server/server.go
+++ b/server/server.go
@@ -86,19 +86,24 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	baseMux := http.NewServeMux()
+	baseMux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
+	baseMux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
+	baseMux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
+	baseMux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
+	baseMux.HandleFunc("POST /models/", handler.HandleGeminiModels)
+	baseMux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
+	baseMux.HandleFunc("POST /v1/responses", handler.HandleResponses)
+	baseMux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
+	baseMux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
+	baseMux.HandleFunc("GET /healthz", handler.HandleHealthz)
+	baseMux.HandleFunc("GET /readyz", handler.HandleReadyz)
+	baseMux.HandleFunc("GET /v1/models", handler.HandleModels)
+
+	metrics := &serverMetrics{}
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
-	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
-	mux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
-	mux.HandleFunc("POST /v1/responses", handler.HandleResponses)
-	mux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
-	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
-	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
-	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
-	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.HandleFunc("GET /metrics", metrics.serveHTTP)
+	mux.Handle("/", metrics.instrument(baseMux))
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +95,42 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestNew_MountsMetricsEndpoint(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthReq := httptest.NewRequest("GET", "/healthz", nil)
+	healthRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthRec, healthReq)
+	if got, want := healthRec.Code, 200; got != want {
+		t.Fatalf("GET /healthz status = %d, want %d", got, want)
+	}
+
+	metricsReq := httptest.NewRequest("GET", "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsRec, metricsReq)
+	if got, want := metricsRec.Code, 200; got != want {
+		t.Fatalf("GET /metrics status = %d, want %d", got, want)
+	}
+	if got := metricsRec.Header().Get("Content-Type"); !strings.Contains(got, "text/plain") {
+		t.Fatalf("GET /metrics Content-Type = %q, want text/plain", got)
+	}
+
+	body := metricsRec.Body.String()
+	if !strings.Contains(body, "vekil_http_requests_total 1") {
+		t.Fatalf("GET /metrics body missing request counter: %q", body)
+	}
+	if !strings.Contains(body, "vekil_http_in_flight_requests 0") {
+		t.Fatalf("GET /metrics body missing in-flight gauge: %q", body)
 	}
 }


### PR DESCRIPTION
$## Summary
- add a lightweight Prometheus-style /metrics endpoint
- instrument application routes while excluding /metrics from self-counting
- add a server test covering /healthz and /metrics behavior

## Testing
- go test ./server -run TestNew_MountsMetricsEndpoint -count=1