### PR TITLE
Add generic compatible provider routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Documentation lives under [`docs/`](docs/README.md); start with these:
 | [Getting Started](docs/getting-started.md)                   | Install, run, first auth            |
 | [Configuration](docs/configuration.md)                       | Config map and generic flags        |
 | [Provider Routing](docs/provider-routing.md)                 | Provider auth and model ownership   |
+| [Provider API Keys](docs/provider-api-keys.md)               | Where to get provider keys          |
 | [Tool Optimizers](docs/tool-optimizers.md)                   | Shell rewrite/output reduction      |
 | [Responses WebSocket](docs/responses-websocket.md)           | Websocket bridge tuning             |
 | [Client Examples](docs/clients.md)                           | Copy-paste snippets per client      |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-Vekil is a Go reverse proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs behind one local endpoint. Run it in zero-config mode against GitHub Copilot, or route selected models to providers like Azure OpenAI and OpenAI Codex. The client-facing API surface stays the same while model ownership is configured behind the proxy.
+Vekil is a Go reverse proxy that exposes Anthropic, Gemini, and OpenAI-compatible APIs behind one local endpoint. Run it in zero-config mode against GitHub Copilot, or route selected models to providers like Azure OpenAI, OpenAI Codex, and generic OpenAI-compatible or Anthropic-compatible upstreams. The client-facing API surface stays the same while model ownership is configured behind the proxy.
 
 ## Why Vekil?
 
@@ -21,7 +21,7 @@ Use your GitHub Copilot subscription with Claude Code, point the Codex CLI at Az
 - **Anthropic Messages API** — drop-in compatible with Claude clients
 - **Gemini API** — Generate Content, Stream Generate Content, and Count Tokens
 - **OpenAI Chat Completions** and **Responses** APIs, including optional Codex websocket bridging
-- **Multi-provider routing** across GitHub Copilot, Azure OpenAI, and OpenAI Codex
+- **Multi-provider routing** across GitHub Copilot, Azure OpenAI, OpenAI Codex, and generic compatible providers
 - **Optional tool optimizers** for opt-in shell command rewrites and tool-output reduction across supported API surfaces; see [Tool Optimizers](docs/tool-optimizers.md)
 - **Codex compatibility shims** for compaction and memory summarization
 - **Streaming**, tool use, parallel tool calls, compressed request bodies, and auth/token caching
@@ -49,7 +49,9 @@ For explicit provider routing, start the proxy with `--providers-config /path/to
 **First-run auth** depends on your providers:
 
 - **Copilot** — `vekil login` uses Vekil-managed GitHub device-code sign-in; first proxy startup starts the same flow when needed. To use your current GitHub CLI account instead, opt in with `vekil login --github-cli` (or `--gh`). `vekil logout` clears cached auth and disables future silent `gh` reuse until you opt in again. `COPILOT_GITHUB_TOKEN` remains the explicit non-interactive override.
+- **Azure OpenAI and generic hosted providers** — use `api_key` or `api_key_env` in your provider config.
 - **OpenAI Codex** — requires `codex login` so `~/.codex/auth.json` exists. In Docker, mount your Codex home into `CODEX_HOME` (default `/home/nonroot/.codex`).
+- **Local generic providers** — use `auth_type: none`.
 
 For full setup details, see [Getting Started](docs/getting-started.md), [Configuration](docs/configuration.md), and [Provider Routing](docs/provider-routing.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-This folder is intentionally split into small, single-purpose files so humans and coding agents can load only the topic they need. It covers both provider-agnostic proxy behavior and provider-specific notes for GitHub Copilot, Azure OpenAI, and OpenAI Codex.
+This folder is intentionally split into small, single-purpose files so humans and coding agents can load only the topic they need. It covers both provider-agnostic proxy behavior and provider-specific notes for GitHub Copilot, Azure OpenAI, OpenAI Codex, and generic compatible providers.
 
 ## Doc Map
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder is intentionally split into small, single-purpose files so humans an
 | [`getting-started.md`](getting-started.md) | install, run, first authentication, deployment entry points | startup flow or distribution changes |
 | [`configuration.md`](configuration.md) | configuration map, generic CLI flags/env vars, and Copilot header overrides | generic flags, env vars, or Copilot header defaults change |
 | [`provider-routing.md`](provider-routing.md) | provider auth, JSON/YAML routing examples, model ownership, endpoint allowlists | providers, routing behavior, auth, or model metadata changes |
+| [`provider-api-keys.md`](provider-api-keys.md) | where to get provider API keys and how to map them into providers config | provider signup/key URLs or auth field guidance changes |
 | [`tool-optimizers.md`](tool-optimizers.md) | optional shell command rewrite and tool-output reduction config | optimizer config or behavior changes |
 | [`responses-websocket.md`](responses-websocket.md) | Codex-style `GET /v1/responses` websocket bridge tuning | websocket bridge, auto-compaction, or compact retry knobs change |
 | [`clients.md`](clients.md) | copy-paste client examples | onboarding snippets or client compatibility changes |

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@ Concise endpoint map for Vekil's public API surface. Provider routing is always 
 
 ## `POST /v1/messages` (Anthropic)
 
-Anthropic Messages compatibility for the supported content and tool subset. Requests are translated to OpenAI Chat Completions, routed through the provider that owns the selected public model, and translated back to Anthropic.
+Anthropic Messages compatibility for the supported content and tool subset. Requests are usually translated to OpenAI Chat Completions, routed through the provider that owns the selected public model, and translated back to Anthropic. For `anthropic-compatible` providers, the proxy directly forwards Messages requests to the configured `messages_path`.
 
 Supported features include text/image/tool-use content blocks, system messages, tool choice, stop sequences, extended thinking via `thinking.type: "enabled"`, and streaming Anthropic SSE event translation.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,8 @@
 │  /models/... ──┤                                   │             │
 │  /v1/chat/... ─┤                                   ├─► Copilot   │
 │  /v1/responses ┘                                   ├─► Azure     │
-│                                                      └─► Codex   │
+│                                                      ├─► Codex   │
+│                                                      └─► Generic │
 │                                                                  │
 │  /v1/responses/compact ─┐                                        │
 │  /v1/memories/... ──────┴─► Proxy-owned Responses compatibility  │
@@ -45,5 +46,6 @@
 - The Codex websocket bridge is transport adaptation over upstream HTTP `/responses`, not a claim that the selected provider has native websocket or realtime support; it is disabled by default and must be enabled explicitly.
 - Tool optimizers are opt-in and fail-open. They must remain disabled by default and must not change default passthrough behavior when unconfigured or when an external optimizer fails.
 - Azure OpenAI support is implemented as an OpenAI-compatible provider behind the existing proxy surface; Azure deployment names are internal to provider config.
+- Generic provider support is config-driven. `openai-compatible` providers use OpenAI Chat Completions and optional Responses paths, while `anthropic-compatible` providers directly forward native Anthropic Messages requests.
 - OpenAI Codex subscription support is a Responses-only dynamic provider backed by Codex CLI ChatGPT credentials.
 - Production dependencies stay minimal.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,6 +1,6 @@
 # Client Usage Examples
 
-These examples all target the same local proxy. Replace model IDs with public IDs from `/v1/models` in your deployment; client setup does not need to change when a model is backed by GitHub Copilot, Azure OpenAI, or OpenAI Codex.
+These examples all target the same local proxy. Replace model IDs with public IDs from `/v1/models` in your deployment; client setup does not need to change when a model is backed by GitHub Copilot, Azure OpenAI, OpenAI Codex, or a generic compatible provider.
 
 ## Claude Code
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ Vekil supports two runtime patterns:
 |------|-----|
 | Runtime flags, env vars, and Copilot header overrides | This file |
 | Provider auth, JSON/YAML routing examples, model ownership, and provider metadata | [Provider Routing](provider-routing.md) |
+| Provider console links and API-key setup patterns | [Provider API Keys](provider-api-keys.md) |
 | Optional shell command rewrite and tool-output reduction config | [Tool Optimizers](tool-optimizers.md) |
 | Codex-style `GET /v1/responses` websocket bridge and compaction tuning | [Responses WebSocket Bridge](responses-websocket.md) |
 
@@ -45,6 +46,7 @@ These overrides only affect Copilot-backed upstream requests. For provider-level
 Use `--providers-config` or `PROVIDERS_CONFIG` when you need explicit ownership of public model IDs across providers. Provider config files can be JSON (`.json`) or YAML (`.yaml`/`.yml`).
 
 - See [Provider Routing](provider-routing.md) for auth notes, generic-compatible provider fields, provider examples, routing rules, endpoint allowlists, and model metadata.
+- See [Provider API Keys](provider-api-keys.md) for provider console links and key-to-config mapping.
 - See [Tool Optimizers](tool-optimizers.md) for the optional `tool_optimizers` block that can live alongside `providers` in the same config file.
 
 ## Responses WebSocket Bridge

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 Vekil supports two runtime patterns:
 
 - **Zero-config mode**: no `--providers-config`; the proxy uses its built-in GitHub Copilot upstream.
-- **Explicit provider routing**: pass `--providers-config` with any mix of `copilot`, `azure-openai`, and `openai-codex`. If the config omits Copilot, GitHub auth is not used.
+- **Explicit provider routing**: pass `--providers-config` with any mix of `copilot`, `azure-openai`, `openai-codex`, `openai-compatible`, and `anthropic-compatible`. If the config omits Copilot, GitHub auth is not used.
 
 ## Topic Map
 
@@ -44,7 +44,7 @@ These overrides only affect Copilot-backed upstream requests. For provider-level
 
 Use `--providers-config` or `PROVIDERS_CONFIG` when you need explicit ownership of public model IDs across providers. Provider config files can be JSON (`.json`) or YAML (`.yaml`/`.yml`).
 
-- See [Provider Routing](provider-routing.md) for auth notes, provider examples, routing rules, endpoint allowlists, and model metadata.
+- See [Provider Routing](provider-routing.md) for auth notes, generic-compatible provider fields, provider examples, routing rules, endpoint allowlists, and model metadata.
 - See [Tool Optimizers](tool-optimizers.md) for the optional `tool_optimizers` block that can live alongside `providers` in the same config file.
 
 ## Responses WebSocket Bridge

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,7 +69,7 @@ The compaction smoke script starts the proxy with a non-interactive GitHub token
 
 The CLI smoke script starts the proxy with the same token pattern, waits for `/readyz`, selects currently available OpenAI, Anthropic, and Gemini models from `/v1/models`, and runs one file-reading headless check per CLI using isolated temp-home config directories.
 
-This workflow is intentionally provider-specific: it exercises a live Copilot-backed deployment because zero-config startup is the simplest upstream path to run in GitHub Actions. It is useful as a real integration smoke test, but it is not the complete provider matrix for Azure OpenAI or OpenAI Codex configs.
+This workflow is intentionally provider-specific: it exercises a live Copilot-backed deployment because zero-config startup is the simplest upstream path to run in GitHub Actions. It is useful as a real integration smoke test, but it is not the complete provider matrix for Azure OpenAI, OpenAI Codex, or generic compatible provider configs.
 
 To use it:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ kubectl apply -f k8s/vekil.yaml
 
 ## First Run And Authentication
 
-Startup behavior depends on active providers. For the full auth matrix, see [Provider Authentication](provider-routing.md#provider-authentication).
+Startup behavior depends on active providers. For the full auth matrix, see [Provider Authentication](provider-routing.md#provider-authentication). For provider console links and key setup patterns, see [Provider API Keys](provider-api-keys.md).
 
 ### GitHub Copilot
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 Vekil commonly runs in one of two modes:
 
 - **Zero-config mode**: no `--providers-config`; uses the built-in GitHub Copilot upstream.
-- **Explicit provider routing**: pass `--providers-config` to expose any mix of `copilot`, `azure-openai`, and `openai-codex` providers behind the same local API surface.
+- **Explicit provider routing**: pass `--providers-config` to expose any mix of `copilot`, `azure-openai`, `openai-codex`, `openai-compatible`, and `anthropic-compatible` providers behind the same local API surface.
 
 ## Install Or Build
 
@@ -93,6 +93,10 @@ Configure Azure credentials in the provider entry. Use `api_key`/`api_key_env` f
 ### OpenAI Codex
 
 Run `codex login` first so `~/.codex/auth.json` exists. Set `CODEX_HOME` if your Codex home lives elsewhere. API-key auth and OS keychain-backed credentials are not read by the proxy.
+
+### Generic Compatible Providers
+
+Generic `openai-compatible` and `anthropic-compatible` providers use the auth fields in the providers config. Use `auth_type: none` for local services, or set `api_key_env` with `auth_type: bearer` or `auth_type: api-key-header` for hosted services. There is no interactive login flow.
 
 If your provider config omits Copilot, startup skips GitHub authentication entirely.
 

--- a/docs/provider-api-keys.md
+++ b/docs/provider-api-keys.md
@@ -8,6 +8,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 
 - Prefer `api_key_env` over inline `api_key` for any config you might commit or share.
 - Use any environment variable name you want; it only needs to match the provider's `api_key_env` value.
+- Names like `AZURE_OPENAI_API_KEY` or `PROVIDER_API_KEY` in examples are placeholders, not names Vekil treats specially.
 - Use `auth_type: none` only for local providers or a trusted private upstream.
 - Keep `models[].endpoints` limited to routes you have validated for that model. Vekil does not infer `/responses` from OpenAI compatibility.
 - Do not paste provider keys into client configs. Clients point at Vekil with dummy local keys; Vekil holds the upstream provider credentials.
@@ -17,7 +18,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 | Provider | How To Authenticate | Vekil Config |
 |----------|---------------------|--------------|
 | GitHub Copilot | Run `vekil login`, opt into GitHub CLI auth with `vekil login --github-cli`, or set `COPILOT_GITHUB_TOKEN` for non-interactive runs. | `type: copilot` |
-| Azure OpenAI | Create an Azure OpenAI resource/deployment in the Azure Portal or Azure AI Foundry, then copy a resource key. | `type: azure-openai`, `api_key_env: AZURE_OPENAI_API_KEY` |
+| Azure OpenAI | Create an Azure OpenAI resource/deployment in the Azure Portal or Azure AI Foundry, then copy a resource key. | `type: azure-openai`, `api_key_env: <the env var name you exported>` |
 | OpenAI Codex | Run `codex login` so `~/.codex/auth.json` exists. API keys are not used for this provider. | `type: openai-codex` |
 
 ## Generic Provider Key Pages
@@ -47,7 +48,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 
 ## Config Field Checklist
 
-After creating a key, add it to your environment under any name you choose and reference that same name from the provider config:
+After creating a key, add it to your environment under any name you choose and reference that exact name from the provider config:
 
 ```bash
 export PROVIDER_API_KEY=sk-...

--- a/docs/provider-api-keys.md
+++ b/docs/provider-api-keys.md
@@ -1,0 +1,75 @@
+# Provider API Keys
+
+Use this file when you need to find where a provider issues API keys and how that key maps into a Vekil providers config. For routing behavior and full config examples, see [Provider Routing](provider-routing.md).
+
+Provider portals, free tiers, and model catalogs change frequently. Treat the links below as starting points, then verify current terms, quotas, regions, and supported endpoints in the provider's own console.
+
+## Key Handling
+
+- Prefer `api_key_env` over inline `api_key` for any config you might commit or share.
+- Use a separate environment variable per provider, such as `NVIDIA_NIM_API_KEY` or `OPENROUTER_API_KEY`.
+- Use `auth_type: none` only for local providers or a trusted private upstream.
+- Keep `models[].endpoints` limited to routes you have validated for that model. Vekil does not infer `/responses` from OpenAI compatibility.
+- Do not paste provider keys into client configs. Clients point at Vekil with dummy local keys; Vekil holds the upstream provider credentials.
+
+## Built-In Provider Auth
+
+| Provider | How To Authenticate | Vekil Config |
+|----------|---------------------|--------------|
+| GitHub Copilot | Run `vekil login`, opt into GitHub CLI auth with `vekil login --github-cli`, or set `COPILOT_GITHUB_TOKEN` for non-interactive runs. | `type: copilot` |
+| Azure OpenAI | Create an Azure OpenAI resource/deployment in the Azure Portal or Azure AI Foundry, then copy a resource key. | `type: azure-openai`, `api_key_env: AZURE_OPENAI_API_KEY` |
+| OpenAI Codex | Run `codex login` so `~/.codex/auth.json` exists. API keys are not used for this provider. | `type: openai-codex` |
+
+## Generic Provider Key Pages
+
+| Provider | Key Page | Typical Vekil Type | Key Env Var | Notes |
+|----------|----------|--------------------|-------------|-------|
+| NVIDIA NIM | [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys) | `openai-compatible` | `NVIDIA_NIM_API_KEY` | Use `/chat/completions`; add `/responses` only for a validated model. |
+| Kimi / Moonshot | [platform.moonshot.ai/console/api-keys](https://platform.moonshot.ai/console/api-keys) | `openai-compatible` | `KIMI_API_KEY` | Configure `base_url` exactly as Moonshot documents for the API you use. |
+| OpenCode Zen / Go | [opencode.ai/auth](https://opencode.ai/auth) | `openai-compatible` | `OPENCODE_API_KEY` | Prefer `/responses` for models documented for Responses; keep chat separate unless validated. |
+| Z.ai | [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list) | `openai-compatible` | `ZAI_API_KEY` | Do not append `/v1` unless that is part of the documented API base. |
+| OpenRouter | [openrouter.ai/keys](https://openrouter.ai/keys) | `anthropic-compatible` or `openai-compatible` | `OPENROUTER_API_KEY` | Pick the provider type that matches the upstream endpoint you configure. |
+| DeepSeek | [platform.deepseek.com/api_keys](https://platform.deepseek.com/api_keys) | `anthropic-compatible` or `openai-compatible` | `DEEPSEEK_API_KEY` | Match `type` and paths to the endpoint family you intend to use. |
+| Wafer | [wafer.ai](https://www.wafer.ai/) | `anthropic-compatible` | `WAFER_API_KEY` | Use its native Messages endpoint when configuring direct Anthropic routing. |
+| Google AI Studio | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) | `openai-compatible` | `GEMINI_API_KEY` | Use Google's OpenAI-compatible API base when configuring this as a generic provider. |
+| Mistral La Plateforme | [console.mistral.ai](https://console.mistral.ai/) | `openai-compatible` | `MISTRAL_API_KEY` | Use the OpenAI-compatible API base documented by Mistral. |
+| Groq | [console.groq.com/keys](https://console.groq.com/keys) | `openai-compatible` | `GROQ_API_KEY` | Some models reject unsupported request fields; validate with a small request first. |
+| Cerebras Cloud | [cloud.cerebras.ai](https://cloud.cerebras.ai/) | `openai-compatible` | `CEREBRAS_API_KEY` | Use the OpenAI-compatible API base from Cerebras docs. |
+
+## Local Providers Without API Keys
+
+| Provider | Typical URL | Vekil Config |
+|----------|-------------|--------------|
+| LM Studio | `http://localhost:1234/v1` | `type: openai-compatible`, `auth_type: none` |
+| llama.cpp server | commonly `http://localhost:8080/v1` | `type: openai-compatible`, `auth_type: none` |
+| Ollama | `http://localhost:11434` | `type: openai-compatible`, `auth_type: none`, `model_discovery: ollama`, `models_path: /api/tags`, `chat_completions_path: /v1/chat/completions` |
+
+## Config Field Checklist
+
+After creating a key, add it to your environment and reference it from the provider config:
+
+```bash
+export PROVIDER_API_KEY=sk-...
+```
+
+```yaml
+providers:
+  - id: hosted-provider
+    type: openai-compatible
+    base_url: https://provider.example.com/v1
+    api_key_env: PROVIDER_API_KEY
+```
+
+Use `auth_type: api-key-header` and `auth_header` for providers that do not accept bearer auth. Use `auth_type: none` for local providers. Full routing examples live in [Provider Routing](provider-routing.md#generic-provider-cookbook).
+
+## Quick Validation
+
+After exporting the environment variables referenced by `api_key_env`, start Vekil with the config and check:
+
+```bash
+vekil serve --providers-config ./providers.yaml
+curl http://localhost:1337/readyz
+curl http://localhost:1337/v1/models
+```
+
+Then send a small request through the public endpoint listed in `models[].endpoints`. If `/readyz` passes but inference fails, verify the upstream path, model/deployment ID, auth header mode, and whether that model actually supports the requested endpoint.

--- a/docs/provider-api-keys.md
+++ b/docs/provider-api-keys.md
@@ -7,7 +7,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 ## Key Handling
 
 - Prefer `api_key_env` over inline `api_key` for any config you might commit or share.
-- Use a separate environment variable per provider, such as `NVIDIA_NIM_API_KEY` or `OPENROUTER_API_KEY`.
+- Use any environment variable name you want; it only needs to match the provider's `api_key_env` value.
 - Use `auth_type: none` only for local providers or a trusted private upstream.
 - Keep `models[].endpoints` limited to routes you have validated for that model. Vekil does not infer `/responses` from OpenAI compatibility.
 - Do not paste provider keys into client configs. Clients point at Vekil with dummy local keys; Vekil holds the upstream provider credentials.
@@ -22,19 +22,19 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 
 ## Generic Provider Key Pages
 
-| Provider | Key Page | Typical Vekil Type | Key Env Var | Notes |
-|----------|----------|--------------------|-------------|-------|
-| NVIDIA NIM | [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys) | `openai-compatible` | `NVIDIA_NIM_API_KEY` | Use `/chat/completions`; add `/responses` only for a validated model. |
-| Kimi / Moonshot | [platform.moonshot.ai/console/api-keys](https://platform.moonshot.ai/console/api-keys) | `openai-compatible` | `KIMI_API_KEY` | Configure `base_url` exactly as Moonshot documents for the API you use. |
-| OpenCode Zen / Go | [opencode.ai/auth](https://opencode.ai/auth) | `openai-compatible` | `OPENCODE_API_KEY` | Prefer `/responses` for models documented for Responses; keep chat separate unless validated. |
-| Z.ai | [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list) | `openai-compatible` | `ZAI_API_KEY` | Do not append `/v1` unless that is part of the documented API base. |
-| OpenRouter | [openrouter.ai/keys](https://openrouter.ai/keys) | `anthropic-compatible` or `openai-compatible` | `OPENROUTER_API_KEY` | Pick the provider type that matches the upstream endpoint you configure. |
-| DeepSeek | [platform.deepseek.com/api_keys](https://platform.deepseek.com/api_keys) | `anthropic-compatible` or `openai-compatible` | `DEEPSEEK_API_KEY` | Match `type` and paths to the endpoint family you intend to use. |
-| Wafer | [wafer.ai](https://www.wafer.ai/) | `anthropic-compatible` | `WAFER_API_KEY` | Use its native Messages endpoint when configuring direct Anthropic routing. |
-| Google AI Studio | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) | `openai-compatible` | `GEMINI_API_KEY` | Use Google's OpenAI-compatible API base when configuring this as a generic provider. |
-| Mistral La Plateforme | [console.mistral.ai](https://console.mistral.ai/) | `openai-compatible` | `MISTRAL_API_KEY` | Use the OpenAI-compatible API base documented by Mistral. |
-| Groq | [console.groq.com/keys](https://console.groq.com/keys) | `openai-compatible` | `GROQ_API_KEY` | Some models reject unsupported request fields; validate with a small request first. |
-| Cerebras Cloud | [cloud.cerebras.ai](https://cloud.cerebras.ai/) | `openai-compatible` | `CEREBRAS_API_KEY` | Use the OpenAI-compatible API base from Cerebras docs. |
+| Provider | Key Page | Typical Vekil Type | Notes |
+|----------|----------|--------------------|-------|
+| NVIDIA NIM | [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys) | `openai-compatible` | Use `/chat/completions`; add `/responses` only for a validated model. |
+| Kimi / Moonshot | [platform.moonshot.ai/console/api-keys](https://platform.moonshot.ai/console/api-keys) | `openai-compatible` | Configure `base_url` exactly as Moonshot documents for the API you use. |
+| OpenCode Zen / Go | [opencode.ai/auth](https://opencode.ai/auth) | `openai-compatible` | Prefer `/responses` for models documented for Responses; keep chat separate unless validated. |
+| Z.ai | [z.ai/manage-apikey/apikey-list](https://z.ai/manage-apikey/apikey-list) | `openai-compatible` | Do not append `/v1` unless that is part of the documented API base. |
+| OpenRouter | [openrouter.ai/keys](https://openrouter.ai/keys) | `anthropic-compatible` or `openai-compatible` | Pick the provider type that matches the upstream endpoint you configure. |
+| DeepSeek | [platform.deepseek.com/api_keys](https://platform.deepseek.com/api_keys) | `anthropic-compatible` or `openai-compatible` | Match `type` and paths to the endpoint family you intend to use. |
+| Wafer | [wafer.ai](https://www.wafer.ai/) | `anthropic-compatible` | Use its native Messages endpoint when configuring direct Anthropic routing. |
+| Google AI Studio | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) | `openai-compatible` | Use Google's OpenAI-compatible API base when configuring this as a generic provider. |
+| Mistral La Plateforme | [console.mistral.ai](https://console.mistral.ai/) | `openai-compatible` | Use the OpenAI-compatible API base documented by Mistral. |
+| Groq | [console.groq.com/keys](https://console.groq.com/keys) | `openai-compatible` | Some models reject unsupported request fields; validate with a small request first. |
+| Cerebras Cloud | [cloud.cerebras.ai](https://cloud.cerebras.ai/) | `openai-compatible` | Use the OpenAI-compatible API base from Cerebras docs. |
 
 ## Local Providers Without API Keys
 
@@ -47,7 +47,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 
 ## Config Field Checklist
 
-After creating a key, add it to your environment and reference it from the provider config:
+After creating a key, add it to your environment under any name you choose and reference that same name from the provider config:
 
 ```bash
 export PROVIDER_API_KEY=sk-...

--- a/docs/provider-api-keys.md
+++ b/docs/provider-api-keys.md
@@ -9,6 +9,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 - Prefer `api_key_env` over inline `api_key` for any config you might commit or share.
 - Use any environment variable name you want; it only needs to match the provider's `api_key_env` value.
 - Names like `AZURE_OPENAI_API_KEY` or `PROVIDER_API_KEY` in examples are placeholders, not names Vekil treats specially.
+- If `api_key_env` is set in config, that environment variable must be set and non-empty before Vekil starts.
 - Use `auth_type: none` only for local providers or a trusted private upstream.
 - Keep `models[].endpoints` limited to routes you have validated for that model. Vekil does not infer `/responses` from OpenAI compatibility.
 - Do not paste provider keys into client configs. Clients point at Vekil with dummy local keys; Vekil holds the upstream provider credentials.

--- a/docs/provider-api-keys.md
+++ b/docs/provider-api-keys.md
@@ -42,6 +42,7 @@ Provider portals, free tiers, and model catalogs change frequently. Treat the li
 |----------|-------------|--------------|
 | LM Studio | `http://localhost:1234/v1` | `type: openai-compatible`, `auth_type: none` |
 | llama.cpp server | commonly `http://localhost:8080/v1` | `type: openai-compatible`, `auth_type: none` |
+| AIKit | `http://localhost:8080/v1` | `type: openai-compatible`, `auth_type: none` |
 | Ollama | `http://localhost:11434` | `type: openai-compatible`, `auth_type: none`, `model_discovery: ollama`, `models_path: /api/tags`, `chat_completions_path: /v1/chat/completions` |
 
 ## Config Field Checklist

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -40,7 +40,7 @@ Vekil does not run `az login` for you. For local development, sign in with Azure
 - `auth_type: none` sends no auth header, useful for local providers.
 - `extra_headers` adds fixed provider headers after client Copilot-identifying headers are stripped.
 
-When `auth_type` is omitted, Vekil uses `bearer` if `api_key` or `api_key_env` is set, otherwise `none`.
+When `auth_type` is omitted, Vekil uses `bearer` if `api_key` or `api_key_env` is set, otherwise `none`. If `api_key_env` is configured, the referenced environment variable must be set and non-empty at startup.
 
 ## Provider Routing
 

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -134,7 +134,7 @@ Anthropic-compatible providers directly forward Anthropic `POST /v1/messages` to
 |-------|------------|---------|
 | `type` | all providers | Use `openai-compatible` or `anthropic-compatible` for generic providers. |
 | `base_url` | generic providers | Upstream origin and any fixed API prefix. The proxy appends only the configured path field. |
-| `api_key`, `api_key_env` | generic providers | Static credential value or environment variable name. |
+| `api_key`, `api_key_env` | generic providers | Static credential value or the name of any environment variable you choose. |
 | `auth_type` | generic providers | `bearer`, `api-key-header`, or `none`. Defaults to `bearer` when a key is present, otherwise `none`. |
 | `auth_header`, `auth_prefix` | generic providers | Header name and optional prefix for `api-key-header`, or overrides for bearer auth. |
 | `extra_headers` | generic providers | Fixed headers to add to every upstream request after client Copilot headers are stripped. |

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -1,6 +1,6 @@
 # Provider Routing and Authentication
 
-Use this file when editing provider credentials, model ownership, JSON/YAML provider configs, provider header profiles, or provider-specific model metadata. For global flags and env vars, see [Configuration](configuration.md).
+Use this file when editing provider credentials, model ownership, JSON/YAML provider configs, provider header profiles, or provider-specific model metadata. For where to obtain provider keys, see [Provider API Keys](provider-api-keys.md). For global flags and env vars, see [Configuration](configuration.md).
 
 ## Provider Authentication
 

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -163,7 +163,7 @@ providers:
           - /chat/completions
 ```
 
-LM Studio and llama.cpp usually fit the same shape with local auth disabled:
+LM Studio, llama.cpp, and AIKit usually fit the same shape with local auth disabled:
 
 ```yaml
 providers:
@@ -178,6 +178,8 @@ providers:
         endpoints:
           - /chat/completions
 ```
+
+For AIKit's default quick-start port, use `base_url: http://localhost:8080/v1` and set `deployment` to the model name served by the image, such as `llama-3.1-8b-instruct`.
 
 Z.ai-style OpenAI-compatible providers can use the same config, but set `base_url` exactly to the upstream API base documented by the provider. Do not append `/v1` unless the provider's OpenAI-compatible base URL includes it.
 

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -31,9 +31,20 @@ For Entra auth, `token_scope` is optional and defaults to `https://ai.azure.com/
 
 Vekil does not run `az login` for you. For local development, sign in with Azure CLI or another credential supported by `DefaultAzureCredential`; in hosted environments, use managed identity, workload identity, or environment credentials. The signed-in principal needs the required Azure RBAC role, for example Cognitive Services OpenAI User on the target resource.
 
+### Generic Providers
+
+`openai-compatible` and `anthropic-compatible` providers use the generic auth fields:
+
+- `auth_type: bearer` sends `Authorization: Bearer <key>` by default.
+- `auth_type: api-key-header` sends the key through `auth_header`, with optional `auth_prefix`.
+- `auth_type: none` sends no auth header, useful for local providers.
+- `extra_headers` adds fixed provider headers after client Copilot-identifying headers are stripped.
+
+When `auth_type` is omitted, Vekil uses `bearer` if `api_key` or `api_key_env` is set, otherwise `none`.
+
 ## Provider Routing
 
-Use `--providers-config` when you want explicit ownership of public model IDs across providers such as GitHub Copilot, Azure OpenAI, and OpenAI Codex. Provider config files can be JSON (`.json`) or YAML (`.yaml`/`.yml`).
+Use `--providers-config` when you want explicit ownership of public model IDs across providers such as GitHub Copilot, Azure OpenAI, OpenAI Codex, or generic OpenAI-compatible and Anthropic-compatible upstreams. Provider config files can be JSON (`.json`) or YAML (`.yaml`/`.yml`).
 
 You can run Azure-only or Codex-only configs, or mix those providers with Copilot behind the same local endpoint.
 
@@ -109,6 +120,118 @@ providers:
 
 JSON configs use the same snake_case field names as YAML.
 
+### Generic Provider Behavior
+
+OpenAI-compatible providers route `POST /v1/chat/completions` to `chat_completions_path`. Anthropic `POST /v1/messages` requests for these models are translated through the existing OpenAI Chat Completions adapter. `POST /v1/responses` is never inferred; add `/responses` to a model only after validating the upstream model and path.
+
+Anthropic-compatible providers directly forward Anthropic `POST /v1/messages` to `messages_path`. They do not serve OpenAI Chat Completions or Responses routes.
+
+`model_discovery` can be `static`, `openai`, `ollama`, or `openrouter-tools`. OpenAI discovery reads an OpenAI-style `data` array. Ollama discovery reads `/api/tags`. OpenRouter-tools discovery reads an OpenAI/OpenRouter-style `data` array and exposes only models that advertise tool parameters.
+
+### Generic Provider Field Reference
+
+| Field | Applies To | Purpose |
+|-------|------------|---------|
+| `type` | all providers | Use `openai-compatible` or `anthropic-compatible` for generic providers. |
+| `base_url` | generic providers | Upstream origin and any fixed API prefix. The proxy appends only the configured path field. |
+| `api_key`, `api_key_env` | generic providers | Static credential value or environment variable name. |
+| `auth_type` | generic providers | `bearer`, `api-key-header`, or `none`. Defaults to `bearer` when a key is present, otherwise `none`. |
+| `auth_header`, `auth_prefix` | generic providers | Header name and optional prefix for `api-key-header`, or overrides for bearer auth. |
+| `extra_headers` | generic providers | Fixed headers to add to every upstream request after client Copilot headers are stripped. |
+| `chat_completions_path` | `openai-compatible` | Upstream path for public `POST /v1/chat/completions`. Defaults to `/chat/completions`. |
+| `responses_path` | `openai-compatible` | Upstream path for public `POST /v1/responses`. Defaults to `/responses`; models must still opt in with `/responses`. |
+| `messages_path` | `anthropic-compatible` | Upstream path for public `POST /v1/messages`. Defaults to `/v1/messages`. |
+| `models_path` | generic providers | Upstream path for dynamic model discovery and readiness probes. Defaults to `/models`. |
+| `model_discovery` | generic providers | `static`, `openai`, `ollama`, or `openrouter-tools`. |
+| `models[].endpoints` | all static models | Public endpoint allowlist. This remains the source of truth for what Vekil advertises and routes. |
+
+### Generic Provider Cookbook
+
+Chat-only OpenAI-compatible hosted providers, including NVIDIA NIM and Kimi, should expose only `/chat/completions` unless you have validated `/responses` for that exact model:
+
+```yaml
+providers:
+  - id: hosted-chat
+    type: openai-compatible
+    default: true
+    base_url: https://provider.example.com/v1
+    api_key_env: PROVIDER_API_KEY
+    models:
+      - public_id: provider-chat-model
+        deployment: upstream-chat-model
+        endpoints:
+          - /chat/completions
+```
+
+LM Studio and llama.cpp usually fit the same shape with local auth disabled:
+
+```yaml
+providers:
+  - id: local-openai
+    type: openai-compatible
+    default: true
+    base_url: http://localhost:1234/v1
+    auth_type: none
+    models:
+      - public_id: local-chat
+        deployment: local-model
+        endpoints:
+          - /chat/completions
+```
+
+Z.ai-style OpenAI-compatible providers can use the same config, but set `base_url` exactly to the upstream API base documented by the provider. Do not append `/v1` unless the provider's OpenAI-compatible base URL includes it.
+
+Ollama can use `/api/tags` discovery and OpenAI-compatible chat routing:
+
+```yaml
+providers:
+  - id: ollama
+    type: openai-compatible
+    default: true
+    base_url: http://localhost:11434
+    auth_type: none
+    model_discovery: ollama
+    models_path: /api/tags
+    chat_completions_path: /v1/chat/completions
+```
+
+OpenAI-compatible providers with validated Responses support, including OpenCode Zen/Go models documented for Responses, should opt in per model:
+
+```yaml
+providers:
+  - id: responses-provider
+    type: openai-compatible
+    default: true
+    base_url: https://provider.example.com/v1
+    api_key_env: PROVIDER_API_KEY
+    models:
+      - public_id: responses-model
+        deployment: upstream-responses-model
+        endpoints:
+          - /responses
+```
+
+Anthropic-compatible providers with native Messages support, including Wafer, OpenRouter, and DeepSeek-style Messages endpoints, should not advertise OpenAI routes:
+
+```yaml
+providers:
+  - id: native-messages
+    type: anthropic-compatible
+    default: true
+    base_url: https://provider.example.com
+    api_key_env: PROVIDER_API_KEY
+    auth_type: api-key-header
+    auth_header: x-api-key
+    messages_path: /v1/messages
+    models:
+      - public_id: claude-compatible
+        deployment: upstream-messages-model
+        endpoints:
+          - /v1/messages
+```
+
+If LM Studio, llama.cpp, or Ollama exposes a native Anthropic Messages endpoint in your local setup, configure it as a separate `anthropic-compatible` provider with `messages_path`. Do not rely on `openai-compatible` to direct-forward Messages; that type translates Anthropic requests through Chat Completions.
+
 ### Copilot Provider Header Profiles
 
 `type: copilot` providers can define a `headers` block with a provider-wide `default` profile and endpoint-specific `chat_completions` and `responses` profiles. Endpoint-specific values override `headers.default`, which overrides the global Copilot header flags/environment variables, which then fall back to the built-in defaults. Omitted fields inherit from the lower-precedence profile. The built-in `openai-intent: conversation-panel` fallback is endpoint-aware: it is applied to upstream `/chat/completions` and `/responses` calls, while upstream `/models` calls send `openai-intent` only when you configure it explicitly through `--copilot-openai-intent`, `COPILOT_OPENAI_INTENT`, or a provider header profile.
@@ -143,6 +266,9 @@ Routing rules:
 - OpenAI Codex discovers models dynamically from its upstream `/models` endpoint and exposes only models that are listed and supported in the API.
 - OpenAI Codex models are `/responses`-only. The proxy rejects `/chat/completions` for those models instead of probing an unsupported route.
 - Azure `auth_mode` is optional and defaults to `api_key`. Supported values are `api_key` and `azure_identity`.
+- `openai-compatible` models default to `/chat/completions` when `models[].endpoints` is omitted. Add `/responses` only for models you have validated on `responses_path`.
+- `anthropic-compatible` models default to `/v1/messages` when `models[].endpoints` is omitted. OpenAI Chat Completions and Responses requests for those models fail fast.
+- Generic path fields are `chat_completions_path`, `responses_path`, `messages_path`, and `models_path`. They are paths relative to `base_url`, with no query string or fragment.
 - Azure `base_url` must be an absolute URL whose path ends with either the OpenAI-compatible `/openai/v1` path or the legacy `/openai` path, with no query string or fragment.
 - Microsoft Foundry inference URLs ending in `/models` are not supported in `type: "azure-openai"` configs. Use the corresponding OpenAI-compatible `.../openai/v1` endpoint instead.
 - For `/openai/v1` base URLs, omit `api_version`; the proxy calls `/chat/completions`, `/responses`, and `/models` directly with no `api-version` query string.

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/sozercan/vekil/logger"
@@ -72,6 +73,53 @@ func prepareAnthropicChatCompletionsRequest(req *models.AnthropicRequest) ([]byt
 	return body, mode, nil
 }
 
+func anthropicExtraHeadersFromRequest(r *http.Request) http.Header {
+	var headers http.Header
+	for _, name := range []string{
+		"Anthropic-Version",
+		"Anthropic-Beta",
+		"Anthropic-Dangerous-Direct-Browser-Access",
+	} {
+		for _, value := range r.Header.Values(name) {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				if headers == nil {
+					headers = make(http.Header, 2)
+				}
+				headers.Add(name, trimmed)
+			}
+		}
+	}
+	return headers
+}
+
+func (h *ProxyHandler) shouldForwardAnthropicMessagesDirect(model string) bool {
+	provider, _, _ := h.resolveProviderModel(model, providerEndpointMessages)
+	return provider != nil && provider.kind == providerTypeAnthropicCompatible
+}
+
+func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *http.Request, body []byte, req *models.AnthropicRequest) {
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(req != nil && req.Stream)
+	defer upstreamCancel()
+
+	resp, err := h.postAnthropicMessages(upstreamCtx, body, anthropicExtraHeadersFromRequest(r))
+	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
+		h.log.Error("upstream request failed", logger.F("endpoint", "anthropic"), logger.Err(err))
+		if statusCode == http.StatusBadRequest {
+			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
+			return
+		}
+		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
+		return
+	}
+
+	writeUpstreamResponse(w, resp)
+}
+
 func (h *ProxyHandler) routeChatCompletionsResponse(w http.ResponseWriter, resp *http.Response, mode chatCompletionsMode, handlers chatCompletionsResponseHandlers) error {
 	if resp.StatusCode == http.StatusOK && mode.clientRequestedStream {
 		if handlers.stream == nil {
@@ -124,6 +172,11 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		logger.F("messages", len(req.Messages)),
 		logger.F("tools", len(req.Tools)),
 	)
+
+	if h.shouldForwardAnthropicMessagesDirect(req.Model) {
+		h.forwardAnthropicMessagesDirect(w, r, body, &req)
+		return
+	}
 
 	scope := chatToolExecutionScopeFromHeaders(r.Header)
 	oaiBody, mode, err := prepareAnthropicChatCompletionsRequest(&req)

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -98,7 +98,10 @@ func (h *ProxyHandler) shouldForwardAnthropicMessagesDirect(model string) bool {
 }
 
 func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *http.Request, body []byte, req *models.AnthropicRequest) {
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(req != nil && req.Stream)
+	streaming := req != nil && req.Stream
+	publicModel, upstreamModel := h.directAnthropicResponseModels(req)
+
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(streaming)
 	defer upstreamCancel()
 
 	resp, err := h.postAnthropicMessages(upstreamCtx, body, anthropicExtraHeadersFromRequest(r))
@@ -117,7 +120,38 @@ func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *
 		return
 	}
 
+	if resp.StatusCode == http.StatusOK && streaming {
+		writeDirectAnthropicStreamResponse(w, resp, publicModel, upstreamModel)
+		return
+	}
+	if resp.StatusCode == http.StatusOK {
+		if err := writeDirectAnthropicJSONResponse(w, resp, publicModel, upstreamModel); err != nil {
+			h.log.Error("upstream response rewrite failed", logger.F("endpoint", "anthropic"), logger.Err(err))
+			writeAnthropicError(w, http.StatusBadGateway, "api_error", "failed to read upstream response")
+		}
+		return
+	}
+
 	writeUpstreamResponse(w, resp)
+}
+
+func (h *ProxyHandler) directAnthropicResponseModels(req *models.AnthropicRequest) (string, string) {
+	if req == nil {
+		return "", ""
+	}
+	publicModel := strings.TrimSpace(req.Model)
+	upstreamModel := publicModel
+	_, owner, known := h.resolveProviderModel(req.Model, providerEndpointMessages)
+	if !known {
+		return publicModel, upstreamModel
+	}
+	if owner.publicID != "" {
+		publicModel = owner.publicID
+	}
+	if owner.upstreamModel != "" {
+		upstreamModel = owner.upstreamModel
+	}
+	return publicModel, upstreamModel
 }
 
 func (h *ProxyHandler) routeChatCompletionsResponse(w http.ResponseWriter, resp *http.Response, mode chatCompletionsMode, handlers chatCompletionsResponseHandlers) error {

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -93,7 +93,7 @@ func anthropicExtraHeadersFromRequest(r *http.Request) http.Header {
 }
 
 func (h *ProxyHandler) shouldForwardAnthropicMessagesDirect(model string) bool {
-	provider, _, _ := h.resolveProviderModel(model, providerEndpointMessages)
+	provider, _, _ := h.resolveProviderModel(NormalizeModelName(model), providerEndpointMessages)
 	return provider != nil && provider.kind == providerTypeAnthropicCompatible
 }
 
@@ -141,7 +141,7 @@ func (h *ProxyHandler) directAnthropicResponseModels(req *models.AnthropicReques
 	}
 	publicModel := strings.TrimSpace(req.Model)
 	upstreamModel := publicModel
-	_, owner, known := h.resolveProviderModel(req.Model, providerEndpointMessages)
+	_, owner, known := h.resolveProviderModel(NormalizeModelName(req.Model), providerEndpointMessages)
 	if !known {
 		return publicModel, upstreamModel
 	}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -673,6 +673,10 @@ func (h *ProxyHandler) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *ProxyHandler) checkProviderReady(ctx context.Context, provider *providerRuntime) error {
+	if providerSkipsReadyzProbe(provider) {
+		return nil
+	}
+
 	req, err := h.newProviderProbeRequest(ctx, provider)
 	if err != nil {
 		return err
@@ -694,6 +698,18 @@ func (h *ProxyHandler) checkProviderReady(ctx context.Context, provider *provide
 	}
 
 	return nil
+}
+
+func providerSkipsReadyzProbe(provider *providerRuntime) bool {
+	if provider == nil {
+		return false
+	}
+	switch provider.kind {
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+		return provider.modelDiscovery == providerModelDiscoveryStatic
+	default:
+		return false
+	}
 }
 
 func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *providerRuntime) (*http.Request, error) {
@@ -880,9 +896,7 @@ func (h *ProxyHandler) buildMergedModelsEntry(ctx context.Context, rawQuery, ifN
 				continue
 			}
 			allDynamicProvidersUnchanged = false
-			if len(setup.providers) > 1 {
-				refreshedDynamicModels[provider.id] = models
-			}
+			refreshedDynamicModels[provider.id] = models
 			if result.etag != "" {
 				mergedETag = result.etag
 			}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -725,6 +725,12 @@ func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *pr
 			return nil, fmt.Errorf("failed to create provider %q probe request: %w", provider.id, err)
 		}
 		return req, nil
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, providerEndpointModels, nil, nil, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create provider %q probe request: %w", provider.id, err)
+		}
+		return req, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider type %q", provider.kind)
 	}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -243,6 +243,49 @@ func TestHandleReadyz(t *testing.T) {
 		}
 	})
 
+	t.Run("static generic provider does not require models probe", func(t *testing.T) {
+		var probeHits atomic.Int32
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			probeHits.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer upstream.Close()
+
+		h, err := NewProxyHandler(
+			auth.NewTestAuthenticator("test-token"),
+			logger.New(logger.LevelInfo),
+			WithProvidersConfig(ProvidersConfig{
+				Providers: []ProviderConfig{{
+					ID:       "local",
+					Type:     "openai-compatible",
+					Default:  true,
+					BaseURL:  upstream.URL,
+					AuthType: "none",
+					Models: []ProviderModelConfig{{
+						PublicID:  "local-public",
+						Endpoints: []string{"/chat/completions"},
+					}},
+				}},
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewProxyHandler returned error: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		h.HandleReadyz(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+		if got := probeHits.Load(); got != 0 {
+			t.Fatalf("expected no upstream probe, got %d hits", got)
+		}
+	})
+
 	t.Run("canceled request does not rewrite readiness status", func(t *testing.T) {
 		var probeHits atomic.Int32
 		h := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
@@ -5863,6 +5906,9 @@ func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProvider(t *tes
 	if anthropicResp.ID != "msg-direct" || len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Text == nil || *anthropicResp.Content[0].Text != "direct" {
 		t.Fatalf("unexpected direct Anthropic response: %+v", anthropicResp)
 	}
+	if anthropicResp.Model != "claude-public" {
+		t.Fatalf("direct Anthropic response model = %q, want public alias", anthropicResp.Model)
+	}
 }
 
 func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProviderStreamsSSE(t *testing.T) {
@@ -5927,6 +5973,63 @@ func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProviderStreams
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "stream-direct") {
 		t.Fatalf("expected direct SSE body to pass through, got %q", body)
+	}
+	if !strings.Contains(string(body), `"model":"claude-public"`) {
+		t.Fatalf("expected direct SSE model to be rewritten to public alias, got %q", body)
+	}
+	if strings.Contains(string(body), `"model":"claude-upstream"`) {
+		t.Fatalf("direct SSE leaked upstream model: %q", body)
+	}
+	if !w.Flushed {
+		t.Fatal("expected direct SSE response to flush")
+	}
+}
+
+func TestHandleOpenAIChatCompletions_RejectsUnknownStaticGenericModel(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:       "local",
+				Type:     "openai-compatible",
+				Default:  true,
+				BaseURL:  upstream.URL,
+				AuthType: "none",
+				Models: []ProviderModelConfig{{
+					PublicID:  "local-public",
+					Endpoints: []string{"/chat/completions"},
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model": "other",
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("expected unknown static model to be rejected before upstream, got %d hits", got)
 	}
 }
 
@@ -6010,6 +6113,222 @@ func TestHandleModels_GenericOpenAICompatibleEndpointVisibility(t *testing.T) {
 	}
 	if got := codexBySlug["responses-capable"]; got.Visibility != "list" || !got.SupportedInAPI {
 		t.Fatalf("responses-capable Codex metadata = %+v, want listed and supported", got)
+	}
+}
+
+func TestHandleResponses_AllowsDiscoveredDynamicGenericResponsesModel(t *testing.T) {
+	var responsesHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"dynamic-responses","object":"model","supported_endpoints":["/responses"],"name":"Dynamic Responses"}]}`))
+		case "/responses":
+			responsesHits.Add(1)
+			var upstreamReq map[string]json.RawMessage
+			if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+				t.Fatalf("decode upstream request: %v", err)
+			}
+			if got := rawJSONString(upstreamReq["model"]); got != "dynamic-responses" {
+				t.Fatalf("upstream model = %q, want dynamic-responses", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-dynamic","object":"response","status":"completed","model":"dynamic-responses","output":[]}`))
+		default:
+			t.Fatalf("unexpected upstream path %s", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:             "dynamic",
+				Type:           "openai-compatible",
+				Default:        true,
+				BaseURL:        upstream.URL,
+				AuthType:       "none",
+				ModelDiscovery: "openai",
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	modelsReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	modelsW := httptest.NewRecorder()
+	handler.HandleModels(modelsW, modelsReq)
+	if resp := modelsW.Result(); resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected models 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model": "dynamic-responses",
+		"input": "Hello"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if got := responsesHits.Load(); got != 1 {
+		t.Fatalf("expected one responses hit, got %d", got)
+	}
+}
+
+func TestHandleModels_GenericDynamicDiscoveryMatchesStaticAliasByDeployment(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("unexpected upstream path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"upstream-model","object":"model","supported_endpoints":["/chat/completions","/responses"],"name":"Upstream Model"}]}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:             "dynamic",
+				Type:           "openai-compatible",
+				Default:        true,
+				BaseURL:        upstream.URL,
+				AuthType:       "none",
+				ModelDiscovery: "openai",
+				Models: []ProviderModelConfig{{
+					PublicID:   "public-alias",
+					Deployment: "upstream-model",
+					Endpoints:  []string{"/responses"},
+					Name:       "Public Alias",
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Data []struct {
+			ID                 string   `json:"id"`
+			Name               string   `json:"name"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("models count = %d, want 1: %+v", len(result.Data), result.Data)
+	}
+	if result.Data[0].ID != "public-alias" {
+		t.Fatalf("model id = %q, want public-alias", result.Data[0].ID)
+	}
+	if result.Data[0].Name != "Public Alias" {
+		t.Fatalf("model name = %q, want Public Alias", result.Data[0].Name)
+	}
+	if !reflect.DeepEqual(result.Data[0].SupportedEndpoints, []string{"/responses"}) {
+		t.Fatalf("supported endpoints = %v, want [/responses]", result.Data[0].SupportedEndpoints)
+	}
+}
+
+func TestHandleModels_GenericDynamicDiscoveryExpandsDeploymentAliases(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("unexpected upstream path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"upstream-model","object":"model","supported_endpoints":["/chat/completions","/responses"],"name":"Upstream Model"}]}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:             "dynamic",
+				Type:           "openai-compatible",
+				Default:        true,
+				BaseURL:        upstream.URL,
+				AuthType:       "none",
+				ModelDiscovery: "openai",
+				Models: []ProviderModelConfig{
+					{
+						PublicID:   "public-chat",
+						Deployment: "upstream-model",
+						Endpoints:  []string{"/chat/completions"},
+						Name:       "Public Chat",
+					},
+					{
+						PublicID:   "public-responses",
+						Deployment: "upstream-model",
+						Endpoints:  []string{"/responses"},
+						Name:       "Public Responses",
+					},
+				},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Data []struct {
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+
+	endpointsByID := make(map[string][]string, len(result.Data))
+	for _, model := range result.Data {
+		endpointsByID[model.ID] = model.SupportedEndpoints
+	}
+	if len(endpointsByID) != 2 {
+		t.Fatalf("models = %+v, want two public aliases", result.Data)
+	}
+	if !reflect.DeepEqual(endpointsByID["public-chat"], []string{"/chat/completions"}) {
+		t.Fatalf("public-chat endpoints = %v, want [/chat/completions]", endpointsByID["public-chat"])
+	}
+	if !reflect.DeepEqual(endpointsByID["public-responses"], []string{"/responses"}) {
+		t.Fatalf("public-responses endpoints = %v, want [/responses]", endpointsByID["public-responses"])
+	}
+	if _, exists := endpointsByID["upstream-model"]; exists {
+		t.Fatalf("upstream model should be replaced by configured public aliases")
 	}
 }
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -5630,6 +5631,516 @@ func TestHandleOpenAIChatCompletions_RoutesConfiguredAzureModel(t *testing.T) {
 	}
 	if len(oaiResp.Choices) != 1 || string(oaiResp.Choices[0].Message.Content) != `"Hi"` {
 		t.Fatalf("unexpected response body: %+v", oaiResp)
+	}
+}
+
+func TestHandleOpenAIChatCompletions_RoutesGenericOpenAICompatibleModel(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/v1/chat/completions" {
+			t.Fatalf("expected generic chat path /v1/chat/completions, got %s", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer generic-key" {
+			t.Fatalf("expected generic bearer auth, got %q", got)
+		}
+		if got := r.Header.Get("X-Provider"); got != "local" {
+			t.Fatalf("expected configured X-Provider header, got %q", got)
+		}
+		if got := r.Header.Get("editor-version"); got != "" {
+			t.Fatalf("expected Copilot headers stripped, got editor-version %q", got)
+		}
+
+		var upstreamReq models.OpenAIRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "local-upstream" {
+			t.Fatalf("upstream model = %q, want local-upstream", upstreamReq.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(models.OpenAIResponse{
+			ID:     "chatcmpl-generic",
+			Object: "chat.completion",
+			Choices: []models.OpenAIChoice{{
+				Index: 0,
+				Message: models.OpenAIMessage{
+					Role:    "assistant",
+					Content: json.RawMessage(`"Hi from generic"`),
+				},
+			}},
+		})
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:                  "local",
+				Type:                "openai-compatible",
+				Default:             true,
+				BaseURL:             upstream.URL,
+				APIKey:              "generic-key",
+				ExtraHeaders:        map[string]string{"X-Provider": "local"},
+				ChatCompletionsPath: "/v1/chat/completions",
+				Models: []ProviderModelConfig{{
+					PublicID:   "local-public",
+					Deployment: "local-upstream",
+					Endpoints:  []string{"/chat/completions"},
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model": "local-public",
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var oaiResp models.OpenAIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&oaiResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(oaiResp.Choices) != 1 || string(oaiResp.Choices[0].Message.Content) != `"Hi from generic"` {
+		t.Fatalf("unexpected response body: %+v", oaiResp)
+	}
+}
+
+func TestHandleAnthropicMessages_UsesOpenAITranslationForGenericOpenAICompatibleProvider(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/chat/completions" {
+			t.Fatalf("expected translated Anthropic request to hit /chat/completions, got %s", got)
+		}
+		var upstreamReq models.OpenAIRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "local-upstream" {
+			t.Fatalf("upstream model = %q, want local-upstream", upstreamReq.Model)
+		}
+		if len(upstreamReq.Messages) == 0 || upstreamReq.Messages[len(upstreamReq.Messages)-1].Role != "user" {
+			t.Fatalf("expected translated user message, got %+v", upstreamReq.Messages)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello via translation\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:      "local",
+				Type:    "openai-compatible",
+				Default: true,
+				BaseURL: upstream.URL,
+				Models: []ProviderModelConfig{{
+					PublicID:   "local-public",
+					Deployment: "local-upstream",
+					Endpoints:  []string{"/chat/completions"},
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model": "local-public",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var anthropicResp models.AnthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&anthropicResp); err != nil {
+		t.Fatalf("decode Anthropic response: %v", err)
+	}
+	if len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Text == nil || *anthropicResp.Content[0].Text != "Hello via translation" {
+		t.Fatalf("unexpected Anthropic response: %+v", anthropicResp)
+	}
+}
+
+func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProvider(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/native/messages" {
+			t.Fatalf("expected native messages path /native/messages, got %s", got)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "anthropic-key" {
+			t.Fatalf("expected X-API-Key auth, got %q", got)
+		}
+		if got := r.Header.Get("Anthropic-Version"); got != "2023-06-01" {
+			t.Fatalf("expected Anthropic-Version forwarded, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("expected client Authorization stripped, got %q", got)
+		}
+
+		var upstreamReq models.AnthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "claude-upstream" {
+			t.Fatalf("upstream model = %q, want claude-upstream", upstreamReq.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg-direct","type":"message","role":"assistant","model":"claude-upstream","content":[{"type":"text","text":"direct"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:           "native",
+				Type:         "anthropic-compatible",
+				Default:      true,
+				BaseURL:      upstream.URL,
+				APIKey:       "anthropic-key",
+				AuthType:     "api-key-header",
+				AuthHeader:   "X-API-Key",
+				MessagesPath: "/native/messages",
+				Models: []ProviderModelConfig{{
+					PublicID:   "claude-public",
+					Deployment: "claude-upstream",
+					Endpoints:  []string{"/v1/messages"},
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model": "claude-public",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer client-token")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var anthropicResp models.AnthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&anthropicResp); err != nil {
+		t.Fatalf("decode Anthropic response: %v", err)
+	}
+	if anthropicResp.ID != "msg-direct" || len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Text == nil || *anthropicResp.Content[0].Text != "direct" {
+		t.Fatalf("unexpected direct Anthropic response: %+v", anthropicResp)
+	}
+}
+
+func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProviderStreamsSSE(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/v1/messages" {
+			t.Fatalf("expected default native messages path /v1/messages, got %s", got)
+		}
+		var upstreamReq models.AnthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if !upstreamReq.Stream {
+			t.Fatal("expected stream=true to be forwarded")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg-stream\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-upstream\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\n"))
+		_, _ = w.Write([]byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"stream-direct\"}}\n\n"))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:       "native",
+				Type:     "anthropic-compatible",
+				Default:  true,
+				BaseURL:  upstream.URL,
+				AuthType: "none",
+				Models: []ProviderModelConfig{{
+					PublicID:   "claude-public",
+					Deployment: "claude-upstream",
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model": "claude-public",
+		"max_tokens": 64,
+		"stream": true,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "stream-direct") {
+		t.Fatalf("expected direct SSE body to pass through, got %q", body)
+	}
+}
+
+func TestHandleModels_GenericOpenAICompatibleEndpointVisibility(t *testing.T) {
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:       "local",
+				Type:     "openai-compatible",
+				Default:  true,
+				BaseURL:  "http://localhost:1234",
+				AuthType: "none",
+				Models: []ProviderModelConfig{
+					{
+						PublicID: "chat-only",
+						Name:     "Chat Only",
+					},
+					{
+						PublicID:  "responses-capable",
+						Name:      "Responses Capable",
+						Endpoints: []string{"/chat/completions", "/responses"},
+					},
+				},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Data []struct {
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+		} `json:"data"`
+		Models []struct {
+			Slug           string `json:"slug"`
+			Visibility     string `json:"visibility"`
+			SupportedInAPI bool   `json:"supported_in_api"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+
+	endpointsByID := make(map[string][]string)
+	for _, model := range result.Data {
+		endpointsByID[model.ID] = model.SupportedEndpoints
+	}
+	if !reflect.DeepEqual(endpointsByID["chat-only"], []string{"/chat/completions"}) {
+		t.Fatalf("chat-only endpoints = %v, want [/chat/completions]", endpointsByID["chat-only"])
+	}
+	if endpoints := endpointsByID["responses-capable"]; !supportsEndpoint(endpoints, "/responses") {
+		t.Fatalf("responses-capable endpoints = %v, want /responses support", endpoints)
+	}
+
+	codexBySlug := make(map[string]struct {
+		Visibility     string
+		SupportedInAPI bool
+	})
+	for _, model := range result.Models {
+		codexBySlug[model.Slug] = struct {
+			Visibility     string
+			SupportedInAPI bool
+		}{Visibility: model.Visibility, SupportedInAPI: model.SupportedInAPI}
+	}
+	if got := codexBySlug["chat-only"]; got.Visibility != "hide" || got.SupportedInAPI {
+		t.Fatalf("chat-only Codex metadata = %+v, want hidden and unsupported", got)
+	}
+	if got := codexBySlug["responses-capable"]; got.Visibility != "list" || !got.SupportedInAPI {
+		t.Fatalf("responses-capable Codex metadata = %+v, want listed and supported", got)
+	}
+}
+
+func TestHandleModels_GenericOllamaDiscoveryUsesConfiguredPath(t *testing.T) {
+	var modelsCalls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		modelsCalls.Add(1)
+		if got := r.URL.Path; got != "/api/tags" {
+			t.Fatalf("expected Ollama models path /api/tags, got %s", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("expected no auth header for auth_type none, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"llama3.2:latest"},{"model":"qwen2.5-coder:latest"}]}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:                  "ollama",
+				Type:                "openai-compatible",
+				Default:             true,
+				BaseURL:             upstream.URL,
+				AuthType:            "none",
+				ModelDiscovery:      "ollama",
+				ModelsPath:          "/api/tags",
+				ChatCompletionsPath: "/v1/chat/completions",
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if got := modelsCalls.Load(); got != 1 {
+		t.Fatalf("expected one Ollama models call, got %d", got)
+	}
+
+	var result struct {
+		Data []struct {
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+	ids := map[string][]string{}
+	for _, model := range result.Data {
+		ids[model.ID] = model.SupportedEndpoints
+	}
+	if !reflect.DeepEqual(ids["llama3.2:latest"], []string{"/chat/completions"}) {
+		t.Fatalf("llama endpoints = %v, want [/chat/completions]", ids["llama3.2:latest"])
+	}
+	if !reflect.DeepEqual(ids["qwen2.5-coder:latest"], []string{"/chat/completions"}) {
+		t.Fatalf("qwen endpoints = %v, want [/chat/completions]", ids["qwen2.5-coder:latest"])
+	}
+}
+
+func TestHandleModels_GenericOpenRouterToolsDiscoveryFiltersToolModels(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/api/v1/models" {
+			t.Fatalf("expected OpenRouter models path /api/v1/models, got %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[
+			{"id":"tool-capable","name":"Tool Capable","supported_parameters":["tools","tool_choice"]},
+			{"id":"plain-chat","name":"Plain Chat","supported_parameters":["temperature"]}
+		]}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:             "openrouter",
+				Type:           "anthropic-compatible",
+				Default:        true,
+				BaseURL:        upstream.URL,
+				AuthType:       "none",
+				ModelDiscovery: "openrouter-tools",
+				ModelsPath:     "/api/v1/models",
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.HandleModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Data []struct {
+			ID                 string   `json:"id"`
+			SupportedEndpoints []string `json:"supported_endpoints"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("models count = %d, want only tool-capable model: %+v", len(result.Data), result.Data)
+	}
+	if result.Data[0].ID != "tool-capable" {
+		t.Fatalf("model id = %q, want tool-capable", result.Data[0].ID)
+	}
+	if !reflect.DeepEqual(result.Data[0].SupportedEndpoints, []string{"/v1/messages"}) {
+		t.Fatalf("supported endpoints = %v, want [/v1/messages]", result.Data[0].SupportedEndpoints)
 	}
 }
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -5985,6 +5985,88 @@ func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProviderStreams
 	}
 }
 
+func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProviderNormalizesModelAlias(t *testing.T) {
+	var openAIHits atomic.Int32
+	openAIUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		openAIHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer openAIUpstream.Close()
+
+	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var upstreamReq models.AnthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "claude-upstream" {
+			t.Fatalf("upstream model = %q, want claude-upstream", upstreamReq.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg-normalized","type":"message","role":"assistant","model":"claude-upstream","content":[{"type":"text","text":"normalized"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer anthropicUpstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:       "openai-default",
+					Type:     "openai-compatible",
+					Default:  true,
+					BaseURL:  openAIUpstream.URL,
+					AuthType: "none",
+					Models: []ProviderModelConfig{{
+						PublicID:  "gpt-default",
+						Endpoints: []string{"/chat/completions"},
+					}},
+				},
+				{
+					ID:       "native",
+					Type:     "anthropic-compatible",
+					BaseURL:  anthropicUpstream.URL,
+					AuthType: "none",
+					Models: []ProviderModelConfig{{
+						PublicID:   "claude-sonnet-4.5",
+						Deployment: "claude-upstream",
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model": "claude-sonnet-4-5",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var anthropicResp models.AnthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&anthropicResp); err != nil {
+		t.Fatalf("decode Anthropic response: %v", err)
+	}
+	if anthropicResp.Model != "claude-sonnet-4.5" {
+		t.Fatalf("response model = %q, want normalized public alias", anthropicResp.Model)
+	}
+	if got := openAIHits.Load(); got != 0 {
+		t.Fatalf("expected normalized Anthropic model to route direct, got %d OpenAI hits", got)
+	}
+}
+
 func TestHandleOpenAIChatCompletions_RejectsUnknownStaticGenericModel(t *testing.T) {
 	var upstreamHits atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -6408,7 +6490,7 @@ func TestHandleModels_GenericOpenRouterToolsDiscoveryFiltersToolModels(t *testin
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[
-			{"id":"tool-capable","name":"Tool Capable","supported_parameters":["tools","tool_choice"]},
+			{"id":"tool-capable","name":"Tool Capable","supported_parameters":["tools","tool_choice"],"supported_endpoints":["/chat/completions"]},
 			{"id":"plain-chat","name":"Plain Chat","supported_parameters":["temperature"]}
 		]}`))
 	}))

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -20,16 +20,44 @@ type providerType string
 type providerAuthMode string
 
 const (
-	providerTypeCopilot     providerType = "copilot"
-	providerTypeAzureOpenAI providerType = "azure-openai"
-	providerTypeOpenAICodex providerType = "openai-codex"
+	providerTypeCopilot             providerType = "copilot"
+	providerTypeAzureOpenAI         providerType = "azure-openai"
+	providerTypeOpenAICodex         providerType = "openai-codex"
+	providerTypeOpenAICompatible    providerType = "openai-compatible"
+	providerTypeAnthropicCompatible providerType = "anthropic-compatible"
 
 	providerAuthModeAPIKey        providerAuthMode = "api_key"
 	providerAuthModeAzureIdentity providerAuthMode = "azure_identity"
 )
 
-var defaultStaticProviderEndpoints = []string{"/chat/completions", "/responses"}
-var openAICodexProviderEndpoints = []string{"/responses"}
+type providerAuthType string
+
+const (
+	providerAuthTypeBearer       providerAuthType = "bearer"
+	providerAuthTypeAPIKeyHeader providerAuthType = "api-key-header"
+	providerAuthTypeNone         providerAuthType = "none"
+)
+
+type providerModelDiscovery string
+
+const (
+	providerModelDiscoveryStatic          providerModelDiscovery = "static"
+	providerModelDiscoveryOpenAI          providerModelDiscovery = "openai"
+	providerModelDiscoveryOllama          providerModelDiscovery = "ollama"
+	providerModelDiscoveryOpenRouterTools providerModelDiscovery = "openrouter-tools"
+)
+
+const (
+	providerEndpointChatCompletions = "/chat/completions"
+	providerEndpointResponses       = "/responses"
+	providerEndpointMessages        = "/v1/messages"
+	providerEndpointModels          = "/models"
+)
+
+var defaultStaticProviderEndpoints = []string{providerEndpointChatCompletions, providerEndpointResponses}
+var defaultOpenAICompatibleProviderEndpoints = []string{providerEndpointChatCompletions}
+var defaultAnthropicCompatibleProviderEndpoints = []string{providerEndpointMessages}
+var openAICodexProviderEndpoints = []string{providerEndpointResponses}
 
 // ProvidersConfig configures optional non-Copilot upstream providers.
 // When empty, the proxy keeps its legacy zero-config Copilot behavior.
@@ -40,19 +68,28 @@ type ProvidersConfig struct {
 
 // ProviderConfig configures one upstream provider instance.
 type ProviderConfig struct {
-	ID            string                      `json:"id" yaml:"id"`
-	Type          string                      `json:"type" yaml:"type"`
-	Default       bool                        `json:"default,omitempty" yaml:"default,omitempty"`
-	IncludeModels []string                    `json:"include_models,omitempty" yaml:"include_models,omitempty"`
-	ExcludeModels []string                    `json:"exclude_models,omitempty" yaml:"exclude_models,omitempty"`
-	BaseURL       string                      `json:"base_url,omitempty" yaml:"base_url,omitempty"`
-	AuthMode      string                      `json:"auth_mode,omitempty" yaml:"auth_mode,omitempty"`
-	APIKey        string                      `json:"api_key,omitempty" yaml:"api_key,omitempty"`
-	APIKeyEnv     string                      `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
-	APIVersion    string                      `json:"api_version,omitempty" yaml:"api_version,omitempty"`
-	TokenScope    string                      `json:"token_scope,omitempty" yaml:"token_scope,omitempty"`
-	Headers       CopilotHeaderProfilesConfig `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Models        []ProviderModelConfig       `json:"models,omitempty" yaml:"models,omitempty"`
+	ID                  string                      `json:"id" yaml:"id"`
+	Type                string                      `json:"type" yaml:"type"`
+	Default             bool                        `json:"default,omitempty" yaml:"default,omitempty"`
+	IncludeModels       []string                    `json:"include_models,omitempty" yaml:"include_models,omitempty"`
+	ExcludeModels       []string                    `json:"exclude_models,omitempty" yaml:"exclude_models,omitempty"`
+	BaseURL             string                      `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	AuthMode            string                      `json:"auth_mode,omitempty" yaml:"auth_mode,omitempty"`
+	APIKey              string                      `json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	APIKeyEnv           string                      `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
+	APIVersion          string                      `json:"api_version,omitempty" yaml:"api_version,omitempty"`
+	TokenScope          string                      `json:"token_scope,omitempty" yaml:"token_scope,omitempty"`
+	AuthType            string                      `json:"auth_type,omitempty" yaml:"auth_type,omitempty"`
+	AuthHeader          string                      `json:"auth_header,omitempty" yaml:"auth_header,omitempty"`
+	AuthPrefix          string                      `json:"auth_prefix,omitempty" yaml:"auth_prefix,omitempty"`
+	ExtraHeaders        map[string]string           `json:"extra_headers,omitempty" yaml:"extra_headers,omitempty"`
+	ChatCompletionsPath string                      `json:"chat_completions_path,omitempty" yaml:"chat_completions_path,omitempty"`
+	ResponsesPath       string                      `json:"responses_path,omitempty" yaml:"responses_path,omitempty"`
+	MessagesPath        string                      `json:"messages_path,omitempty" yaml:"messages_path,omitempty"`
+	ModelsPath          string                      `json:"models_path,omitempty" yaml:"models_path,omitempty"`
+	ModelDiscovery      string                      `json:"model_discovery,omitempty" yaml:"model_discovery,omitempty"`
+	Headers             CopilotHeaderProfilesConfig `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Models              []ProviderModelConfig       `json:"models,omitempty" yaml:"models,omitempty"`
 }
 
 // ProviderModelConfig maps a public model ID exposed by this proxy to the
@@ -80,6 +117,12 @@ type providerRuntime struct {
 	apiVersion     string
 	tokenScope     string
 	azureToken     azureTokenSource
+	authType       providerAuthType
+	authHeader     string
+	authPrefix     string
+	extraHeaders   http.Header
+	paths          providerEndpointPaths
+	modelDiscovery providerModelDiscovery
 	includeModels  map[string]struct{}
 	excludeModels  map[string]struct{}
 	staticModels   map[string]providerModel
@@ -87,6 +130,13 @@ type providerRuntime struct {
 	staticOrder    []string
 	codexAuth      *openAICodexAuth
 	headerProfiles CopilotHeaderProfilesConfig
+}
+
+type providerEndpointPaths struct {
+	chatCompletions string
+	responses       string
+	messages        string
+	models          string
 }
 
 type providerModel struct {
@@ -223,6 +273,7 @@ func defaultProviderSetup(h *ProxyHandler) *providerSetup {
 				kind:          providerTypeCopilot,
 				isDefault:     true,
 				baseURL:       strings.TrimRight(h.copilotURL, "/"),
+				paths:         defaultProviderEndpointPaths(providerTypeCopilot),
 				includeModels: map[string]struct{}{},
 				excludeModels: map[string]struct{}{},
 				staticModels:  map[string]providerModel{},
@@ -459,19 +510,21 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 
 	kind := providerType(strings.TrimSpace(cfg.Type))
 	switch kind {
-	case providerTypeCopilot, providerTypeAzureOpenAI, providerTypeOpenAICodex:
+	case providerTypeCopilot, providerTypeAzureOpenAI, providerTypeOpenAICodex, providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
 	default:
 		return nil, fmt.Errorf("provider %q has unsupported type %q", id, cfg.Type)
 	}
 
 	runtime := &providerRuntime{
-		id:            id,
-		kind:          kind,
-		isDefault:     cfg.Default,
-		includeModels: make(map[string]struct{}, len(cfg.IncludeModels)),
-		excludeModels: make(map[string]struct{}, len(cfg.ExcludeModels)),
-		staticModels:  make(map[string]providerModel, len(cfg.Models)),
-		staticConfigs: make(map[string]ProviderModelConfig, len(cfg.Models)),
+		id:             id,
+		kind:           kind,
+		isDefault:      cfg.Default,
+		paths:          defaultProviderEndpointPaths(kind),
+		modelDiscovery: providerModelDiscoveryStatic,
+		includeModels:  make(map[string]struct{}, len(cfg.IncludeModels)),
+		excludeModels:  make(map[string]struct{}, len(cfg.ExcludeModels)),
+		staticModels:   make(map[string]providerModel, len(cfg.Models)),
+		staticConfigs:  make(map[string]ProviderModelConfig, len(cfg.Models)),
 	}
 
 	for _, included := range cfg.IncludeModels {
@@ -548,20 +601,8 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		if len(cfg.Models) == 0 {
 			return nil, fmt.Errorf("provider %q must configure at least one model", id)
 		}
-		for _, modelCfg := range cfg.Models {
-			model, err := buildStaticProviderModel(id, modelCfg)
-			if err != nil {
-				return nil, err
-			}
-			if !runtime.allowsModel(model.publicID) {
-				continue
-			}
-			if _, exists := runtime.staticModels[model.publicID]; exists {
-				return nil, fmt.Errorf("provider %q configures model %q more than once", id, model.publicID)
-			}
-			runtime.staticModels[model.publicID] = model
-			runtime.staticConfigs[model.publicID] = normalizeProviderModelConfig(modelCfg)
-			runtime.staticOrder = append(runtime.staticOrder, model.publicID)
+		if err := addStaticProviderModels(runtime, cfg.Models, defaultStaticEndpointsForProvider(kind)); err != nil {
+			return nil, err
 		}
 	case providerTypeOpenAICodex:
 		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
@@ -577,9 +618,232 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		}
 		runtime.baseURL = baseURL
 		runtime.codexAuth = codexAuth
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+		if baseURL == "" {
+			return nil, fmt.Errorf("provider %q must set base_url", id)
+		}
+		if err := validateGenericProviderBaseURL(id, string(kind), baseURL); err != nil {
+			return nil, err
+		}
+		paths, err := configuredProviderEndpointPaths(kind, cfg)
+		if err != nil {
+			return nil, err
+		}
+		authType, authHeader, authPrefix, apiKey, err := configuredGenericProviderAuth(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", id, err)
+		}
+		extraHeaders, err := configuredProviderExtraHeaders(cfg.ExtraHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", id, err)
+		}
+		modelDiscovery, err := configuredProviderModelDiscovery(kind, cfg.ModelDiscovery)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", id, err)
+		}
+
+		runtime.baseURL = baseURL
+		runtime.paths = paths
+		runtime.authType = authType
+		runtime.authHeader = authHeader
+		runtime.authPrefix = authPrefix
+		runtime.apiKey = apiKey
+		runtime.extraHeaders = extraHeaders
+		runtime.modelDiscovery = modelDiscovery
+
+		if modelDiscovery == providerModelDiscoveryStatic && len(cfg.Models) == 0 {
+			return nil, fmt.Errorf("provider %q must configure at least one model when model_discovery is static", id)
+		}
+		if err := addStaticProviderModels(runtime, cfg.Models, defaultStaticEndpointsForProvider(kind)); err != nil {
+			return nil, err
+		}
 	}
 
 	return runtime, nil
+}
+
+func addStaticProviderModels(runtime *providerRuntime, models []ProviderModelConfig, defaultEndpoints []string) error {
+	if runtime == nil {
+		return fmt.Errorf("provider runtime is required")
+	}
+	for _, modelCfg := range models {
+		model, err := buildStaticProviderModel(runtime.id, modelCfg, defaultEndpoints)
+		if err != nil {
+			return err
+		}
+		if !runtime.allowsModel(model.publicID) {
+			continue
+		}
+		if _, exists := runtime.staticModels[model.publicID]; exists {
+			return fmt.Errorf("provider %q configures model %q more than once", runtime.id, model.publicID)
+		}
+		runtime.staticModels[model.publicID] = model
+		runtime.staticConfigs[model.publicID] = normalizeProviderModelConfig(modelCfg)
+		runtime.staticOrder = append(runtime.staticOrder, model.publicID)
+	}
+	return nil
+}
+
+func defaultStaticEndpointsForProvider(kind providerType) []string {
+	switch kind {
+	case providerTypeOpenAICompatible:
+		return defaultOpenAICompatibleProviderEndpoints
+	case providerTypeAnthropicCompatible:
+		return defaultAnthropicCompatibleProviderEndpoints
+	default:
+		return defaultStaticProviderEndpoints
+	}
+}
+
+func defaultProviderEndpointPaths(kind providerType) providerEndpointPaths {
+	paths := providerEndpointPaths{
+		chatCompletions: providerEndpointChatCompletions,
+		responses:       providerEndpointResponses,
+		messages:        providerEndpointMessages,
+		models:          providerEndpointModels,
+	}
+	if kind == providerTypeOpenAICodex {
+		paths.chatCompletions = ""
+		paths.messages = ""
+	}
+	return paths
+}
+
+func configuredProviderEndpointPaths(kind providerType, cfg ProviderConfig) (providerEndpointPaths, error) {
+	paths := defaultProviderEndpointPaths(kind)
+
+	var err error
+	if paths.chatCompletions, err = normalizeProviderPath(cfg.ChatCompletionsPath, paths.chatCompletions, "chat_completions_path"); err != nil {
+		return providerEndpointPaths{}, err
+	}
+	if paths.responses, err = normalizeProviderPath(cfg.ResponsesPath, paths.responses, "responses_path"); err != nil {
+		return providerEndpointPaths{}, err
+	}
+	if paths.messages, err = normalizeProviderPath(cfg.MessagesPath, paths.messages, "messages_path"); err != nil {
+		return providerEndpointPaths{}, err
+	}
+	if paths.models, err = normalizeProviderPath(cfg.ModelsPath, paths.models, "models_path"); err != nil {
+		return providerEndpointPaths{}, err
+	}
+	return paths, nil
+}
+
+func normalizeProviderPath(configured, fallback, field string) (string, error) {
+	path := strings.TrimSpace(configured)
+	if path == "" {
+		return fallback, nil
+	}
+	if !strings.HasPrefix(path, "/") || strings.ContainsAny(path, "?#") {
+		return "", fmt.Errorf("%s must be an absolute path with no query string or fragment", field)
+	}
+	return path, nil
+}
+
+func configuredGenericProviderAuth(cfg ProviderConfig) (providerAuthType, string, string, string, error) {
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	if apiKey == "" && strings.TrimSpace(cfg.APIKeyEnv) != "" {
+		apiKey = strings.TrimSpace(os.Getenv(strings.TrimSpace(cfg.APIKeyEnv)))
+	}
+
+	authType := providerAuthType(strings.TrimSpace(cfg.AuthType))
+	if authType == "" {
+		if apiKey == "" {
+			authType = providerAuthTypeNone
+		} else {
+			authType = providerAuthTypeBearer
+		}
+	}
+
+	authHeader := strings.TrimSpace(cfg.AuthHeader)
+	authPrefix := strings.TrimSpace(cfg.AuthPrefix)
+
+	switch authType {
+	case providerAuthTypeNone:
+		return authType, "", "", apiKey, nil
+	case providerAuthTypeBearer:
+		if apiKey == "" {
+			return "", "", "", "", fmt.Errorf("auth_type bearer requires api_key or api_key_env")
+		}
+		if authHeader == "" {
+			authHeader = "Authorization"
+		}
+		if authPrefix == "" {
+			authPrefix = "Bearer"
+		}
+	case providerAuthTypeAPIKeyHeader:
+		if apiKey == "" {
+			return "", "", "", "", fmt.Errorf("auth_type api-key-header requires api_key or api_key_env")
+		}
+		if authHeader == "" {
+			return "", "", "", "", fmt.Errorf("auth_type api-key-header requires auth_header")
+		}
+	default:
+		return "", "", "", "", fmt.Errorf("unsupported auth_type %q", cfg.AuthType)
+	}
+
+	if !validProviderHeaderName(authHeader) {
+		return "", "", "", "", fmt.Errorf("auth_header %q is invalid", authHeader)
+	}
+	return authType, http.CanonicalHeaderKey(authHeader), authPrefix, apiKey, nil
+}
+
+func configuredProviderExtraHeaders(configured map[string]string) (http.Header, error) {
+	if len(configured) == 0 {
+		return nil, nil
+	}
+	headers := make(http.Header, len(configured))
+	for name, value := range configured {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if !validProviderHeaderName(name) {
+			return nil, fmt.Errorf("extra_headers contains invalid header %q", name)
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		headers.Set(http.CanonicalHeaderKey(name), value)
+	}
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	return headers, nil
+}
+
+func validProviderHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case strings.ContainsRune("!#$%&'*+-.^_`|~", r):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func configuredProviderModelDiscovery(kind providerType, configured string) (providerModelDiscovery, error) {
+	discovery := providerModelDiscovery(strings.TrimSpace(configured))
+	if discovery == "" {
+		return providerModelDiscoveryStatic, nil
+	}
+	switch discovery {
+	case providerModelDiscoveryStatic, providerModelDiscoveryOpenAI, providerModelDiscoveryOllama, providerModelDiscoveryOpenRouterTools:
+	default:
+		return "", fmt.Errorf("unsupported model_discovery %q", configured)
+	}
+	if kind == providerTypeAnthropicCompatible && discovery == providerModelDiscoveryOllama {
+		return "", fmt.Errorf("model_discovery ollama is only supported for openai-compatible providers")
+	}
+	return discovery, nil
 }
 
 func filterProviderModels(provider *providerRuntime, models []providerModel) []providerModel {
@@ -624,7 +888,14 @@ func providerUsesDynamicModels(provider *providerRuntime) bool {
 	if provider == nil {
 		return false
 	}
-	return provider.kind == providerTypeCopilot || provider.kind == providerTypeOpenAICodex
+	switch provider.kind {
+	case providerTypeCopilot, providerTypeOpenAICodex:
+		return true
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+		return provider.modelDiscovery != providerModelDiscoveryStatic
+	default:
+		return false
+	}
 }
 
 func (p *providerRuntime) allowsModel(model string) bool {
@@ -662,7 +933,7 @@ func providerModelCollisionError(publicID, existingProviderID, incomingProviderI
 	)
 }
 
-func buildStaticProviderModel(providerID string, cfg ProviderModelConfig) (providerModel, error) {
+func buildStaticProviderModel(providerID string, cfg ProviderModelConfig, defaultEndpoints []string) (providerModel, error) {
 	publicID := strings.TrimSpace(cfg.PublicID)
 	if publicID == "" {
 		return providerModel{}, fmt.Errorf("provider %q contains a model without public_id", providerID)
@@ -678,7 +949,7 @@ func buildStaticProviderModel(providerID string, cfg ProviderModelConfig) (provi
 		name = publicID
 	}
 
-	endpoints := normalizeProviderEndpoints(cfg.Endpoints)
+	endpoints := normalizeProviderEndpoints(cfg.Endpoints, defaultEndpoints)
 	raw, err := synthesizeProviderModelRaw(providerID, publicID, name, endpoints, cfg)
 	if err != nil {
 		return providerModel{}, err
@@ -707,9 +978,9 @@ func normalizeProviderModelConfig(cfg ProviderModelConfig) ProviderModelConfig {
 	return cfg
 }
 
-func normalizeProviderEndpoints(endpoints []string) []string {
+func normalizeProviderEndpoints(endpoints []string, defaultEndpoints []string) []string {
 	if len(endpoints) == 0 {
-		return append([]string(nil), defaultStaticProviderEndpoints...)
+		return append([]string(nil), defaultEndpoints...)
 	}
 
 	normalized := make([]string, 0, len(endpoints))
@@ -726,7 +997,7 @@ func normalizeProviderEndpoints(endpoints []string) []string {
 		normalized = append(normalized, endpoint)
 	}
 	if len(normalized) == 0 {
-		return append([]string(nil), defaultStaticProviderEndpoints...)
+		return append([]string(nil), defaultEndpoints...)
 	}
 	return normalized
 }
@@ -858,11 +1129,40 @@ func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string
 	}
 
 	baseURL := strings.TrimRight(provider.baseURL, "/")
-	fullURL := baseURL + path
+	upstreamPath := provider.upstreamPath(path)
+	if upstreamPath == "" {
+		return "", fmt.Errorf("provider %q has no upstream path configured for %s", provider.id, path)
+	}
+	fullURL := baseURL + upstreamPath
 	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" || classifyAzureBaseURL(baseURL) == azureBaseURLKindOpenAIV1 {
 		return appendRawQuery(fullURL, extraQuery), nil
 	}
 	return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+}
+
+func (p *providerRuntime) upstreamPath(endpoint string) string {
+	if p == nil {
+		return endpoint
+	}
+	switch strings.TrimSpace(endpoint) {
+	case providerEndpointChatCompletions:
+		if p.paths.chatCompletions != "" {
+			return p.paths.chatCompletions
+		}
+	case providerEndpointResponses:
+		if p.paths.responses != "" {
+			return p.paths.responses
+		}
+	case providerEndpointMessages:
+		if p.paths.messages != "" {
+			return p.paths.messages
+		}
+	case providerEndpointModels:
+		if p.paths.models != "" {
+			return p.paths.models
+		}
+	}
+	return endpoint
 }
 
 func classifyAzureBaseURL(baseURL string) azureBaseURLKind {
@@ -980,10 +1280,42 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 			req.Header.Set("X-OpenAI-Fedramp", "true")
 		}
 		req.Header.Set("Content-Type", "application/json")
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+		clearCopilotHeaders(req.Header)
+		mergeHeaderValues(req.Header, provider.extraHeaders)
+		if err := applyGenericProviderAuth(req, provider); err != nil {
+			return err
+		}
+		if req.Method != http.MethodGet {
+			req.Header.Set("Content-Type", "application/json")
+		}
 	default:
 		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("unsupported provider type %q", provider.kind)}
 	}
 	return nil
+}
+
+func applyGenericProviderAuth(req *http.Request, provider *providerRuntime) error {
+	switch provider.authType {
+	case providerAuthTypeNone, "":
+		return nil
+	case providerAuthTypeBearer, providerAuthTypeAPIKeyHeader:
+		if strings.TrimSpace(provider.apiKey) == "" {
+			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no API key configured", provider.id)}
+		}
+		header := strings.TrimSpace(provider.authHeader)
+		if header == "" {
+			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no auth header configured", provider.id)}
+		}
+		value := provider.apiKey
+		if prefix := strings.TrimSpace(provider.authPrefix); prefix != "" {
+			value = prefix + " " + value
+		}
+		req.Header.Set(header, value)
+		return nil
+	default:
+		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("unsupported auth type %q", provider.authType)}
+	}
 }
 
 func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string) (*http.Request, error) {
@@ -1140,6 +1472,58 @@ func (h *ProxyHandler) fetchProviderModels(ctx context.Context, provider *provid
 			return providerModelsFetchResult{}, err
 		}
 		result.models = models
+		return result, nil
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+		if provider.modelDiscovery == providerModelDiscoveryStatic {
+			return providerModelsFetchResult{models: orderedStaticProviderModels(provider)}, nil
+		}
+
+		resp, err := h.doWithRetry(func() (*http.Request, error) {
+			req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, providerEndpointModels, nil, nil, rawQuery)
+			if err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(ifNoneMatch) != "" {
+				req.Header.Set("If-None-Match", ifNoneMatch)
+			}
+			return req, nil
+		})
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		result := providerModelsFetchResult{etag: resp.Header.Get("ETag")}
+		if resp.StatusCode == http.StatusNotModified {
+			result.notModified = true
+			return result, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			return providerModelsFetchResult{}, &providerRequestError{
+				statusCode: resp.StatusCode,
+				err:        fmt.Errorf("unexpected /models status %d: %s", resp.StatusCode, string(body)),
+			}
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+
+		var models []providerModel
+		switch provider.modelDiscovery {
+		case providerModelDiscoveryOpenAI, providerModelDiscoveryOpenRouterTools:
+			models, err = decodeProviderModelsFromBody(provider, body)
+		case providerModelDiscoveryOllama:
+			models, err = decodeOllamaModelsFromBody(provider, body)
+		default:
+			err = fmt.Errorf("unsupported model discovery %q", provider.modelDiscovery)
+		}
+		if err != nil {
+			return providerModelsFetchResult{}, err
+		}
+		result.models = mergeDiscoveredProviderModelsWithStaticConfig(provider, models)
 		return result, nil
 	default:
 		return providerModelsFetchResult{}, fmt.Errorf("unsupported provider type %q", provider.kind)
@@ -1347,7 +1731,10 @@ func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]pro
 	for _, raw := range upstream.Data {
 		var parsed struct {
 			ID                 string   `json:"id"`
+			Name               string   `json:"name"`
 			SupportedEndpoints []string `json:"supported_endpoints"`
+			SupportedParams    []string `json:"supported_parameters"`
+			ContextLength      int64    `json:"context_length"`
 			Policy             struct {
 				State string `json:"state"`
 			} `json:"policy"`
@@ -1362,8 +1749,14 @@ func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]pro
 		if !provider.allowsModel(publicID) {
 			continue
 		}
+		if provider.modelDiscovery == providerModelDiscoveryOpenRouterTools && !openRouterModelSupportsTools(parsed.SupportedParams) {
+			continue
+		}
 
 		supportedEndpoints := normalizeDynamicProviderEndpoints(parsed.SupportedEndpoints)
+		if len(supportedEndpoints) == 0 {
+			supportedEndpoints = defaultDynamicProviderEndpoints(provider)
+		}
 		disabled := strings.EqualFold(parsed.Policy.State, "disabled")
 		if index, duplicate := indexByID[publicID]; duplicate {
 			merged := models[index]
@@ -1386,6 +1779,118 @@ func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]pro
 			supportedEndpoints: supportedEndpoints,
 			disabled:           disabled,
 			raw:                mergeProviderModelRaw(raw, supportedEndpoints),
+		})
+	}
+
+	return models, nil
+}
+
+func openRouterModelSupportsTools(supportedParams []string) bool {
+	for _, param := range supportedParams {
+		switch strings.TrimSpace(param) {
+		case "tools", "tool_choice":
+			return true
+		}
+	}
+	return false
+}
+
+func defaultDynamicProviderEndpoints(provider *providerRuntime) []string {
+	if provider == nil {
+		return nil
+	}
+	switch provider.kind {
+	case providerTypeOpenAICompatible:
+		return append([]string(nil), defaultOpenAICompatibleProviderEndpoints...)
+	case providerTypeAnthropicCompatible:
+		return append([]string(nil), defaultAnthropicCompatibleProviderEndpoints...)
+	default:
+		return nil
+	}
+}
+
+func mergeDiscoveredProviderModelsWithStaticConfig(provider *providerRuntime, discovered []providerModel) []providerModel {
+	if provider == nil || len(discovered) == 0 || len(provider.staticConfigs) == 0 {
+		return discovered
+	}
+
+	merged := make([]providerModel, 0, len(discovered))
+	for _, model := range discovered {
+		cfg, ok := provider.staticConfigs[model.publicID]
+		if !ok {
+			merged = append(merged, model)
+			continue
+		}
+
+		staticModel, err := buildStaticProviderModel(provider.id, cfg, defaultStaticEndpointsForProvider(provider.kind))
+		if err != nil {
+			merged = append(merged, model)
+			continue
+		}
+		staticModel.disabled = model.disabled
+		staticModel.raw, err = mergeProviderModelMetadataOverlayRaw(staticModel.raw, model.raw, cfg)
+		if err != nil {
+			staticModel.raw = mergeProviderModelRaw(staticModel.raw, staticModel.supportedEndpoints)
+		}
+		merged = append(merged, staticModel)
+	}
+	return merged
+}
+
+func decodeOllamaModelsFromBody(provider *providerRuntime, body []byte) ([]providerModel, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is required")
+	}
+
+	var upstream struct {
+		Models []json.RawMessage `json:"models"`
+	}
+	if err := json.Unmarshal(body, &upstream); err != nil {
+		return nil, err
+	}
+
+	defaultEndpoints := defaultDynamicProviderEndpoints(provider)
+	models := make([]providerModel, 0, len(upstream.Models))
+	seen := make(map[string]struct{}, len(upstream.Models))
+	for _, raw := range upstream.Models {
+		var parsed struct {
+			Name  string `json:"name"`
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			continue
+		}
+		publicID := strings.TrimSpace(parsed.Name)
+		if publicID == "" {
+			publicID = strings.TrimSpace(parsed.Model)
+		}
+		if publicID == "" {
+			continue
+		}
+		if _, duplicate := seen[publicID]; duplicate {
+			continue
+		}
+		if !provider.allowsModel(publicID) {
+			continue
+		}
+
+		cfg := ProviderModelConfig{
+			PublicID:  publicID,
+			Name:      publicID,
+			Endpoints: defaultEndpoints,
+		}
+		modelRaw, err := synthesizeProviderModelRaw(provider.id, publicID, publicID, defaultEndpoints, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		seen[publicID] = struct{}{}
+		models = append(models, providerModel{
+			publicID:           publicID,
+			upstreamModel:      publicID,
+			providerID:         provider.id,
+			supportedEndpoints: append([]string(nil), defaultEndpoints...),
+			raw:                modelRaw,
 		})
 	}
 

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -742,8 +742,12 @@ func normalizeProviderPath(configured, fallback, field string) (string, error) {
 
 func configuredGenericProviderAuth(cfg ProviderConfig) (providerAuthType, string, string, string, error) {
 	apiKey := strings.TrimSpace(cfg.APIKey)
-	if apiKey == "" && strings.TrimSpace(cfg.APIKeyEnv) != "" {
-		apiKey = strings.TrimSpace(os.Getenv(strings.TrimSpace(cfg.APIKeyEnv)))
+	apiKeyEnv := strings.TrimSpace(cfg.APIKeyEnv)
+	if apiKey == "" && apiKeyEnv != "" {
+		apiKey = strings.TrimSpace(os.Getenv(apiKeyEnv))
+		if apiKey == "" {
+			return "", "", "", "", fmt.Errorf("api_key_env %q is not set or is empty", apiKeyEnv)
+		}
 	}
 
 	authType := providerAuthType(strings.TrimSpace(cfg.AuthType))
@@ -1753,7 +1757,7 @@ func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]pro
 			continue
 		}
 
-		supportedEndpoints := normalizeDynamicProviderEndpoints(parsed.SupportedEndpoints)
+		supportedEndpoints := normalizeDynamicProviderEndpoints(provider, parsed.SupportedEndpoints)
 		if len(supportedEndpoints) == 0 {
 			supportedEndpoints = defaultDynamicProviderEndpoints(provider)
 		}
@@ -2083,7 +2087,7 @@ func rawQueryHasParam(rawQuery, name string) bool {
 	return ok
 }
 
-func normalizeDynamicProviderEndpoints(endpoints []string) []string {
+func normalizeDynamicProviderEndpoints(provider *providerRuntime, endpoints []string) []string {
 	if len(endpoints) == 0 {
 		return nil
 	}
@@ -2093,6 +2097,9 @@ func normalizeDynamicProviderEndpoints(endpoints []string) []string {
 	for _, endpoint := range endpoints {
 		endpoint = strings.TrimSpace(endpoint)
 		if endpoint == "" {
+			continue
+		}
+		if provider != nil && provider.kind == providerTypeAnthropicCompatible && endpoint != providerEndpointMessages {
 			continue
 		}
 		if _, exists := seen[endpoint]; exists {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -805,7 +805,7 @@ func configuredProviderExtraHeaders(configured map[string]string) (http.Header, 
 		if value == "" {
 			continue
 		}
-		headers.Set(http.CanonicalHeaderKey(name), value)
+		headers.Set(name, value)
 	}
 	if len(headers) == 0 {
 		return nil, nil
@@ -1816,25 +1816,44 @@ func mergeDiscoveredProviderModelsWithStaticConfig(provider *providerRuntime, di
 
 	merged := make([]providerModel, 0, len(discovered))
 	for _, model := range discovered {
-		cfg, ok := provider.staticConfigs[model.publicID]
-		if !ok {
+		configs := staticConfigsForDiscoveredProviderModel(provider, model)
+		if len(configs) == 0 {
 			merged = append(merged, model)
 			continue
 		}
 
-		staticModel, err := buildStaticProviderModel(provider.id, cfg, defaultStaticEndpointsForProvider(provider.kind))
-		if err != nil {
-			merged = append(merged, model)
-			continue
+		for _, cfg := range configs {
+			staticModel, err := buildStaticProviderModel(provider.id, cfg, defaultStaticEndpointsForProvider(provider.kind))
+			if err != nil {
+				continue
+			}
+			staticModel.disabled = model.disabled
+			staticModel.raw, err = mergeProviderModelMetadataOverlayRaw(staticModel.raw, model.raw, cfg)
+			if err != nil {
+				staticModel.raw = mergeProviderModelRaw(staticModel.raw, staticModel.supportedEndpoints)
+			}
+			merged = append(merged, staticModel)
 		}
-		staticModel.disabled = model.disabled
-		staticModel.raw, err = mergeProviderModelMetadataOverlayRaw(staticModel.raw, model.raw, cfg)
-		if err != nil {
-			staticModel.raw = mergeProviderModelRaw(staticModel.raw, staticModel.supportedEndpoints)
-		}
-		merged = append(merged, staticModel)
 	}
 	return merged
+}
+
+func staticConfigsForDiscoveredProviderModel(provider *providerRuntime, model providerModel) []ProviderModelConfig {
+	if provider == nil || len(provider.staticOrder) == 0 {
+		return nil
+	}
+
+	configs := make([]ProviderModelConfig, 0, 1)
+	for _, publicID := range provider.staticOrder {
+		cfg, ok := provider.staticConfigs[publicID]
+		if !ok {
+			continue
+		}
+		if publicID == model.publicID || strings.TrimSpace(cfg.Deployment) == model.publicID {
+			configs = append(configs, cfg)
+		}
+	}
+	return configs
 }
 
 func decodeOllamaModelsFromBody(provider *providerRuntime, body []byte) ([]providerModel, error) {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -361,6 +361,183 @@ func TestLoadProvidersConfigFileCopilotHeaderProfiles(t *testing.T) {
 	}
 }
 
+func TestBuildProvidersGenericOpenAICompatibleConfig(t *testing.T) {
+	t.Setenv("TEST_GENERIC_API_KEY", "generic-key")
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	providers, _, defaultProviderID, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:                  "local-openai",
+			Type:                "openai-compatible",
+			Default:             true,
+			BaseURL:             "http://localhost:1234",
+			APIKeyEnv:           "TEST_GENERIC_API_KEY",
+			AuthType:            "api-key-header",
+			AuthHeader:          "X-API-Key",
+			AuthPrefix:          "Token",
+			ExtraHeaders:        map[string]string{"X-Provider": "local"},
+			ChatCompletionsPath: "/v1/chat/completions",
+			ResponsesPath:       "/v1/responses",
+			ModelsPath:          "/api/tags",
+			ModelDiscovery:      "ollama",
+			Models: []ProviderModelConfig{{
+				PublicID:   "local-chat",
+				Deployment: "llama3.2:latest",
+				Name:       "Local Chat",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	if defaultProviderID != "local-openai" {
+		t.Fatalf("default provider = %q, want local-openai", defaultProviderID)
+	}
+
+	provider := providers["local-openai"]
+	if provider == nil {
+		t.Fatal("expected local-openai provider")
+	}
+	if provider.kind != providerTypeOpenAICompatible {
+		t.Fatalf("provider.kind = %q, want %q", provider.kind, providerTypeOpenAICompatible)
+	}
+	if provider.authType != providerAuthTypeAPIKeyHeader {
+		t.Fatalf("authType = %q, want api-key-header", provider.authType)
+	}
+	if provider.authHeader != "X-Api-Key" {
+		t.Fatalf("authHeader = %q, want X-Api-Key", provider.authHeader)
+	}
+	if provider.authPrefix != "Token" {
+		t.Fatalf("authPrefix = %q, want Token", provider.authPrefix)
+	}
+	if provider.apiKey != "generic-key" {
+		t.Fatalf("apiKey = %q, want generic-key", provider.apiKey)
+	}
+	if got := provider.extraHeaders.Get("X-Provider"); got != "local" {
+		t.Fatalf("extra header X-Provider = %q, want local", got)
+	}
+	if provider.paths.chatCompletions != "/v1/chat/completions" || provider.paths.responses != "/v1/responses" || provider.paths.models != "/api/tags" {
+		t.Fatalf("paths = %+v, want configured generic paths", provider.paths)
+	}
+	if provider.modelDiscovery != providerModelDiscoveryOllama {
+		t.Fatalf("modelDiscovery = %q, want ollama", provider.modelDiscovery)
+	}
+
+	model := provider.staticModels["local-chat"]
+	if model.publicID != "local-chat" || model.upstreamModel != "llama3.2:latest" {
+		t.Fatalf("static model = %+v, want public local-chat mapped to llama3.2:latest", model)
+	}
+	if !reflect.DeepEqual(model.supportedEndpoints, []string{"/chat/completions"}) {
+		t.Fatalf("default openai-compatible endpoints = %v, want [/chat/completions]", model.supportedEndpoints)
+	}
+}
+
+func TestBuildProvidersGenericAnthropicCompatibleConfig(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:             "anthropic-native",
+			Type:           "anthropic-compatible",
+			Default:        true,
+			BaseURL:        "https://anthropic-compatible.example.com",
+			AuthType:       "none",
+			MessagesPath:   "/messages",
+			ModelDiscovery: "static",
+			Models: []ProviderModelConfig{{
+				PublicID: "claude-local",
+				Name:     "Claude Local",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+
+	provider := providers["anthropic-native"]
+	if provider == nil {
+		t.Fatal("expected anthropic-native provider")
+	}
+	if provider.authType != providerAuthTypeNone {
+		t.Fatalf("authType = %q, want none", provider.authType)
+	}
+	if provider.paths.messages != "/messages" {
+		t.Fatalf("messages path = %q, want /messages", provider.paths.messages)
+	}
+	model := provider.staticModels["claude-local"]
+	if !reflect.DeepEqual(model.supportedEndpoints, []string{"/v1/messages"}) {
+		t.Fatalf("default anthropic-compatible endpoints = %v, want [/v1/messages]", model.supportedEndpoints)
+	}
+}
+
+func TestBuildProvidersGenericValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  ProviderConfig
+		want string
+	}{
+		{
+			name: "static requires models",
+			cfg: ProviderConfig{
+				ID:      "local",
+				Type:    "openai-compatible",
+				BaseURL: "http://localhost:1234",
+			},
+			want: "must configure at least one model",
+		},
+		{
+			name: "api key header requires header",
+			cfg: ProviderConfig{
+				ID:       "local",
+				Type:     "openai-compatible",
+				BaseURL:  "http://localhost:1234",
+				APIKey:   "key",
+				AuthType: "api-key-header",
+				Models:   []ProviderModelConfig{{PublicID: "m"}},
+			},
+			want: "requires auth_header",
+		},
+		{
+			name: "path rejects query",
+			cfg: ProviderConfig{
+				ID:                  "local",
+				Type:                "openai-compatible",
+				BaseURL:             "http://localhost:1234",
+				ChatCompletionsPath: "/v1/chat/completions?debug=true",
+				Models:              []ProviderModelConfig{{PublicID: "m"}},
+			},
+			want: "no query string or fragment",
+		},
+		{
+			name: "bad discovery",
+			cfg: ProviderConfig{
+				ID:             "local",
+				Type:           "openai-compatible",
+				BaseURL:        "http://localhost:1234",
+				ModelDiscovery: "made-up",
+				Models:         []ProviderModelConfig{{PublicID: "m"}},
+			},
+			want: "unsupported model_discovery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+			_, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{tt.cfg}})
+			if err == nil {
+				t.Fatalf("buildProviders() error = nil, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("buildProviders() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadProvidersConfigFileRejectsEmptyBody(t *testing.T) {
 	t.Parallel()
 

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -501,6 +501,17 @@ func TestBuildProvidersGenericValidation(t *testing.T) {
 			want: "requires auth_header",
 		},
 		{
+			name: "configured api key env must be set",
+			cfg: ProviderConfig{
+				ID:        "local",
+				Type:      "openai-compatible",
+				BaseURL:   "http://localhost:1234",
+				APIKeyEnv: "VEKIL_TEST_MISSING_GENERIC_API_KEY",
+				Models:    []ProviderModelConfig{{PublicID: "m"}},
+			},
+			want: "api_key_env",
+		},
+		{
 			name: "path rejects query",
 			cfg: ProviderConfig{
 				ID:                  "local",

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -143,6 +143,75 @@ func StreamOpenAIPassthroughWithFinalResponse(
 	onFinalResponse(aggregator.buildResponse())
 }
 
+func streamAnthropicPassthroughBody(w http.ResponseWriter, body io.Reader, publicModel, upstreamModel string) {
+	publicModel = strings.TrimSpace(publicModel)
+	upstreamModel = strings.TrimSpace(upstreamModel)
+
+	var flusher http.Flusher
+	if f, ok := w.(http.Flusher); ok {
+		flusher = f
+	}
+
+	if publicModel == "" || publicModel == upstreamModel {
+		_, _ = io.Copy(&flushWriter{w: w, flusher: flusher}, body)
+		return
+	}
+
+	reader := bufio.NewReaderSize(body, openAIStreamScannerInitialBuffer)
+	frame := make([]string, 0, 4)
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			frame = append(frame, line)
+			if strings.TrimRight(line, "\r\n") == "" {
+				writeAnthropicSSEFrame(w, frame, publicModel)
+				if flusher != nil {
+					flusher.Flush()
+				}
+				frame = frame[:0]
+			}
+		}
+		if err != nil {
+			if len(frame) > 0 {
+				writeAnthropicSSEFrame(w, frame, publicModel)
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			return
+		}
+	}
+}
+
+func writeAnthropicSSEFrame(w io.Writer, frame []string, publicModel string) {
+	for _, line := range frame {
+		content, ending := splitSSELineEnding(line)
+		data, ok := parseSSELine(content)
+		if !ok {
+			_, _ = io.WriteString(w, line)
+			continue
+		}
+
+		rewritten, changed := rewriteAnthropicResponseModelJSON([]byte(data), publicModel, "")
+		if !changed {
+			_, _ = io.WriteString(w, line)
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "data: %s%s", rewritten, ending)
+	}
+}
+
+func splitSSELineEnding(line string) (string, string) {
+	switch {
+	case strings.HasSuffix(line, "\r\n"):
+		return strings.TrimSuffix(line, "\r\n"), "\r\n"
+	case strings.HasSuffix(line, "\n"):
+		return strings.TrimSuffix(line, "\n"), "\n"
+	default:
+		return line, ""
+	}
+}
+
 // StreamOpenAIToAnthropic translates an OpenAI SSE stream into Anthropic SSE format.
 func StreamOpenAIToAnthropic(w http.ResponseWriter, body io.ReadCloser, model string, requestID string) {
 	StreamOpenAIToAnthropicWithFinalResponse(w, body, model, requestID, nil)

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -135,6 +135,12 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
 		}
 	}
+	if !known && !providerAllowsUnknownModelEndpoint(provider, endpoint) {
+		return nil, nil, &providerRequestError{
+			statusCode: http.StatusBadRequest,
+			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
+		}
+	}
 
 	rewrittenBody, _, err := rewriteRequestModelForProvider(body, owner.upstreamModel)
 	if err != nil {
@@ -147,10 +153,30 @@ func providerSupportsEndpoint(provider *providerRuntime, endpoint string) bool {
 	if provider == nil {
 		return false
 	}
-	if provider.kind == providerTypeOpenAICodex {
+	switch provider.kind {
+	case providerTypeOpenAICodex:
 		return supportsEndpoint(openAICodexProviderEndpoints, endpoint)
+	case providerTypeOpenAICompatible:
+		return endpoint == providerEndpointChatCompletions || endpoint == providerEndpointResponses
+	case providerTypeAnthropicCompatible:
+		return endpoint == providerEndpointMessages
+	default:
+		return true
 	}
-	return true
+}
+
+func providerAllowsUnknownModelEndpoint(provider *providerRuntime, endpoint string) bool {
+	if provider == nil {
+		return false
+	}
+	switch provider.kind {
+	case providerTypeOpenAICompatible:
+		return endpoint == providerEndpointChatCompletions
+	case providerTypeAnthropicCompatible:
+		return endpoint == providerEndpointMessages
+	default:
+		return true
+	}
 }
 
 func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body []byte) (*http.Response, error) {
@@ -173,11 +199,15 @@ func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path str
 }
 
 func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*http.Response, error) {
-	return h.postJSONEndpoint(ctx, "/chat/completions", body)
+	return h.postJSONEndpoint(ctx, providerEndpointChatCompletions, body)
 }
 
 func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	return h.postJSONEndpointWithHeaders(ctx, "/responses", body, extraHeaders)
+	return h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, body, extraHeaders)
+}
+
+func (h *ProxyHandler) postAnthropicMessages(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
+	return h.postJSONEndpointWithHeaders(ctx, providerEndpointMessages, body, extraHeaders)
 }
 
 func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -119,7 +119,11 @@ func mergeHeaderValues(dst, src http.Header) {
 
 func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, []byte, error) {
 	model := extractRequestModel(body)
-	provider, owner, known := h.resolveProviderModel(model, endpoint)
+	lookupModel := model
+	if endpoint == providerEndpointMessages {
+		lookupModel = NormalizeModelName(model)
+	}
+	provider, owner, known := h.resolveProviderModel(lookupModel, endpoint)
 	if provider == nil {
 		return nil, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
 	}

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -171,9 +171,9 @@ func providerAllowsUnknownModelEndpoint(provider *providerRuntime, endpoint stri
 	}
 	switch provider.kind {
 	case providerTypeOpenAICompatible:
-		return endpoint == providerEndpointChatCompletions
+		return providerUsesDynamicModels(provider) && endpoint == providerEndpointChatCompletions
 	case providerTypeAnthropicCompatible:
-		return endpoint == providerEndpointMessages
+		return providerUsesDynamicModels(provider) && endpoint == providerEndpointMessages
 	default:
 		return true
 	}
@@ -215,4 +215,85 @@ func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {
 	copyPassthroughHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+func writeDirectAnthropicJSONResponse(w http.ResponseWriter, resp *http.Response, publicModel, upstreamModel string) error {
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	rewritten, changed := rewriteAnthropicResponseModelJSON(body, publicModel, upstreamModel)
+
+	copyPassthroughHeaders(w.Header(), resp.Header)
+	if changed {
+		w.Header().Del("Content-Length")
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(rewritten)
+	return nil
+}
+
+func writeDirectAnthropicStreamResponse(w http.ResponseWriter, resp *http.Response, publicModel, upstreamModel string) {
+	defer func() { _ = resp.Body.Close() }()
+
+	copyPassthroughHeaders(w.Header(), resp.Header)
+	w.Header().Del("Content-Length")
+	setSSEHeaders(w)
+	w.WriteHeader(resp.StatusCode)
+	streamAnthropicPassthroughBody(w, resp.Body, publicModel, upstreamModel)
+}
+
+func rewriteAnthropicResponseModelJSON(body []byte, publicModel, upstreamModel string) ([]byte, bool) {
+	publicModel = strings.TrimSpace(publicModel)
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	if publicModel == "" || publicModel == upstreamModel {
+		return body, false
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body, false
+	}
+
+	changed := rewriteAnthropicModelFields(payload, publicModel)
+	if !changed {
+		return body, false
+	}
+
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return body, false
+	}
+	return rewritten, true
+}
+
+func rewriteAnthropicModelFields(payload map[string]json.RawMessage, publicModel string) bool {
+	if len(payload) == 0 || strings.TrimSpace(publicModel) == "" {
+		return false
+	}
+
+	changed := false
+	if rawJSONString(payload["model"]) != "" {
+		rawModel, err := json.Marshal(publicModel)
+		if err == nil {
+			payload["model"] = rawModel
+			changed = true
+		}
+	}
+
+	var message map[string]json.RawMessage
+	if err := json.Unmarshal(payload["message"], &message); err == nil && len(message) > 0 && rawJSONString(message["model"]) != "" {
+		rawModel, err := json.Marshal(publicModel)
+		if err == nil {
+			message["model"] = rawModel
+			if rawMessage, err := json.Marshal(message); err == nil {
+				payload["message"] = rawMessage
+				changed = true
+			}
+		}
+	}
+
+	return changed
 }


### PR DESCRIPTION
## Summary
- add generic `openai-compatible` and `anthropic-compatible` provider types with configurable auth, paths, headers, and model discovery
- route Anthropic-compatible providers directly through native Messages while preserving OpenAI translation for OpenAI-compatible providers
- document generic provider fields, cookbook configs, updated auth/setup notes, and provider API-key locations

## Verification
- `go test ./proxy/ -count=1`
- `make test`
- `make vet`
- `make build`
- `git diff --check`