### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | unset | `false` | Suppress non-error CLI output; errors still go to stderr |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,17 +28,71 @@ const (
 )
 
 func main() {
+	global, args, err := extractGlobalOptions(os.Args)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch commandFromArgs(args) {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(args[2:], global)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(args[2:], global)
 		return
 	}
 
-	runServe()
+	runServe(args[1:], global)
+}
+
+type cliOptions struct {
+	quiet bool
+}
+
+const quietFlagHelp = "suppress non-error output"
+
+func registerQuietFlag(fs *flag.FlagSet) *bool {
+	return fs.Bool("quiet", false, quietFlagHelp)
+}
+
+func extractGlobalOptions(args []string) (cliOptions, []string, error) {
+	if len(args) == 0 {
+		return cliOptions{}, nil, nil
+	}
+
+	global := cliOptions{}
+	filtered := make([]string, 0, len(args))
+	filtered = append(filtered, args[0])
+
+	for _, arg := range args[1:] {
+		switch {
+		case arg == "--quiet":
+			global.quiet = true
+		case strings.HasPrefix(arg, "--quiet="):
+			value := strings.TrimPrefix(arg, "--quiet=")
+			quiet, err := strconv.ParseBool(value)
+			if err != nil {
+				return cliOptions{}, nil, fmt.Errorf("invalid value %q for --quiet: expected bool", value)
+			}
+			global.quiet = quiet
+		default:
+			filtered = append(filtered, arg)
+		}
+	}
+
+	return global, filtered, nil
+}
+
+func withGlobalOptions(args []string, global cliOptions) []string {
+	if !global.quiet {
+		return args
+	}
+	merged := make([]string, 0, len(args)+1)
+	merged = append(merged, "--quiet")
+	merged = append(merged, args...)
+	return merged
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -59,6 +114,7 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -72,12 +128,13 @@ type loginAuthenticator interface {
 
 type loginDeps struct {
 	stderr           io.Writer
+	output           io.Writer
 	newAuthenticator func(string) (loginAuthenticator, error)
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, global cliOptions) {
+	if code := runLoginWithDeps(withGlobalOptions(args, global), defaultLoginDeps()); code != 0 {
 		os.Exit(code)
 	}
 }
@@ -85,6 +142,7 @@ func runLogin(args []string) {
 func defaultLoginDeps() loginDeps {
 	return loginDeps{
 		stderr: os.Stderr,
+		output: os.Stderr,
 		newAuthenticator: func(tokenDir string) (loginAuthenticator, error) {
 			return auth.NewAuthenticator(tokenDir)
 		},
@@ -112,19 +170,24 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
+	output := deps.output
+	if opts.quiet {
+		output = io.Discard
+	}
+
 	ctx := context.Background()
 	if opts.useGitHubCLI {
 		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(output, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(output, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +201,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(output, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(output, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(output, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,13 +213,16 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(output, "Login successful.")
 	return 0
 }
 
 func normalizeLoginDeps(deps loginDeps) loginDeps {
 	if deps.stderr == nil {
 		deps.stderr = io.Discard
+	}
+	if deps.output == nil {
+		deps.output = deps.stderr
 	}
 	if deps.newAuthenticator == nil {
 		deps.newAuthenticator = defaultLoginDeps().newAuthenticator
@@ -178,6 +244,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := registerQuietFlag(fs)
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,16 +252,18 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
 	return opts, nil
 }
 
-func runLogout(args []string) {
+func runLogout(args []string, global cliOptions) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	fs.Parse(args) //nolint:errcheck
+	quiet := registerQuietFlag(fs)
+	fs.Parse(withGlobalOptions(args, global)) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
 	if err != nil {
@@ -207,7 +276,9 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !*quiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
@@ -232,6 +303,7 @@ type serveFlags struct {
 	compactUpstreamChunkBytes       *int
 	compactUpstreamChunkConcurrency *int
 	compactUpstreamMaxAttempts      *int
+	quiet                           *bool
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
@@ -257,6 +329,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+		quiet:                           registerQuietFlag(fs),
 	}
 }
 
@@ -282,11 +355,15 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
+func runServe(args []string, global cliOptions) {
 	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+	flag.CommandLine.Parse(withGlobalOptions(args, global)) //nolint:errcheck
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if *serve.quiet {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -188,6 +189,18 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeFlagsQuietDefaultAndOverride(t *testing.T) {
+	defaultServe := parseServeFlagsForTest(t)
+	if *defaultServe.quiet {
+		t.Fatal("quiet should be disabled by default")
+	}
+
+	quietServe := parseServeFlagsForTest(t, "--quiet")
+	if !*quietServe.quiet {
+		t.Fatal("--quiet should enable quiet mode")
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -220,6 +233,52 @@ func TestCommandFromArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := commandFromArgs(tc.args); got != tc.want {
 				t.Fatalf("commandFromArgs(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractGlobalOptionsQuiet(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantQuiet bool
+		wantArgs  []string
+	}{
+		{
+			name:      "quiet before subcommand",
+			args:      []string{"vekil", "--quiet", "login"},
+			wantQuiet: true,
+			wantArgs:  []string{"vekil", "login"},
+		},
+		{
+			name:      "quiet after subcommand",
+			args:      []string{"vekil", "login", "--quiet"},
+			wantQuiet: true,
+			wantArgs:  []string{"vekil", "login"},
+		},
+		{
+			name:      "quiet false leaves disabled",
+			args:      []string{"vekil", "--quiet=false", "login"},
+			wantQuiet: false,
+			wantArgs:  []string{"vekil", "login"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, args, err := extractGlobalOptions(tc.args)
+			if err != nil {
+				t.Fatalf("extractGlobalOptions() error = %v", err)
+			}
+			if got.quiet != tc.wantQuiet {
+				t.Fatalf("extractGlobalOptions() quiet = %v, want %v", got.quiet, tc.wantQuiet)
+			}
+			if strings.Join(args, "\x00") != strings.Join(tc.wantArgs, "\x00") {
+				t.Fatalf("extractGlobalOptions() args = %v, want %v", args, tc.wantArgs)
+			}
+			if commandFromArgs(args) != cliCommandLogin {
+				t.Fatalf("commandFromArgs(%v) did not dispatch login", args)
 			}
 		})
 	}
@@ -307,6 +366,62 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	if got := stderr.String(); !strings.Contains(got, "Login successful.") {
 		t.Fatalf("stderr missing success message, got %q", got)
 	}
+}
+
+func TestRunLoginQuietSuppressesNormalOutputButPreservesErrors(t *testing.T) {
+	t.Run("normal output visible by default", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--github-cli"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{}, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		if got := stderr.String(); !strings.Contains(got, "Login successful.") {
+			t.Fatalf("stderr missing normal output, got %q", got)
+		}
+	})
+
+	t.Run("quiet suppresses normal output", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--quiet", "--github-cli"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{}, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("quiet stderr = %q, want empty", got)
+		}
+	})
+
+	t.Run("quiet preserves errors", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--quiet", "--github-cli"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{signInWithGitHubCLIErr: errors.New("gh unavailable")}, nil
+			},
+		})
+
+		if code != 1 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+		}
+		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: gh unavailable") {
+			t.Fatalf("quiet stderr missing error, got %q", got)
+		}
+	})
 }
 
 func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a global `--quiet` flag that suppresses non-error CLI output. Errors still go to stderr. The flag is accepted before or after the subcommand (`vekil --quiet login` and `vekil login --quiet`).

### Behavior
- **serve**: forces logger output to `error` level when `--quiet` is set.
- **login**: routes informational output (`Login successful.`, `Opening browser to ...`, `Enter code: ...`, `Already logged in.`, `Could not open browser ...`) to a writer that becomes `io.Discard` when quiet. Errors still go to stderr; exit codes unchanged.
- **logout**: gates the `Logged out.` message on `!quiet`. Errors unchanged.

### Tests added
- `TestServeFlagsQuietDefaultAndOverride`
- `TestExtractGlobalOptionsQuiet` (placement before/after subcommand, `--quiet=false`)
- `TestRunLoginQuietSuppressesNormalOutputButPreservesErrors` (default visible, quiet suppresses, quiet preserves errors)

### Verification
- `go vet ./...`, `go build ./...`, `go test ./...` all pass on Go 1.25.
- Docs updated in `docs/configuration.md`.
