### PR TITLE
Add quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,6 +215,7 @@ type serveFlags struct {
 	host                            *string
 	tokenDir                        *string
 	providersConfigPath             *string
+	quiet                           *bool
 	logLevel                        *string
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
@@ -240,6 +241,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
@@ -258,6 +260,13 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
 	}
+}
+
+func (f serveFlags) loggerLevel() logger.Level {
+	if f.quiet != nil && *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
 }
 
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
@@ -286,7 +295,7 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.loggerLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -291,7 +292,35 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+var envWarningWriter io.Writer = os.Stderr
+
+func quietRequested(args []string) bool {
+	for _, arg := range args {
+		switch {
+		case arg == "--":
+			return false
+		case arg == "--quiet" || arg == "-quiet":
+			return true
+		case strings.HasPrefix(arg, "--quiet="):
+			v, err := strconv.ParseBool(strings.TrimPrefix(arg, "--quiet="))
+			return err == nil && v
+		case strings.HasPrefix(arg, "-quiet="):
+			v, err := strconv.ParseBool(strings.TrimPrefix(arg, "-quiet="))
+			return err == nil && v
+		}
+	}
+	return false
+}
+
 func runServe() {
+	previousEnvWarningWriter := envWarningWriter
+	if quietRequested(os.Args[1:]) {
+		envWarningWriter = io.Discard
+	}
+	defer func() {
+		envWarningWriter = previousEnvWarningWriter
+	}()
+
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -365,7 +394,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -378,7 +407,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -391,7 +420,7 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -188,6 +189,23 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeFlagsQuietSuppressesNonErrorOutput(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet", "--log-level", "debug")
+
+	output := captureStderr(t, func() {
+		log := logger.New(serve.loggerLevel())
+		log.Info("suppressed info")
+		log.Error("kept error")
+	})
+
+	if strings.Contains(output, "suppressed info") {
+		t.Fatalf("quiet logger should suppress info output, got %q", output)
+	}
+	if !strings.Contains(output, "kept error") {
+		t.Fatalf("quiet logger should keep error output, got %q", output)
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -356,6 +374,27 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 			t.Fatalf("stderr missing %q, got %q", want, output)
 		}
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
 }
 
 type fakeLoginAuthenticator struct {

--- a/main_test.go
+++ b/main_test.go
@@ -3,16 +3,18 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/sozercan/vekil/auth"
-	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -102,15 +104,15 @@ func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	const envKey = "TEST_WARN_VAR"
 
 	// Capture stderr to verify warning is emitted.
-	old := os.Stderr
+	oldWriter := envWarningWriter
 	r, w, _ := os.Pipe()
-	os.Stderr = w
+	envWarningWriter = w
 
 	t.Setenv(envKey, "not-a-bool")
 	getEnvBool(envKey, false)
 
 	_ = w.Close()
-	os.Stderr = old
+	envWarningWriter = oldWriter
 
 	var buf bytes.Buffer
 	_, _ = buf.ReadFrom(r)
@@ -190,19 +192,46 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 }
 
 func TestServeFlagsQuietSuppressesNonErrorOutput(t *testing.T) {
-	serve := parseServeFlagsForTest(t, "--quiet", "--log-level", "debug")
-
-	output := captureStderr(t, func() {
-		log := logger.New(serve.loggerLevel())
-		log.Info("suppressed info")
-		log.Error("kept error")
-	})
-
-	if strings.Contains(output, "suppressed info") {
-		t.Fatalf("quiet logger should suppress info output, got %q", output)
+	if os.Getenv("VEKIL_HELPER_QUIET_SERVE") == "1" {
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		os.Args = []string{
+			"vekil",
+			"--quiet",
+			"--providers-config",
+			filepath.Join(t.TempDir(), "missing-providers.yaml"),
+		}
+		main()
+		return
 	}
-	if !strings.Contains(output, "kept error") {
-		t.Fatalf("quiet logger should keep error output, got %q", output)
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestServeFlagsQuietSuppressesNonErrorOutput$")
+	cmd.Env = append(os.Environ(),
+		"VEKIL_HELPER_QUIET_SERVE=1",
+		"RESPONSES_WS_ENABLED=not-a-bool",
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected subprocess exit error, got %v", err)
+	}
+	if exitErr.ExitCode() == 0 {
+		t.Fatal("expected subprocess to fail when providers config is missing")
+	}
+
+	output := stderr.String()
+	if strings.Contains(output, `warning: ignoring invalid RESPONSES_WS_ENABLED="not-a-bool"`) {
+		t.Fatalf("quiet serve should suppress non-error warning output, got %q", output)
+	}
+	if !strings.Contains(output, "failed to load providers config") {
+		t.Fatalf("quiet serve should keep error output, got %q", output)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout output, got %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `--quiet` flag for `vekil` serve mode to suppress non-error output
- ensure startup/env warning output is also quieted while preserving error output
- add automated test coverage for quiet behavior

## Validation
- `go test ./... -count=1 && go build .` in `golang:1.25`

## Review
- Security review: approved
- Quality review: approved