### PR TITLE
Add Anthropic count tokens compatibility

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,12 @@ Supported features include text/image/tool-use content blocks, system messages, 
 
 Model normalization strips dated suffixes such as `claude-sonnet-4-20250514` and maps hyphenated version numbers to dotted form, for example `claude-sonnet-4-5` to `claude-sonnet-4.5`.
 
+## `POST /v1/messages/count_tokens` (Anthropic)
+
+Anthropic count-tokens compatibility for clients such as Claude Code. For OpenAI-compatible upstreams, Vekil translates the Messages request to Chat Completions, sends a minimal one-token probe, and returns `usage.prompt_tokens` as Anthropic `input_tokens`. For `anthropic-compatible` providers, the proxy directly forwards count-tokens requests to `{messages_path}/count_tokens`.
+
+The endpoint is a compatibility probe rather than a native tokenizer. It may make a small upstream inference request, and counts follow the owning provider's reported prompt-token usage.
+
 ## `GET /v1/models`
 
 The proxy builds a merged catalog across active providers. It preserves OpenAI-style `data` and also adds a Codex-compatible top-level `models` array.

--- a/models/anthropic.go
+++ b/models/anthropic.go
@@ -95,6 +95,12 @@ type AnthropicUsage struct {
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 }
 
+// AnthropicCountTokensResponse is the response from the Anthropic
+// Messages count_tokens endpoint.
+type AnthropicCountTokensResponse struct {
+	InputTokens int `json:"input_tokens"`
+}
+
 // AnthropicStreamEvent is a single SSE event in an Anthropic streaming response.
 type AnthropicStreamEvent struct {
 	Type         string             `json:"type"`

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -97,6 +97,11 @@ func (h *ProxyHandler) shouldForwardAnthropicMessagesDirect(model string) bool {
 	return provider != nil && provider.kind == providerTypeAnthropicCompatible
 }
 
+func (h *ProxyHandler) shouldForwardAnthropicCountTokensDirect(model string) bool {
+	provider, _, _ := h.resolveProviderModel(NormalizeModelName(model), providerEndpointMessages)
+	return provider != nil && provider.kind == providerTypeAnthropicCompatible
+}
+
 func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *http.Request, body []byte, req *models.AnthropicRequest) {
 	streaming := req != nil && req.Stream
 	publicModel, upstreamModel := h.directAnthropicResponseModels(req)
@@ -129,6 +134,29 @@ func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *
 			h.log.Error("upstream response rewrite failed", logger.F("endpoint", "anthropic"), logger.Err(err))
 			writeAnthropicError(w, http.StatusBadGateway, "api_error", "failed to read upstream response")
 		}
+		return
+	}
+
+	writeUpstreamResponse(w, resp)
+}
+
+func (h *ProxyHandler) forwardAnthropicCountTokensDirect(w http.ResponseWriter, r *http.Request, body []byte) {
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+	defer upstreamCancel()
+
+	resp, err := h.postAnthropicMessagesCountTokens(upstreamCtx, body, anthropicExtraHeadersFromRequest(r))
+	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
+		h.log.Error("upstream request failed", logger.F("endpoint", "anthropic_count_tokens"), logger.Err(err))
+		if statusCode == http.StatusBadRequest {
+			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
+			return
+		}
+		if statusCode == http.StatusInternalServerError {
+			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
+			return
+		}
+		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
 		return
 	}
 
@@ -272,6 +300,146 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		writeAnthropicError(w, http.StatusBadGateway, "api_error", "failed to aggregate upstream response")
 	}
+}
+
+// HandleAnthropicMessagesCountTokens handles POST /v1/messages/count_tokens.
+// OpenAI-compatible upstreams do not expose a token-count endpoint, so this uses
+// the same minimal chat-completions probe as the Gemini countTokens adapter and
+// returns the upstream prompt token count in Anthropic's response shape.
+func (h *ProxyHandler) HandleAnthropicMessagesCountTokens(w http.ResponseWriter, r *http.Request) {
+	body, err := readBody(r)
+	if err != nil {
+		status := readBodyStatusCode(err)
+		writeAnthropicError(w, status, "invalid_request_error", err.Error())
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	var req models.AnthropicRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON in request body")
+		return
+	}
+
+	if h.shouldForwardAnthropicCountTokensDirect(req.Model) {
+		h.forwardAnthropicCountTokensDirect(w, r, body)
+		return
+	}
+
+	oaiReq, err := prepareAnthropicCountTokensProbeRequest(&req)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", fmt.Sprintf("translation error: %v", err))
+		return
+	}
+
+	oaiResp, err := h.runAnthropicCountTokensProbe(oaiReq)
+	if err != nil {
+		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
+		h.log.Error("upstream request failed", logger.F("endpoint", "anthropic_count_tokens"), logger.Err(err))
+		if statusCode == http.StatusBadRequest {
+			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
+			return
+		}
+		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
+		return
+	}
+
+	if oaiResp.Usage == nil {
+		writeAnthropicError(w, http.StatusBadGateway, "api_error", "upstream response did not include usage")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(models.AnthropicCountTokensResponse{
+		InputTokens: oaiResp.Usage.PromptTokens,
+	})
+}
+
+func prepareAnthropicCountTokensProbeRequest(req *models.AnthropicRequest) (*models.OpenAIRequest, error) {
+	oaiReq, err := TranslateAnthropicToOpenAI(req)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := false
+	temperature := 0.0
+	one := 1
+
+	oaiReq.Stream = &stream
+	oaiReq.StreamOptions = nil
+	oaiReq.Temperature = &temperature
+	oaiReq.MaxCompletionTokens = &one
+	oaiReq.MaxTokens = nil
+
+	return oaiReq, nil
+}
+
+func (h *ProxyHandler) runAnthropicCountTokensProbe(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
+	oaiResp, fallback, err := h.executeAnthropicCountTokensProbe(probeReq)
+	if fallback {
+		one := 1
+		probeReq.MaxCompletionTokens = nil
+		probeReq.MaxTokens = &one
+		return h.executeAnthropicCountTokensProbeFinal(probeReq)
+	}
+	return oaiResp, err
+}
+
+func (h *ProxyHandler) executeAnthropicCountTokensProbe(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+	defer upstreamCancel()
+
+	body, err := json.Marshal(probeReq)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to marshal count_tokens probe request: %w", err)
+	}
+
+	resp, err := h.postChatCompletions(upstreamCtx, body)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if resp.StatusCode == http.StatusBadRequest && probeReq.MaxCompletionTokens != nil {
+		_ = resp.Body.Close()
+		return nil, true, nil
+	}
+
+	oaiResp, err := h.decodeAnthropicCountTokensProbeResponse(resp)
+	return oaiResp, false, err
+}
+
+func (h *ProxyHandler) executeAnthropicCountTokensProbeFinal(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(false)
+	defer upstreamCancel()
+
+	body, err := json.Marshal(probeReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal count_tokens probe request: %w", err)
+	}
+
+	resp, err := h.postChatCompletions(upstreamCtx, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.decodeAnthropicCountTokensProbeResponse(resp)
+}
+
+func (h *ProxyHandler) decodeAnthropicCountTokensProbeResponse(resp *http.Response) (*models.OpenAIResponse, error) {
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		h.log.Error("upstream error", logger.F("endpoint", "anthropic_count_tokens"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
+		return nil, &upstreamError{statusCode: resp.StatusCode}
+	}
+
+	var oaiResp models.OpenAIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&oaiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse upstream count_tokens probe response: %w", err)
+	}
+
+	return &oaiResp, nil
 }
 
 // HandleOpenAIChatCompletions handles POST /v1/chat/completions by forwarding the

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -466,6 +466,196 @@ func TestHandleAnthropicMessages(t *testing.T) {
 	}
 }
 
+func TestHandleAnthropicMessagesCountTokens(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("expected path /chat/completions, got %q", r.URL.Path)
+		}
+
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("failed to parse upstream request: %v", err)
+		}
+		if oaiReq.Model != "claude-sonnet-4" {
+			t.Fatalf("model = %q, want claude-sonnet-4", oaiReq.Model)
+		}
+		if oaiReq.Stream == nil || *oaiReq.Stream {
+			t.Fatalf("stream = %v, want false", oaiReq.Stream)
+		}
+		if oaiReq.StreamOptions != nil {
+			t.Fatalf("stream_options = %#v, want nil", oaiReq.StreamOptions)
+		}
+		if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+			t.Fatalf("max_completion_tokens = %v, want 1", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens != nil {
+			t.Fatalf("max_tokens = %v, want nil", oaiReq.MaxTokens)
+		}
+		if len(oaiReq.Tools) != 1 || oaiReq.Tools[0].Function.Name != "lookup" {
+			t.Fatalf("tools = %#v, want translated lookup tool", oaiReq.Tools)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-count","object":"chat.completion","created":1,"model":"claude-sonnet-4","choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"length"}],"usage":{"prompt_tokens":123,"completion_tokens":1,"total_tokens":124}}`))
+	})
+
+	countReq := `{
+		"model": "claude-sonnet-4",
+		"messages": [{"role": "user", "content": "Count this"}],
+		"tools": [{"name": "lookup", "description": "Lookup", "input_schema": {"type": "object"}}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(countReq))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessagesCountTokens(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var countResp models.AnthropicCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode count_tokens response: %v", err)
+	}
+	if countResp.InputTokens != 123 {
+		t.Fatalf("input_tokens = %d, want 123", countResp.InputTokens)
+	}
+}
+
+func TestHandleAnthropicMessagesCountTokensFallbacksToMaxTokens(t *testing.T) {
+	var attempts int
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("failed to parse upstream request: %v", err)
+		}
+
+		switch attempts {
+		case 1:
+			if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 || oaiReq.MaxTokens != nil {
+				t.Fatalf("first probe max fields = max_completion_tokens:%v max_tokens:%v", oaiReq.MaxCompletionTokens, oaiReq.MaxTokens)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"unsupported field max_completion_tokens"}}`))
+		case 2:
+			if oaiReq.MaxCompletionTokens != nil || oaiReq.MaxTokens == nil || *oaiReq.MaxTokens != 1 {
+				t.Fatalf("fallback probe max fields = max_completion_tokens:%v max_tokens:%v", oaiReq.MaxCompletionTokens, oaiReq.MaxTokens)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl-count","object":"chat.completion","created":1,"model":"claude-sonnet-4","choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"length"}],"usage":{"prompt_tokens":77,"completion_tokens":1,"total_tokens":78}}`))
+		default:
+			t.Fatalf("unexpected attempt %d", attempts)
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(`{
+		"model": "claude-sonnet-4",
+		"messages": [{"role": "user", "content": "Count this"}]
+	}`))
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessagesCountTokens(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var countResp models.AnthropicCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode count_tokens response: %v", err)
+	}
+	if countResp.InputTokens != 77 {
+		t.Fatalf("input_tokens = %d, want 77", countResp.InputTokens)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestHandleAnthropicMessagesCountTokens_DirectGenericAnthropicCompatibleProvider(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/native/messages/count_tokens" {
+			t.Fatalf("expected native count_tokens path /native/messages/count_tokens, got %s", got)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "anthropic-key" {
+			t.Fatalf("expected X-API-Key auth, got %q", got)
+		}
+		if got := r.Header.Get("Anthropic-Version"); got != "2023-06-01" {
+			t.Fatalf("expected Anthropic-Version forwarded, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("expected client Authorization stripped, got %q", got)
+		}
+
+		var upstreamReq models.AnthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "claude-upstream" {
+			t.Fatalf("upstream model = %q, want claude-upstream", upstreamReq.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":42}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:           "native",
+				Type:         "anthropic-compatible",
+				Default:      true,
+				BaseURL:      upstream.URL,
+				APIKey:       "anthropic-key",
+				AuthType:     "api-key-header",
+				AuthHeader:   "X-API-Key",
+				MessagesPath: "/native/messages",
+				Models: []ProviderModelConfig{{
+					PublicID:   "claude-public",
+					Deployment: "claude-upstream",
+					Endpoints:  []string{"/v1/messages"},
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(`{
+		"model": "claude-public",
+		"messages": [{"role": "user", "content": "Count this"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer client-token")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessagesCountTokens(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var countResp models.AnthropicCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode count_tokens response: %v", err)
+	}
+	if countResp.InputTokens != 42 {
+		t.Fatalf("input_tokens = %d, want 42", countResp.InputTokens)
+	}
+}
+
 func TestHandleAnthropicMessages_ImageBlocksForwarded(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		var oaiReq models.OpenAIRequest

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -51,6 +51,7 @@ const (
 	providerEndpointChatCompletions = "/chat/completions"
 	providerEndpointResponses       = "/responses"
 	providerEndpointMessages        = "/v1/messages"
+	providerEndpointMessagesCount   = "/v1/messages/count_tokens"
 	providerEndpointModels          = "/models"
 )
 
@@ -1160,6 +1161,10 @@ func (p *providerRuntime) upstreamPath(endpoint string) string {
 	case providerEndpointMessages:
 		if p.paths.messages != "" {
 			return p.paths.messages
+		}
+	case providerEndpointMessagesCount:
+		if p.paths.messages != "" {
+			return strings.TrimRight(p.paths.messages, "/") + "/count_tokens"
 		}
 	case providerEndpointModels:
 		if p.paths.models != "" {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -214,6 +214,27 @@ func (h *ProxyHandler) postAnthropicMessages(ctx context.Context, body []byte, e
 	return h.postJSONEndpointWithHeaders(ctx, providerEndpointMessages, body, extraHeaders)
 }
 
+func (h *ProxyHandler) postAnthropicMessagesCountTokens(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
+	provider, rewrittenBody, err := h.resolveProviderRequest(body, providerEndpointMessages)
+	if err != nil {
+		return nil, err
+	}
+	if provider.kind != providerTypeAnthropicCompatible {
+		return nil, &providerRequestError{
+			statusCode: http.StatusBadRequest,
+			err:        fmt.Errorf("provider %q does not support %s", provider.id, providerEndpointMessagesCount),
+		}
+	}
+
+	return h.doWithRetry(func() (*http.Request, error) {
+		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "")
+		if err != nil {
+			return nil, err
+		}
+		return req, nil
+	})
+}
+
 func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {
 	defer func() { _ = resp.Body.Close() }()
 	copyPassthroughHeaders(w.Header(), resp.Header)

--- a/server/server.go
+++ b/server/server.go
@@ -87,6 +87,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
 	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
 	mux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)


### PR DESCRIPTION
## Summary

- add `POST /v1/messages/count_tokens` for Claude Code / Anthropic Messages compatibility
- translate count-token requests through a minimal OpenAI Chat Completions probe and return `usage.prompt_tokens` as Anthropic `input_tokens`
- fallback from `max_completion_tokens: 1` to `max_tokens: 1` for upstreams that reject `max_completion_tokens`
- directly forward count-token requests for `anthropic-compatible` providers to `{messages_path}/count_tokens`
- document the new Anthropic count-tokens compatibility endpoint

## Validation

- `go test ./... -count=1`
- `go test ./proxy -run 'TestHandleAnthropicMessagesCountTokens' -count=1 -v`
- Live Copilot/Vekil smoke:
  - `/v1/messages/count_tokens` for `claude-sonnet-4.5` returned `{"input_tokens":9}` for a tiny prompt
  - `/v1/messages` for the same tiny prompt returned `usage.input_tokens: 9`
  - Claude Code `--print --output-format json` through patched Vekil returned `PROXY_OK`
- Live compaction smoke:
  - `scripts/live-compact-smoke.sh` passed against a patched binary
  - larger manual compact/replay covered 80-message history, `context_compaction`, and `function_call`/`function_call_output` replay markers

## Follow-up audit notes

A deep dive through an old Claude Code source tree found no additional required inference endpoints for normal local proxy use beyond Messages, Messages count_tokens, and Models. The main unsupported public Anthropic API family used by that tree is Files (`/v1/files`, `/v1/files/{id}/content`), which is tied to `--file`/remote file persistence flows and should be treated as a separate feature if needed.
