### PR TITLE
feat(cli): add --quiet/-q flag to suppress non-error output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet`, `-q` | unset | `false` | Suppress non-error CLI output; errors and exit codes are preserved |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,38 +28,90 @@ const (
 )
 
 func main() {
+	invocation := parseInvocation(os.Args)
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch invocation.command {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(invocation.args, invocation.quiet)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(invocation.args, invocation.quiet)
 		return
 	}
 
-	runServe()
+	runServe(invocation.args, invocation.quiet)
 }
 
 func commandFromArgs(args []string) cliCommand {
+	return parseInvocation(args).command
+}
+
+type cliInvocation struct {
+	command cliCommand
+	args    []string
+	quiet   bool
+}
+
+func parseInvocation(args []string) cliInvocation {
+	invocation := cliInvocation{command: cliCommandServe}
 	if len(args) < 2 {
-		return cliCommandServe
+		return invocation
 	}
 
-	switch args[1] {
-	case "login":
-		return cliCommandLogin
-	case "logout":
-		return cliCommandLogout
-	default:
-		return cliCommandServe
+	serveArgs := make([]string, 0, len(args)-1)
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if value, ok := parseRootQuietArg(arg); ok {
+			invocation.quiet = value
+			continue
+		}
+
+		switch arg {
+		case "login":
+			invocation.command = cliCommandLogin
+			invocation.args = args[i+1:]
+			return invocation
+		case "logout":
+			invocation.command = cliCommandLogout
+			invocation.args = args[i+1:]
+			return invocation
+		}
+
+		serveArgs = append(serveArgs, arg)
+		serveArgs = append(serveArgs, args[i+1:]...)
+		invocation.args = serveArgs
+		return invocation
 	}
+
+	invocation.args = serveArgs
+	return invocation
+}
+
+func parseRootQuietArg(arg string) (bool, bool) {
+	switch arg {
+	case "--quiet", "-q":
+		return true, true
+	}
+	for _, prefix := range []string{"--quiet=", "-q="} {
+		value, ok := strings.CutPrefix(arg, prefix)
+		if !ok {
+			continue
+		}
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return false, false
+		}
+		return parsed, true
+	}
+	return false, false
 }
 
 type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -76,8 +129,8 @@ type loginDeps struct {
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, quiet bool) {
+	if code := runLoginWithDeps(args, quiet, defaultLoginDeps()); code != 0 {
 		os.Exit(code)
 	}
 }
@@ -92,10 +145,10 @@ func defaultLoginDeps() loginDeps {
 	}
 }
 
-func runLoginWithDeps(args []string, deps loginDeps) int {
+func runLoginWithDeps(args []string, quiet bool, deps loginDeps) int {
 	deps = normalizeLoginDeps(deps)
 
-	opts, err := parseLoginOptions(args, deps.stderr)
+	opts, err := parseLoginOptions(args, quiet, deps.stderr)
 	if err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -112,19 +165,24 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
+	nonErrorOutput := deps.stderr
+	if opts.quiet {
+		nonErrorOutput = io.Discard
+	}
+
 	ctx := context.Background()
 	if opts.useGitHubCLI {
 		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(nonErrorOutput, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(nonErrorOutput, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +196,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(nonErrorOutput, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(nonErrorOutput, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(nonErrorOutput, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +208,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(nonErrorOutput, "Login successful.")
 	return 0
 }
 
@@ -167,13 +225,14 @@ func normalizeLoginDeps(deps loginDeps) loginDeps {
 	return deps
 }
 
-func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
+func parseLoginOptions(args []string, quiet bool, stderr io.Writer) (loginOptions, error) {
 	if stderr == nil {
 		stderr = io.Discard
 	}
 	opts := loginOptions{}
 	fs := flag.NewFlagSet("login", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	quietFlag := registerQuietFlag(fs, quiet)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
@@ -185,14 +244,16 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quietFlag
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
 	return opts, nil
 }
 
-func runLogout(args []string) {
+func runLogout(args []string, quiet bool) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
+	quietFlag := registerQuietFlag(fs, quiet)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
 	fs.Parse(args) //nolint:errcheck
 
@@ -207,10 +268,13 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !*quietFlag {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
+	quiet                           *bool
 	port                            *string
 	host                            *string
 	tokenDir                        *string
@@ -235,7 +299,12 @@ type serveFlags struct {
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
+	return registerServeFlagsWithQuietDefault(fs, false)
+}
+
+func registerServeFlagsWithQuietDefault(fs *flag.FlagSet, quiet bool) serveFlags {
 	return serveFlags{
+		quiet:                           registerQuietFlag(fs, quiet),
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
@@ -260,6 +329,20 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 	}
 }
 
+func registerQuietFlag(fs *flag.FlagSet, defaultValue bool) *bool {
+	quiet := defaultValue
+	fs.BoolVar(&quiet, "quiet", defaultValue, "Suppress non-error output")
+	fs.BoolVar(&quiet, "q", defaultValue, "Alias for --quiet")
+	return &quiet
+}
+
+func (f serveFlags) effectiveLogLevel() logger.Level {
+	if f.quiet != nil && *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
+}
+
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
 	return proxy.CopilotHeaderConfig{
 		EditorVersion:       *f.copilotEditorVersion,
@@ -282,11 +365,12 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string, quiet bool) {
+	fs := flag.NewFlagSet("vekil", flag.ExitOnError)
+	serve := registerServeFlagsWithQuietDefault(fs, quiet)
+	fs.Parse(args) //nolint:errcheck
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.effectiveLogLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -188,6 +189,34 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeQuietFlagSuppressesNonErrorLoggerOutput(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet", "--log-level", "debug")
+	if serve.effectiveLogLevel() != logger.LevelError {
+		t.Fatalf("effectiveLogLevel() = %v, want %v", serve.effectiveLogLevel(), logger.LevelError)
+	}
+
+	output := captureStderr(t, func() {
+		log := logger.New(serve.effectiveLogLevel())
+		log.Debug("debug output")
+		log.Info("non-error output")
+		log.Error("error output")
+	})
+
+	if strings.Contains(output, "debug output") || strings.Contains(output, "non-error output") {
+		t.Fatalf("quiet logger emitted non-error output: %q", output)
+	}
+	if !strings.Contains(output, "error output") {
+		t.Fatalf("quiet logger suppressed error output: %q", output)
+	}
+}
+
+func TestServeQuietShortFlag(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "-q")
+	if serve.quiet == nil || !*serve.quiet {
+		t.Fatal("-q should enable quiet mode")
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -205,6 +234,11 @@ func TestCommandFromArgs(t *testing.T) {
 			want: cliCommandLogin,
 		},
 		{
+			name: "root quiet before login still dispatches",
+			args: []string{"vekil", "--quiet", "login"},
+			want: cliCommandLogin,
+		},
+		{
 			name: "logout subcommand dispatches",
 			args: []string{"vekil", "logout"},
 			want: cliCommandLogout,
@@ -212,6 +246,11 @@ func TestCommandFromArgs(t *testing.T) {
 		{
 			name: "unknown subcommand falls back to serve",
 			args: []string{"vekil", "serve"},
+			want: cliCommandServe,
+		},
+		{
+			name: "flag value named login remains serve",
+			args: []string{"vekil", "--providers-config", "login"},
 			want: cliCommandServe,
 		},
 	}
@@ -225,13 +264,26 @@ func TestCommandFromArgs(t *testing.T) {
 	}
 }
 
+func TestParseInvocationRootQuietAppliesToSubcommand(t *testing.T) {
+	invocation := parseInvocation([]string{"vekil", "-q", "login", "--github-cli"})
+	if invocation.command != cliCommandLogin {
+		t.Fatalf("command = %v, want %v", invocation.command, cliCommandLogin)
+	}
+	if !invocation.quiet {
+		t.Fatal("quiet = false, want true")
+	}
+	if got, want := strings.Join(invocation.args, " "), "--github-cli"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
 func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	for _, helpArg := range []string{"-h", "--help"} {
 		t.Run(helpArg, func(t *testing.T) {
 			var stderr bytes.Buffer
 			constructed := false
 
-			code := runLoginWithDeps([]string{helpArg}, loginDeps{
+			code := runLoginWithDeps([]string{helpArg}, false, loginDeps{
 				stderr: &stderr,
 				newAuthenticator: func(string) (loginAuthenticator, error) {
 					constructed = true
@@ -256,11 +308,51 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	}
 }
 
+func TestRunLoginQuietSuppressesSuccessButPreservesErrors(t *testing.T) {
+	t.Run("suppresses success output", func(t *testing.T) {
+		var stderr bytes.Buffer
+		fake := &fakeLoginAuthenticator{}
+
+		code := runLoginWithDeps([]string{"--github-cli", "--quiet"}, false, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return fake, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("quiet login emitted non-error output %q", got)
+		}
+	})
+
+	t.Run("preserves error output", func(t *testing.T) {
+		var stderr bytes.Buffer
+		fake := &fakeLoginAuthenticator{signInWithGitHubCLIErr: fmt.Errorf("boom")}
+
+		code := runLoginWithDeps([]string{"--github-cli", "--quiet"}, false, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return fake, nil
+			},
+		})
+
+		if code != 1 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+		}
+		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
+			t.Fatalf("quiet login suppressed error output, got %q", got)
+		}
+	})
+}
+
 func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
 	var stderr bytes.Buffer
 	constructed := false
 
-	code := runLoginWithDeps([]string{"--github-cli", "--force"}, loginDeps{
+	code := runLoginWithDeps([]string{"--github-cli", "--force"}, false, loginDeps{
 		stderr: &stderr,
 		newAuthenticator: func(string) (loginAuthenticator, error) {
 			constructed = true
@@ -284,7 +376,7 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	fake := &fakeLoginAuthenticator{}
 	var gotTokenDir string
 
-	code := runLoginWithDeps([]string{"--gh", "--token-dir", "/tmp/vekil-test-tokens"}, loginDeps{
+	code := runLoginWithDeps([]string{"--gh", "--token-dir", "/tmp/vekil-test-tokens"}, false, loginDeps{
 		stderr: &stderr,
 		newAuthenticator: func(tokenDir string) (loginAuthenticator, error) {
 			gotTokenDir = tokenDir
@@ -321,7 +413,7 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 	}
 	var openedURL string
 
-	code := runLoginWithDeps([]string{"--force"}, loginDeps{
+	code := runLoginWithDeps([]string{"--force"}, false, loginDeps{
 		stderr: &stderr,
 		newAuthenticator: func(string) (loginAuthenticator, error) {
 			return fake, nil
@@ -356,6 +448,33 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 			t.Fatalf("stderr missing %q, got %q", want, output)
 		}
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr pipe: %v", err)
+	}
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stderr pipe: %v", err)
+	}
+	return buf.String()
 }
 
 type fakeLoginAuthenticator struct {


### PR DESCRIPTION
## Summary
Adds a `--quiet` / `-q` flag to the vekil CLI that suppresses non-error output while preserving error output to stderr and the process exit code.

## Changes
- **`main.go`** — registers `--quiet` for `serve`, `login`, `logout`; root-level parsing so `vekil --quiet login ...` works. When set:
  - `serve` logger effective level becomes `error` (quiet wins over `--log-level debug`).
  - `login` / `logout` suppress non-error status output; errors and exit codes preserved.
- **`main_test.go`** — tests for quiet logger behavior, `-q` short flag, root-level quiet dispatch, and login-quiet preserving errors.
- **`docs/configuration.md`** — documents `--quiet`, `-q`.

## Validation
- `gofmt -w`, `go build ./...`, `go test ./...` — all pass (verified independently on `golang:1.25`, including the `proxy` suite).

🤖 Generated with Orka