### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", getEnvBool("QUIET", false), "Suppress non-error log output"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -283,10 +285,19 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 }
 
 func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+	runServeWithArgs(os.Args[1:])
+}
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+func runServeWithArgs(args []string) {
+	fs := flag.NewFlagSet("vekil", flag.ExitOnError)
+	serve := registerServeFlags(fs)
+	fs.Parse(args) //nolint:errcheck
+
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if *serve.quiet {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -185,6 +187,49 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsQuietCanBeEnabled(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet")
+	if !*serve.quiet {
+		t.Fatal("--quiet should enable quiet mode")
+	}
+}
+
+func TestQuietFlagSuppressesNonErrorOutput(t *testing.T) {
+	cfgPath := writeProvidersConfigForTest(t)
+
+	stdout, stderr, err := runServeSubprocess(t, []string{
+		"--quiet",
+		"--host", "127.0.0.1",
+		"--port", "0",
+		"--providers-config", cfgPath,
+	}, true)
+	if err != nil {
+		t.Fatalf("quiet subprocess failed: %v\nstderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("stdout should be empty in quiet mode, got %q", stdout)
+	}
+	if strings.Contains(stderr, `"level":"info"`) {
+		t.Fatalf("quiet mode should suppress info logs, got %q", stderr)
+	}
+}
+
+func TestQuietFlagStillEmitsErrors(t *testing.T) {
+	_, stderr, err := runServeSubprocess(t, []string{
+		"--quiet",
+		"--providers-config", "/tmp/this-file-should-not-exist-vekil.json",
+	}, false)
+	if err == nil {
+		t.Fatal("expected subprocess to fail with invalid providers config")
+	}
+	if !strings.Contains(stderr, `"level":"fatal"`) {
+		t.Fatalf("expected fatal log output when run fails, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "failed to load providers config") {
+		t.Fatalf("expected providers config error in stderr, got %q", stderr)
 	}
 }
 
@@ -402,4 +447,75 @@ func (f *fakeLoginAuthenticator) PollForAuthorization(_ context.Context, dcResp 
 	f.pollForAuthorizationCalls++
 	f.polledDeviceCode = dcResp
 	return f.pollForAuthorizationErr
+}
+
+func TestRunServeHelperProcess(t *testing.T) {
+	if os.Getenv("VEKIL_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	sep := -1
+	for i, arg := range args {
+		if arg == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep == -1 || sep+1 >= len(args) {
+		_, _ = fmt.Fprintln(os.Stderr, "missing helper args")
+		os.Exit(2)
+	}
+
+	runServeWithArgs(args[sep+1:])
+	os.Exit(0)
+}
+
+func runServeSubprocess(t *testing.T, args []string, stopAfterStart bool) (string, string, error) {
+	t.Helper()
+
+	cmdArgs := append([]string{"-test.run=TestRunServeHelperProcess", "--"}, args...)
+	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(), "VEKIL_HELPER_PROCESS=1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper subprocess: %v", err)
+	}
+
+	if stopAfterStart {
+		time.Sleep(300 * time.Millisecond)
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	err := cmd.Wait()
+	return stdout.String(), stderr.String(), err
+}
+
+func writeProvidersConfigForTest(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir() + "/providers.json"
+	body := `{
+  "providers": [
+    {
+      "id": "test-openai",
+      "type": "openai-compatible",
+      "base_url": "https://example.com",
+      "models": [
+        {
+          "public_id": "gpt-test",
+          "deployment": "gpt-test"
+        }
+      ]
+    }
+  ]
+}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write providers config: %v", err)
+	}
+	return path
 }


### PR DESCRIPTION
## Summary
Adds a `--quiet` flag to vekil that suppresses non-error output (info, warning logs) when enabled, while preserving error output.

## Changes
- **main.go**: Added `--quiet` flag to serve command with QUIET environment variable support. When enabled, logger level is forced to error, suppressing info and warning logs.
- **main_test.go**: Added comprehensive tests:
  - `TestServeFlagsQuietCanBeEnabled`: Verifies flag parsing
  - `TestQuietFlagSuppressesNonErrorOutput`: Subprocess test confirming non-error output is suppressed
  - `TestQuietFlagStillEmitsErrors`: Subprocess test confirming errors still appear with --quiet

## Testing
- ✅ All existing tests pass (`go test ./...`)
- ✅ New tests cover the --quiet flag functionality
- ✅ Manual verification confirms quiet mode works correctly

## Review Status
- ✅ Code review approved (LGTM)