### PR TITLE
docs: add Copilot CLI client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ env OPENAI_API_KEY=dummy \
   codex exec --skip-git-repo-check -m gpt-5.5 "Reply with exactly PROXY_OK"
 ```
 
+### GitHub Copilot CLI
+
+```bash
+env COPILOT_PROVIDER_BASE_URL=http://localhost:1337/v1 \
+  COPILOT_PROVIDER_TYPE=openai \
+  COPILOT_PROVIDER_WIRE_API=responses \
+  COPILOT_MODEL=gpt-5.5 \
+  COPILOT_OFFLINE=true \
+  copilot -p "Reply with exactly PROXY_OK" -s
+```
+
 ### Gemini CLI
 
 ```bash

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -18,6 +18,17 @@ env OPENAI_API_KEY=dummy \
   codex exec --skip-git-repo-check -m gpt-5.5 "Reply with exactly PROXY_OK"
 ```
 
+## GitHub Copilot CLI
+
+```bash
+env COPILOT_PROVIDER_BASE_URL=http://localhost:1337/v1 \
+  COPILOT_PROVIDER_TYPE=openai \
+  COPILOT_PROVIDER_WIRE_API=responses \
+  COPILOT_MODEL=gpt-5.5 \
+  COPILOT_OFFLINE=true \
+  copilot -p "Reply with exactly PROXY_OK" -s
+```
+
 ## Gemini CLI
 
 ```bash


### PR DESCRIPTION
## Summary
- Add GitHub Copilot CLI to README client examples
- Mirror the Copilot CLI snippet in docs/clients.md

## Validation
- copilot help providers
- Copilot CLI smoke test through local Vekil with fake OpenAI-compatible /v1/responses upstream returned PROXY_OK
- go test ./... -count=1