### PR TITLE
Add --quiet flag to suppress non-error CLI output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | — | `false` | Suppress non-error CLI output |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -148,7 +149,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
 	}
 
-	if err := deps.openURL(dcResp.VerificationURI); err != nil && !opts.quiet {
+	if err := deps.openURL(dcResp.VerificationURI); err != nil {
 		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
@@ -299,7 +300,10 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 }
 
 func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
+	var serve serveFlags
+	withEnvWarningsSuppressed(serveQuietRequested(os.Args[1:]), func() {
+		serve = registerServeFlags(flag.CommandLine)
+	})
 	flag.Parse()
 
 	logLevel := logger.ParseLevel(*serve.logLevel)
@@ -369,6 +373,44 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+var suppressEnvWarnings bool
+
+func withEnvWarningsSuppressed(suppress bool, fn func()) {
+	prev := suppressEnvWarnings
+	suppressEnvWarnings = suppress
+	defer func() {
+		suppressEnvWarnings = prev
+	}()
+	fn()
+}
+
+func serveQuietRequested(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--quiet", "-quiet":
+			if i+1 >= len(args) {
+				return true
+			}
+			if v, err := strconv.ParseBool(args[i+1]); err == nil {
+				return v
+			}
+			return true
+		default:
+			if value, ok := strings.CutPrefix(args[i], "--quiet="); ok {
+				if parsed, err := strconv.ParseBool(value); err == nil {
+					return parsed
+				}
+			}
+			if value, ok := strings.CutPrefix(args[i], "-quiet="); ok {
+				if parsed, err := strconv.ParseBool(value); err == nil {
+					return parsed
+				}
+			}
+		}
+	}
+	return false
+}
+
 func getEnvBool(key string, fallback bool) bool {
 	v := getEnv(key, "")
 	if v == "" {
@@ -376,7 +418,9 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		if !suppressEnvWarnings {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed
@@ -389,7 +433,9 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		if !suppressEnvWarnings {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed
@@ -402,7 +448,9 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		if !suppressEnvWarnings {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -118,13 +119,17 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		if !opts.quiet {
+			_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		}
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			if !opts.quiet {
+				_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			}
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,10 +143,12 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	if !opts.quiet {
+		_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+		_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	}
 
-	if err := deps.openURL(dcResp.VerificationURI); err != nil {
+	if err := deps.openURL(dcResp.VerificationURI); err != nil && !opts.quiet {
 		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
@@ -150,7 +157,9 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	if !opts.quiet {
+		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	}
 	return 0
 }
 
@@ -178,6 +187,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,6 +195,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
@@ -194,6 +205,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 func runLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,7 +219,9 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !*quiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
@@ -232,6 +246,7 @@ type serveFlags struct {
 	compactUpstreamChunkBytes       *int
 	compactUpstreamChunkConcurrency *int
 	compactUpstreamMaxAttempts      *int
+	quiet                           *bool
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
@@ -257,6 +272,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 	}
 }
 
@@ -286,7 +302,11 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if *serve.quiet {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -125,11 +125,37 @@ func parseServeFlagsForTest(t *testing.T, args ...string) serveFlags {
 	t.Helper()
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	serve := registerServeFlags(fs)
+	var serve serveFlags
+	withEnvWarningsSuppressed(serveQuietRequested(args), func() {
+		serve = registerServeFlags(fs)
+	})
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("parse serve flags: %v", err)
 	}
 	return serve
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	_ = r.Close()
+	return buf.String()
 }
 
 func TestServeFlagsCopilotHeaderEnvDefaults(t *testing.T) {
@@ -185,6 +211,18 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeQuietSuppressesEnvWarningsDuringFlagRegistration(t *testing.T) {
+	t.Setenv("RESPONSES_WS_ENABLED", "not-a-bool")
+
+	output := captureStderr(t, func() {
+		_ = parseServeFlagsForTest(t, "--quiet")
+	})
+
+	if output != "" {
+		t.Fatalf("stderr = %q, want empty output", output)
 	}
 }
 
@@ -394,6 +432,40 @@ func TestRunLoginQuietSuppressesNonErrorOutputButNotErrors(t *testing.T) {
 		}
 		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
 			t.Fatalf("stderr missing error output, got %q", got)
+		}
+	})
+
+	t.Run("browser failure output preserved in quiet mode", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--force", "--quiet"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{
+					deviceCodeResponse: &auth.DeviceCodeResponse{
+						DeviceCode:      "device-code",
+						UserCode:        "ABCD-EFGH",
+						VerificationURI: "https://github.com/login/device",
+						Interval:        1,
+					},
+				}, nil
+			},
+			openURL: func(string) error {
+				return fmt.Errorf("open failed")
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+		}
+		output := stderr.String()
+		if !strings.Contains(output, "Could not open browser automatically, please visit the URL above.") {
+			t.Fatalf("stderr missing browser failure output, got %q", output)
+		}
+		for _, want := range []string{"Opening browser to", "Enter code:", "Login successful."} {
+			if strings.Contains(output, want) {
+				t.Fatalf("stderr unexpectedly contains %q: %q", want, output)
+			}
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -358,6 +358,46 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 	}
 }
 
+func TestRunLoginQuietSuppressesNonErrorOutputButNotErrors(t *testing.T) {
+	t.Run("success output suppressed", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--gh", "--quiet"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{}, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("stderr = %q, want empty output", got)
+		}
+	})
+
+	t.Run("error output preserved", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--gh", "--quiet"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{
+					signInWithGitHubCLIErr: fmt.Errorf("boom"),
+				}, nil
+			},
+		})
+
+		if code != 1 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+		}
+		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
+			t.Fatalf("stderr missing error output, got %q", got)
+		}
+	})
+}
+
 type fakeLoginAuthenticator struct {
 	signInWithGitHubCLICalls int
 	signInWithGitHubCLIErr   error


### PR DESCRIPTION
## Summary
- add a `--quiet` flag to relevant `vekil` commands to suppress non-error output
- preserve error output while quiet mode is enabled
- add tests covering quiet-mode behavior, including preserved error-path output

## Validation
- Validation environment derived from repo evidence:
  - `go.mod` specifies `go 1.25`
  - `.github/workflows/ci.yaml` uses `actions/setup-go` with `go-version-file: go.mod`
- Validated on immutable ref `b8600eee18e0922e1f0c5adf057d000a6cb4cedd` with:
  - `go test .`
  - `go build .`
  - `go vet .`

## Review
- Security review: approved
- Quality review: approved