### PR TITLE
Add minimal /metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -18,7 +18,7 @@ type metrics struct {
 
 func (m *metrics) wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/metrics" {
+		if isUntrackedMetricsPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -49,4 +49,13 @@ func (m *metrics) handle(w http.ResponseWriter, _ *http.Request) {
 		requestsInflightMetricName,
 		m.requestsInflight.Load(),
 	)
+}
+
+func isUntrackedMetricsPath(path string) bool {
+	switch path {
+	case "/healthz", "/readyz", "/metrics":
+		return true
+	default:
+		return false
+	}
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+const (
+	requestsTotalMetricName    = "vekil_http_requests_total"
+	requestsInflightMetricName = "vekil_http_inflight_requests"
+)
+
+type metrics struct {
+	requestsTotal    atomic.Uint64
+	requestsInflight atomic.Int64
+}
+
+func (m *metrics) wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		m.requestsInflight.Add(1)
+		defer m.requestsInflight.Add(-1)
+		m.requestsTotal.Add(1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handle(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w,
+		"# HELP %s Total HTTP requests handled by Vekil.\n"+
+			"# TYPE %s counter\n"+
+			"%s %d\n"+
+			"# HELP %s Current in-flight HTTP requests handled by Vekil.\n"+
+			"# TYPE %s gauge\n"+
+			"%s %d\n",
+		requestsTotalMetricName,
+		requestsTotalMetricName,
+		requestsTotalMetricName,
+		m.requestsTotal.Load(),
+		requestsInflightMetricName,
+		requestsInflightMetricName,
+		requestsInflightMetricName,
+		m.requestsInflight.Load(),
+	)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -100,11 +100,14 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
 
+	metrics := &metrics{}
+	mux.HandleFunc("GET /metrics", metrics.handle)
+
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.wrap(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +96,46 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestNew_ExposesMetrics(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	healthRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthRec, healthReq)
+	if healthRec.Code != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", healthRec.Code, http.StatusOK)
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsRec, metricsReq)
+	if metricsRec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", metricsRec.Code, http.StatusOK)
+	}
+	if got := metricsRec.Header().Get("Content-Type"); got != "text/plain; version=0.0.4; charset=utf-8" {
+		t.Fatalf("GET /metrics content type = %q, want %q", got, "text/plain; version=0.0.4; charset=utf-8")
+	}
+
+	body := metricsRec.Body.String()
+	for _, want := range []string{
+		"# TYPE vekil_http_requests_total counter",
+		"vekil_http_requests_total 1",
+		"# TYPE vekil_http_inflight_requests gauge",
+		"vekil_http_inflight_requests 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("GET /metrics body missing %q:\n%s", want, body)
+		}
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -130,12 +130,41 @@ func TestNew_ExposesMetrics(t *testing.T) {
 	body := metricsRec.Body.String()
 	for _, want := range []string{
 		"# TYPE vekil_http_requests_total counter",
-		"vekil_http_requests_total 1",
+		"vekil_http_requests_total 0",
 		"# TYPE vekil_http_inflight_requests gauge",
 		"vekil_http_inflight_requests 0",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("GET /metrics body missing %q:\n%s", want, body)
 		}
+	}
+}
+
+func TestMetrics_ExcludesHealthAndMetricsEndpoints(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	for _, path := range []string{"/healthz", "/readyz", "/metrics"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+		if rec.Code == 0 {
+			t.Fatalf("GET %s returned no status", path)
+		}
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsRec, metricsReq)
+
+	if body := metricsRec.Body.String(); !strings.Contains(body, "vekil_http_requests_total 0") {
+		t.Fatalf("GET /metrics body missing zero request count after excluded endpoints:\n%s", body)
 	}
 }


### PR DESCRIPTION
$## Summary
- add a minimal Prometheus text-format /metrics handler
- track total and in-flight HTTP requests via middleware
- add a focused server test covering health and metrics responses

## Testing
- GOROOT=/tmp/go PATH=/tmp/go/bin:$PATH /tmp/go/bin/go test ./server -run TestNew_ExposesMetrics -count=1