### PR TITLE
fix: surface upstream error details

### DIFF
--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -116,7 +116,7 @@ func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *
 			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
 			return
 		}
-		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
+		writeAnthropicError(w, statusCode, "api_error", formatUpstreamRequestFailure(err, "upstream request failed"))
 		return
 	}
 
@@ -235,7 +235,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
 			return
 		}
-		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
+		writeAnthropicError(w, statusCode, "api_error", formatUpstreamRequestFailure(err, "upstream request failed"))
 		return
 	}
 
@@ -248,7 +248,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 			logger.F("body", string(errBody)),
 			logger.F("request_bytes", len(oaiBody)),
 		)
-		writeAnthropicError(w, resp.StatusCode, "api_error", fmt.Sprintf("upstream error (%d)", resp.StatusCode))
+		writeAnthropicError(w, resp.StatusCode, "api_error", formatUpstreamErrorMessage(resp.StatusCode, errBody))
 		return
 	}
 
@@ -304,7 +304,7 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
-		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -107,7 +107,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 			logger.F("body", string(errBody)),
 			logger.F("request_bytes", len(oaiBody)),
 		)
-		writeGeminiError(w, resp.StatusCode, mapGeminiUpstreamStatus(resp.StatusCode), fmt.Sprintf("upstream error (%d)", resp.StatusCode))
+		writeGeminiError(w, resp.StatusCode, mapGeminiUpstreamStatus(resp.StatusCode), formatUpstreamErrorMessage(resp.StatusCode, errBody))
 		return
 	}
 
@@ -324,7 +324,7 @@ func (h *ProxyHandler) decodeGeminiProbeResponse(resp *http.Response) (*models.O
 		return nil, false, &geminiProtocolError{
 			statusCode: resp.StatusCode,
 			status:     mapGeminiUpstreamStatus(resp.StatusCode),
-			message:    fmt.Sprintf("upstream error (%d)", resp.StatusCode),
+			message:    formatUpstreamErrorMessage(resp.StatusCode, errBody),
 		}
 	}
 

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -2269,7 +2269,7 @@ func TestHandleGeminiModelsErrors(t *testing.T) {
 		handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error":{"message":"bad upstream request"}}`))
+			_, _ = w.Write([]byte(`{"error":{"message":"bad upstream request","type":"invalid_request_error","param":"messages","code":"context_length_exceeded"}}`))
 		})
 
 		reqBody := `{
@@ -2293,8 +2293,10 @@ func TestHandleGeminiModelsErrors(t *testing.T) {
 		if errResp.Error.Status != "INVALID_ARGUMENT" {
 			t.Errorf("status = %q, want INVALID_ARGUMENT", errResp.Error.Status)
 		}
-		if !strings.Contains(errResp.Error.Message, "upstream error (400)") {
-			t.Errorf("message = %q, want upstream 400 detail", errResp.Error.Message)
+		for _, want := range []string{"upstream error (400)", "bad upstream request", "type=invalid_request_error", "param=messages", "code=context_length_exceeded"} {
+			if !strings.Contains(errResp.Error.Message, want) {
+				t.Errorf("message = %q, want %q", errResp.Error.Message, want)
+			}
 		}
 	})
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -819,7 +819,7 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
-		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -562,8 +562,9 @@ func TestHandleAnthropicMessagesInvalidJSON(t *testing.T) {
 
 func TestHandleAnthropicUpstreamError(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"tool schema is invalid","type":"invalid_request_error","param":"tools.0","code":"invalid_tool_schema"}}`))
 	})
 
 	anthropicReq := `{
@@ -578,8 +579,8 @@ func TestHandleAnthropicUpstreamError(t *testing.T) {
 	handler.HandleAnthropicMessages(w, req)
 
 	resp := w.Result()
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
 
 	var errResp models.AnthropicError
@@ -589,6 +590,11 @@ func TestHandleAnthropicUpstreamError(t *testing.T) {
 	}
 	if errResp.Error.Type != "api_error" {
 		t.Errorf("expected error type api_error, got %q", errResp.Error.Type)
+	}
+	for _, want := range []string{"upstream error (400)", "tool schema is invalid", "type=invalid_request_error", "param=tools.0", "code=invalid_tool_schema"} {
+		if !strings.Contains(errResp.Error.Message, want) {
+			t.Errorf("message = %q, want %q", errResp.Error.Message, want)
+		}
 	}
 }
 
@@ -8857,6 +8863,46 @@ func TestOpenAIChatCompletionsUpstreamErrorPassthrough(t *testing.T) {
 	}
 	if errResp["error"]["type"] != "invalid_request_error" {
 		t.Errorf("error.type = %v, want invalid_request_error", errResp["error"]["type"])
+	}
+}
+
+func TestOpenAIChatCompletionsRetryableUpstreamErrorIncludesDetail(t *testing.T) {
+	var calls atomic.Int32
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", fmt.Sprintf("req-%d", n))
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded","type":"rate_limit_error","param":"model","code":"too_many_requests"}}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", resp.StatusCode)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("expected 3 upstream attempts, got %d", calls.Load())
+	}
+	if got := resp.Header.Get("X-Request-Id"); got != "req-3" {
+		t.Fatalf("X-Request-Id = %q, want req-3", got)
+	}
+
+	var errResp map[string]map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to parse error: %v", err)
+	}
+	message, _ := errResp["error"]["message"].(string)
+	for _, want := range []string{"upstream error (429)", "rate limit exceeded", "type=rate_limit_error", "param=model", "code=too_many_requests"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("message = %q, want %q", message, want)
+		}
 	}
 }
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -103,7 +103,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 				writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
 				return
 			}
-			writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+			writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 			return
 		}
 		writeUpstreamResponse(w, compactionResp)
@@ -122,7 +122,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
-		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 	resp, err = h.maybeRetryCompactedResponsesRequest(upstreamCtx, bodyBytes, extraHeaders, upstreamHeaders, resp)
@@ -137,7 +137,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
-		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 
@@ -372,7 +372,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
-		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 	if resp != nil {
@@ -457,7 +457,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
-		writeOpenAIError(w, statusCode, "upstream request failed", "server_error")
+		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -6,8 +6,11 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 )
+
+const upstreamErrorDetailDrainTimeout = 250 * time.Millisecond
 
 // retryable returns true for status codes that warrant a retry.
 func retryable(statusCode int) bool {
@@ -140,7 +143,24 @@ func readRetryableUpstreamErrorBody(body io.ReadCloser) []byte {
 	if body == nil {
 		return nil
 	}
-	defer func() { _ = body.Close() }()
 	bodyBytes, _ := io.ReadAll(io.LimitReader(body, upstreamErrorDetailMaxBodyBytes))
+	drainRetryableUpstreamErrorBody(body)
 	return bodyBytes
+}
+
+func drainRetryableUpstreamErrorBody(body io.ReadCloser) {
+	// Drain a bounded remainder after the bounded capture. This preserves
+	// connection reuse for normal upstream error bodies without letting a huge or
+	// stalled body delay returning the synthesized error indefinitely.
+	go func() {
+		var closeOnce sync.Once
+		closeBody := func() {
+			closeOnce.Do(func() { _ = body.Close() })
+		}
+
+		timer := time.AfterFunc(upstreamErrorDetailDrainTimeout, closeBody)
+		_, _ = io.Copy(io.Discard, io.LimitReader(body, upstreamErrorDetailDrainBytes))
+		_ = timer.Stop()
+		closeBody()
+	}()
 }

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -85,12 +85,16 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		}
 
 		retryAfterHeader := resp.Header.Get("Retry-After")
-
-		// Drain and close body before retry to allow connection reuse.
-		drainAndClose(resp.Body)
-		lastErr = &upstreamError{statusCode: resp.StatusCode}
+		upstreamErr := &upstreamError{
+			statusCode: resp.StatusCode,
+			retryAfter: retryAfterHeader,
+			headers:    resp.Header.Clone(),
+		}
+		lastErr = upstreamErr
 
 		if attempt < maxRetries-1 {
+			// Drain and close body before retry to allow connection reuse.
+			drainAndClose(resp.Body)
 			delay := backoff(retryDelay, attempt)
 			if ra, ok := parseRetryAfter(retryAfterHeader); ok && ra > delay {
 				delay = ra
@@ -98,6 +102,8 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			if ctxErr := sleepWithContext(req.Context(), delay); ctxErr != nil {
 				return nil, ctxErr
 			}
+		} else {
+			upstreamErr.body = readRetryableUpstreamErrorBody(resp.Body)
 		}
 	}
 	return nil, lastErr
@@ -118,8 +124,23 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 
 type upstreamError struct {
 	statusCode int
+	body       []byte
+	retryAfter string
+	headers    http.Header
 }
 
 func (e *upstreamError) Error() string {
-	return http.StatusText(e.statusCode)
+	if e == nil {
+		return ""
+	}
+	return formatUpstreamErrorMessage(e.statusCode, e.body)
+}
+
+func readRetryableUpstreamErrorBody(body io.ReadCloser) []byte {
+	if body == nil {
+		return nil
+	}
+	defer func() { _ = body.Close() }()
+	bodyBytes, _ := io.ReadAll(io.LimitReader(body, upstreamErrorDetailMaxBodyBytes))
+	return bodyBytes
 }

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -3,8 +3,11 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -241,6 +244,115 @@ func TestDoWithRetry_RespectsRetryAfter(t *testing.T) {
 	// Retry-After: 1 means at least 1 second of delay.
 	if elapsed < 900*time.Millisecond {
 		t.Errorf("expected at least ~1s delay from Retry-After, got %v", elapsed)
+	}
+}
+
+func TestReadRetryableUpstreamErrorBodyDrainsAfterBoundedCapture(t *testing.T) {
+	body := strings.Repeat("a", upstreamErrorDetailMaxBodyBytes+123)
+	reader := newRetryBodyReadCloser(body)
+
+	got := readRetryableUpstreamErrorBody(reader)
+	waitForRetryBodyClose(t, reader.closed)
+
+	if string(got) != body[:upstreamErrorDetailMaxBodyBytes] {
+		t.Fatalf("captured body = %q, want first %d bytes", string(got), upstreamErrorDetailMaxBodyBytes)
+	}
+	if unread := reader.Len(); unread != 0 {
+		t.Fatalf("expected response body to be drained to EOF, %d bytes unread", unread)
+	}
+}
+
+func TestReadRetryableUpstreamErrorBodyCapsDrainAfterCapture(t *testing.T) {
+	body := strings.Repeat("a", upstreamErrorDetailMaxBodyBytes+upstreamErrorDetailDrainBytes+123)
+	reader := newRetryBodyReadCloser(body)
+
+	got := readRetryableUpstreamErrorBody(reader)
+	waitForRetryBodyClose(t, reader.closed)
+
+	if string(got) != body[:upstreamErrorDetailMaxBodyBytes] {
+		t.Fatalf("captured body = %q, want first %d bytes", string(got), upstreamErrorDetailMaxBodyBytes)
+	}
+	if unread := reader.Len(); unread != 123 {
+		t.Fatalf("unread bytes after bounded drain = %d, want 123", unread)
+	}
+}
+
+func TestReadRetryableUpstreamErrorBodyDoesNotWaitForStalledDrain(t *testing.T) {
+	reader := newBlockingRetryBodyReadCloser(upstreamErrorDetailMaxBodyBytes)
+
+	start := time.Now()
+	got := readRetryableUpstreamErrorBody(reader)
+	elapsed := time.Since(start)
+
+	if len(got) != upstreamErrorDetailMaxBodyBytes {
+		t.Fatalf("captured body length = %d, want %d", len(got), upstreamErrorDetailMaxBodyBytes)
+	}
+	if elapsed >= upstreamErrorDetailDrainTimeout {
+		t.Fatalf("readRetryableUpstreamErrorBody elapsed = %v, want less than drain timeout %v", elapsed, upstreamErrorDetailDrainTimeout)
+	}
+	select {
+	case <-reader.closed:
+		t.Fatal("expected stalled drain to close asynchronously after timeout, not before return")
+	default:
+	}
+	waitForRetryBodyClose(t, reader.closed)
+}
+
+type retryBodyReadCloser struct {
+	*strings.Reader
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func newRetryBodyReadCloser(body string) *retryBodyReadCloser {
+	return &retryBodyReadCloser{
+		Reader: strings.NewReader(body),
+		closed: make(chan struct{}),
+	}
+}
+
+func (r *retryBodyReadCloser) Close() error {
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
+}
+
+type blockingRetryBodyReadCloser struct {
+	remaining int
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func newBlockingRetryBodyReadCloser(prefixBytes int) *blockingRetryBodyReadCloser {
+	return &blockingRetryBodyReadCloser{
+		remaining: prefixBytes,
+		closed:    make(chan struct{}),
+	}
+}
+
+func (r *blockingRetryBodyReadCloser) Read(p []byte) (int, error) {
+	if r.remaining > 0 {
+		n := min(len(p), r.remaining)
+		for i := range n {
+			p[i] = 'a'
+		}
+		r.remaining -= n
+		return n, nil
+	}
+	<-r.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingRetryBodyReadCloser) Close() error {
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
+}
+
+func waitForRetryBodyClose(t *testing.T, closed <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-closed:
+	case <-time.After(upstreamErrorDetailDrainTimeout + time.Second):
+		t.Fatal("timed out waiting for response body to close")
 	}
 }
 

--- a/proxy/upstream_error_detail.go
+++ b/proxy/upstream_error_detail.go
@@ -13,6 +13,7 @@ import (
 const (
 	upstreamErrorDetailMaxChars     = 1024
 	upstreamErrorDetailMaxBodyBytes = 4096
+	upstreamErrorDetailDrainBytes   = 64 * 1024
 )
 
 func formatUpstreamErrorMessage(statusCode int, body []byte) string {
@@ -129,8 +130,10 @@ func sanitizeUpstreamErrorText(value string) string {
 	if len(runes) <= upstreamErrorDetailMaxChars {
 		return value
 	}
-	if upstreamErrorDetailMaxChars <= len("…") {
+	ellipsis := "…"
+	ellipsisRunes := utf8.RuneCountInString(ellipsis)
+	if upstreamErrorDetailMaxChars <= ellipsisRunes {
 		return string(runes[:upstreamErrorDetailMaxChars])
 	}
-	return string(runes[:upstreamErrorDetailMaxChars-len("…")]) + "…"
+	return string(runes[:upstreamErrorDetailMaxChars-ellipsisRunes]) + ellipsis
 }

--- a/proxy/upstream_error_detail.go
+++ b/proxy/upstream_error_detail.go
@@ -1,0 +1,136 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	upstreamErrorDetailMaxChars     = 1024
+	upstreamErrorDetailMaxBodyBytes = 4096
+)
+
+func formatUpstreamErrorMessage(statusCode int, body []byte) string {
+	message := fmt.Sprintf("upstream error (%d)", statusCode)
+	if detail := summarizeUpstreamErrorBody(body); detail != "" {
+		return message + ": " + detail
+	}
+	return message
+}
+
+func formatUpstreamRequestFailure(err error, fallback string) string {
+	var upstreamErr *upstreamError
+	if errors.As(err, &upstreamErr) {
+		return upstreamErr.Error()
+	}
+	return fallback
+}
+
+func upstreamErrorRetryMetadata(err error) (string, http.Header) {
+	var upstreamErr *upstreamError
+	if !errors.As(err, &upstreamErr) {
+		return "", nil
+	}
+	return upstreamErr.retryAfter, upstreamErr.headers
+}
+
+func writeOpenAIUpstreamRequestFailure(w http.ResponseWriter, statusCode int, err error) {
+	retryAfter, upstreamHeaders := upstreamErrorRetryMetadata(err)
+	writeOpenAIErrorWithRetryAfter(
+		w,
+		statusCode,
+		formatUpstreamRequestFailure(err, "upstream request failed"),
+		"server_error",
+		retryAfter,
+		upstreamHeaders,
+	)
+}
+
+func summarizeUpstreamErrorBody(body []byte) string {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return ""
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &envelope); err == nil {
+		if detail := summarizeJSONErrorValue(envelope["error"]); detail != "" {
+			return detail
+		}
+		for _, key := range []string{"message", "error_description", "detail"} {
+			if detail := rawJSONErrorString(envelope[key]); detail != "" {
+				return detail
+			}
+		}
+	}
+
+	if !utf8.Valid(trimmed) {
+		return ""
+	}
+	return sanitizeUpstreamErrorText(string(trimmed))
+}
+
+func summarizeJSONErrorValue(raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+
+	if message := rawJSONErrorString(raw); message != "" {
+		return message
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+
+	message := ""
+	for _, key := range []string{"message", "error_description", "detail"} {
+		if message = rawJSONErrorString(obj[key]); message != "" {
+			break
+		}
+	}
+
+	attrs := make([]string, 0, 4)
+	for _, key := range []string{"type", "code", "param", "status"} {
+		if value := rawJSONErrorString(obj[key]); value != "" {
+			attrs = append(attrs, key+"="+value)
+		}
+	}
+
+	if message == "" {
+		return strings.Join(attrs, ", ")
+	}
+	if len(attrs) == 0 {
+		return message
+	}
+	return message + " (" + strings.Join(attrs, ", ") + ")"
+}
+
+func rawJSONErrorString(raw json.RawMessage) string {
+	value := rawJSONString(raw)
+	if value == "" {
+		return ""
+	}
+	return sanitizeUpstreamErrorText(value)
+}
+
+func sanitizeUpstreamErrorText(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= upstreamErrorDetailMaxChars {
+		return value
+	}
+	if upstreamErrorDetailMaxChars <= len("…") {
+		return string(runes[:upstreamErrorDetailMaxChars])
+	}
+	return string(runes[:upstreamErrorDetailMaxChars-len("…")]) + "…"
+}

--- a/proxy/upstream_error_detail_test.go
+++ b/proxy/upstream_error_detail_test.go
@@ -1,0 +1,20 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSanitizeUpstreamErrorTextTruncatesToMaxRunes(t *testing.T) {
+	value := strings.Repeat("界", upstreamErrorDetailMaxChars+10)
+
+	got := sanitizeUpstreamErrorText(value)
+
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncated message to end with ellipsis, got %q", got)
+	}
+	if gotRunes := utf8.RuneCountInString(got); gotRunes != upstreamErrorDetailMaxChars {
+		t.Fatalf("truncated message rune count = %d, want %d", gotRunes, upstreamErrorDetailMaxChars)
+	}
+}


### PR DESCRIPTION
## Summary
- surface sanitized upstream error messages/codes/params in synthesized proxy error envelopes
- retain final retry-exhausted upstream error body and request metadata for 429/502/503/504 failures
- add coverage for Anthropic, Gemini, and OpenAI-compatible upstream error detail propagation

## Tests
- `go test ./... -count=1`
