### PR TITLE
feat(cli): add --quiet flag to suppress non-error output

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -62,6 +62,7 @@ type Authenticator struct {
 	copilotToken   string
 	tokenExpiry    time.Time
 	mu             sync.RWMutex
+	interactiveOut io.Writer
 	client         *http.Client
 	directClient   *http.Client
 	copilotBaseURL string // overridable for tests; defaults to https://api.github.com
@@ -157,10 +158,23 @@ func NewAuthenticator(tokenDir string) (*Authenticator, error) {
 	}
 
 	return &Authenticator{
-		tokenDir:     tokenDir,
-		client:       newAuthHTTPClient(30*time.Second, true),
-		directClient: newAuthHTTPClient(30*time.Second, false),
+		tokenDir:       tokenDir,
+		interactiveOut: os.Stderr,
+		client:         newAuthHTTPClient(30*time.Second, true),
+		directClient:   newAuthHTTPClient(30*time.Second, false),
 	}, nil
+}
+
+// SetInteractiveOutput sets where interactive device-code prompts are written.
+// A nil writer disables prompt output.
+func (a *Authenticator) SetInteractiveOutput(w io.Writer) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if w == nil {
+		a.interactiveOut = io.Discard
+		return
+	}
+	a.interactiveOut = w
 }
 
 // IsSignedIn reports whether the authenticator has a usable or explicitly
@@ -515,7 +529,11 @@ func (a *Authenticator) deviceCodeFlow(ctx context.Context) error {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
+	out := a.interactiveOut
+	if out == nil {
+		out = io.Discard
+	}
+	_, _ = fmt.Fprintf(out, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
 
 	return a.pollForAuthorization(ctx, dcResp)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | n/a | `false` | Suppress non-error CLI output (errors still print) |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ const (
 	cliCommandLogout
 )
 
+var suppressEnvWarnings bool
+
 func main() {
 	if code := runCLI(os.Args); code != 0 {
 		os.Exit(code)
@@ -67,6 +69,8 @@ func runCLIWithDeps(args []string, deps cliDeps) int {
 		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
 		return 2
 	}
+	restoreEnvWarningSetting := setSuppressEnvWarnings(quiet)
+	defer restoreEnvWarningSetting()
 
 	// Dispatch subcommands before falling through to the default server mode.
 	switch commandFromArgs(filteredArgs) {
@@ -99,18 +103,29 @@ func normalizeCLIDeps(deps cliDeps) cliDeps {
 func stripGlobalQuietFlags(args []string) ([]string, bool, error) {
 	filtered := make([]string, 0, len(args))
 	quiet := false
+	beforeSubcommand := true
 
-	for _, arg := range args {
-		switch arg {
-		case "--quiet", "-quiet", "--q", "-q":
-			quiet = true
+	for idx, arg := range args {
+		if idx == 0 {
+			filtered = append(filtered, arg)
 			continue
-		case "--quiet=true", "-quiet=true", "--q=true", "-q=true":
-			quiet = true
-			continue
-		case "--quiet=false", "-quiet=false", "--q=false", "-q=false":
-			quiet = false
-			continue
+		}
+
+		if beforeSubcommand {
+			switch arg {
+			case "--quiet", "-quiet", "--q", "-q":
+				quiet = true
+				continue
+			case "--quiet=true", "-quiet=true", "--q=true", "-q=true":
+				quiet = true
+				continue
+			case "--quiet=false", "-quiet=false", "--q=false", "-q=false":
+				quiet = false
+				continue
+			}
+			if arg == "--" || len(arg) == 0 || arg[0] != '-' {
+				beforeSubcommand = false
+			}
 		}
 
 		filtered = append(filtered, arg)
@@ -156,12 +171,6 @@ type loginDeps struct {
 	stderr           io.Writer
 	newAuthenticator func(string) (loginAuthenticator, error)
 	openURL          func(string) error
-}
-
-func runLogin(args []string, quiet bool) {
-	if code := runLoginWithDeps(args, defaultLoginDeps(), quiet); code != 0 {
-		os.Exit(code)
-	}
 }
 
 func defaultLoginDeps() loginDeps {
@@ -299,12 +308,6 @@ func normalizeLogoutDeps(deps logoutDeps) logoutDeps {
 		deps.newAuthenticator = defaultLogoutDeps().newAuthenticator
 	}
 	return deps
-}
-
-func runLogout(args []string, quiet bool) {
-	if code := runLogoutWithDeps(args, defaultLogoutDeps(), quiet); code != 0 {
-		os.Exit(code)
-	}
 }
 
 func runLogoutWithDeps(args []string, deps logoutDeps, quiet bool) int {
@@ -501,7 +504,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter(), "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -514,7 +517,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter(), "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -527,8 +530,23 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter(), "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
+}
+
+func setSuppressEnvWarnings(suppress bool) func() {
+	previous := suppressEnvWarnings
+	suppressEnvWarnings = suppress
+	return func() {
+		suppressEnvWarnings = previous
+	}
+}
+
+func envWarningWriter() io.Writer {
+	if suppressEnvWarnings {
+		return io.Discard
+	}
+	return os.Stderr
 }

--- a/main.go
+++ b/main.go
@@ -27,17 +27,99 @@ const (
 )
 
 func main() {
-	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
-	case cliCommandLogin:
-		runLogin(os.Args[2:])
-		return
-	case cliCommandLogout:
-		runLogout(os.Args[2:])
-		return
+	if code := runCLI(os.Args); code != 0 {
+		os.Exit(code)
+	}
+}
+
+func runCLI(args []string) int {
+	return runCLIWithDeps(args, defaultCLIDeps())
+}
+
+type cliDeps struct {
+	stderr    io.Writer
+	runServe  func([]string, bool) int
+	runLogin  func([]string, bool) int
+	runLogout func([]string, bool) int
+}
+
+func defaultCLIDeps() cliDeps {
+	return cliDeps{
+		stderr: os.Stderr,
+		runServe: func(args []string, quiet bool) int {
+			runServe(args, quiet)
+			return 0
+		},
+		runLogin: func(args []string, quiet bool) int {
+			return runLoginWithDeps(args, defaultLoginDeps(), quiet)
+		},
+		runLogout: func(args []string, quiet bool) int {
+			return runLogoutWithDeps(args, defaultLogoutDeps(), quiet)
+		},
+	}
+}
+
+func runCLIWithDeps(args []string, deps cliDeps) int {
+	deps = normalizeCLIDeps(deps)
+
+	filteredArgs, quiet, err := stripGlobalQuietFlags(args)
+	if err != nil {
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 2
 	}
 
-	runServe()
+	// Dispatch subcommands before falling through to the default server mode.
+	switch commandFromArgs(filteredArgs) {
+	case cliCommandLogin:
+		return deps.runLogin(filteredArgs[2:], quiet)
+	case cliCommandLogout:
+		return deps.runLogout(filteredArgs[2:], quiet)
+	default:
+		return deps.runServe(filteredArgs[1:], quiet)
+	}
+}
+
+func normalizeCLIDeps(deps cliDeps) cliDeps {
+	defaults := defaultCLIDeps()
+	if deps.stderr == nil {
+		deps.stderr = defaults.stderr
+	}
+	if deps.runServe == nil {
+		deps.runServe = defaults.runServe
+	}
+	if deps.runLogin == nil {
+		deps.runLogin = defaults.runLogin
+	}
+	if deps.runLogout == nil {
+		deps.runLogout = defaults.runLogout
+	}
+	return deps
+}
+
+func stripGlobalQuietFlags(args []string) ([]string, bool, error) {
+	filtered := make([]string, 0, len(args))
+	quiet := false
+
+	for _, arg := range args {
+		switch arg {
+		case "--quiet", "-quiet", "--q", "-q":
+			quiet = true
+			continue
+		case "--quiet=true", "-quiet=true", "--q=true", "-q=true":
+			quiet = true
+			continue
+		case "--quiet=false", "-quiet=false", "--q=false", "-q=false":
+			quiet = false
+			continue
+		}
+
+		filtered = append(filtered, arg)
+	}
+
+	if len(filtered) == 0 {
+		return nil, false, fmt.Errorf("invalid arguments")
+	}
+	return filtered, quiet, nil
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -76,8 +158,8 @@ type loginDeps struct {
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, quiet bool) {
+	if code := runLoginWithDeps(args, defaultLoginDeps(), quiet); code != 0 {
 		os.Exit(code)
 	}
 }
@@ -92,8 +174,12 @@ func defaultLoginDeps() loginDeps {
 	}
 }
 
-func runLoginWithDeps(args []string, deps loginDeps) int {
+func runLoginWithDeps(args []string, deps loginDeps, quiet bool) int {
 	deps = normalizeLoginDeps(deps)
+	infoOut := deps.stderr
+	if quiet {
+		infoOut = io.Discard
+	}
 
 	opts, err := parseLoginOptions(args, deps.stderr)
 	if err != nil {
@@ -118,13 +204,13 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(infoOut, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(infoOut, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +224,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(infoOut, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(infoOut, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(infoOut, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +236,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(infoOut, "Login successful.")
 	return 0
 }
 
@@ -191,26 +277,70 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	return opts, nil
 }
 
-func runLogout(args []string) {
-	fs := flag.NewFlagSet("logout", flag.ExitOnError)
-	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	fs.Parse(args) //nolint:errcheck
+type logoutDeps struct {
+	stderr           io.Writer
+	newAuthenticator func(string) (*auth.Authenticator, error)
+}
 
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
+func defaultLogoutDeps() logoutDeps {
+	return logoutDeps{
+		stderr: os.Stderr,
+		newAuthenticator: func(tokenDir string) (*auth.Authenticator, error) {
+			return auth.NewAuthenticator(tokenDir)
+		},
+	}
+}
+
+func normalizeLogoutDeps(deps logoutDeps) logoutDeps {
+	if deps.stderr == nil {
+		deps.stderr = io.Discard
+	}
+	if deps.newAuthenticator == nil {
+		deps.newAuthenticator = defaultLogoutDeps().newAuthenticator
+	}
+	return deps
+}
+
+func runLogout(args []string, quiet bool) {
+	if code := runLogoutWithDeps(args, defaultLogoutDeps(), quiet); code != 0 {
+		os.Exit(code)
+	}
+}
+
+func runLogoutWithDeps(args []string, deps logoutDeps, quiet bool) int {
+	deps = normalizeLogoutDeps(deps)
+	infoOut := deps.stderr
+	if quiet {
+		infoOut = io.Discard
+	}
+
+	fs := flag.NewFlagSet("logout", flag.ContinueOnError)
+	fs.SetOutput(deps.stderr)
+	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+
+	authenticator, err := deps.newAuthenticator(*tokenDir)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
 	if err := authenticator.SignOut(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	_, _ = fmt.Fprintln(infoOut, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	return 0
 }
 
 type serveFlags struct {
+	quiet                           *bool
 	port                            *string
 	host                            *string
 	tokenDir                        *string
@@ -235,7 +365,12 @@ type serveFlags struct {
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
+	quiet := false
+	fs.BoolVar(&quiet, "quiet", false, "Suppress non-error CLI output")
+	fs.BoolVar(&quiet, "q", false, "Alias for --quiet")
+
 	return serveFlags{
+		quiet:                           &quiet,
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
@@ -282,15 +417,25 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string, quiet bool) {
+	fs := flag.NewFlagSet("vekil", flag.ExitOnError)
+	serve := registerServeFlags(fs)
+	fs.Parse(args) //nolint:errcheck
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	quiet = quiet || *serve.quiet
+
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if quiet && logLevel < logger.LevelError {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
 		log.Fatal("failed to initialize authenticator", logger.Err(err))
+	}
+	if quiet {
+		authenticator.SetInteractiveOutput(io.Discard)
 	}
 
 	providersCfg, err := proxy.LoadProvidersConfigFile(*serve.providersConfigPath)

--- a/main_test.go
+++ b/main_test.go
@@ -99,6 +99,8 @@ func TestGetEnvInt(t *testing.T) {
 
 func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	const envKey = "TEST_WARN_VAR"
+	restore := setSuppressEnvWarnings(false)
+	defer restore()
 
 	// Capture stderr to verify warning is emitted.
 	old := os.Stderr
@@ -226,15 +228,51 @@ func TestCommandFromArgs(t *testing.T) {
 }
 
 func TestStripGlobalQuietFlags(t *testing.T) {
-	filtered, quiet, err := stripGlobalQuietFlags([]string{"vekil", "--quiet", "login", "--gh"})
-	if err != nil {
-		t.Fatalf("stripGlobalQuietFlags() error = %v", err)
+	tests := []struct {
+		name         string
+		args         []string
+		wantQuiet    bool
+		wantFiltered []string
+	}{
+		{
+			name:         "long form true is stripped",
+			args:         []string{"vekil", "--quiet=true", "login", "--gh"},
+			wantQuiet:    true,
+			wantFiltered: []string{"vekil", "login", "--gh"},
+		},
+		{
+			name:         "long form false is stripped",
+			args:         []string{"vekil", "--quiet=false", "login"},
+			wantQuiet:    false,
+			wantFiltered: []string{"vekil", "login"},
+		},
+		{
+			name:         "short form is stripped",
+			args:         []string{"vekil", "-q", "logout"},
+			wantQuiet:    true,
+			wantFiltered: []string{"vekil", "logout"},
+		},
+		{
+			name:         "quiet-looking args after subcommand are preserved",
+			args:         []string{"vekil", "login", "--quiet=false", "-q"},
+			wantQuiet:    false,
+			wantFiltered: []string{"vekil", "login", "--quiet=false", "-q"},
+		},
 	}
-	if !quiet {
-		t.Fatal("quiet = false, want true")
-	}
-	if got, want := strings.Join(filtered, " "), "vekil login --gh"; got != want {
-		t.Fatalf("filtered args = %q, want %q", got, want)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered, quiet, err := stripGlobalQuietFlags(tc.args)
+			if err != nil {
+				t.Fatalf("stripGlobalQuietFlags() error = %v", err)
+			}
+			if quiet != tc.wantQuiet {
+				t.Fatalf("quiet = %v, want %v", quiet, tc.wantQuiet)
+			}
+			if got, want := strings.Join(filtered, " "), strings.Join(tc.wantFiltered, " "); got != want {
+				t.Fatalf("filtered args = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -316,6 +354,131 @@ func TestRunCLIWithQuietSuppressesLoginInfoButKeepsErrors(t *testing.T) {
 		}
 		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
 			t.Fatalf("stderr missing error, got %q", got)
+		}
+	})
+}
+
+func TestRunCLIWithQuietAffectsServeAndLogoutPaths(t *testing.T) {
+	t.Run("short quiet form reaches serve", func(t *testing.T) {
+		code := runCLIWithDeps([]string{"vekil", "-q", "--port", "1444"}, cliDeps{
+			stderr: io.Discard,
+			runServe: func(args []string, quiet bool) int {
+				if !quiet {
+					t.Fatal("quiet = false, want true")
+				}
+				if got, want := strings.Join(args, " "), "--port 1444"; got != want {
+					t.Fatalf("serve args = %q, want %q", got, want)
+				}
+				return 0
+			},
+			runLogin: func([]string, bool) int {
+				t.Fatal("unexpected login dispatch")
+				return 1
+			},
+			runLogout: func([]string, bool) int {
+				t.Fatal("unexpected logout dispatch")
+				return 1
+			},
+		})
+		if code != 0 {
+			t.Fatalf("runCLIWithDeps() code = %d, want 0", code)
+		}
+	})
+
+	t.Run("quiet false reaches logout unchanged", func(t *testing.T) {
+		code := runCLIWithDeps([]string{"vekil", "--quiet=false", "logout"}, cliDeps{
+			stderr: io.Discard,
+			runServe: func([]string, bool) int {
+				t.Fatal("unexpected serve dispatch")
+				return 1
+			},
+			runLogin: func([]string, bool) int {
+				t.Fatal("unexpected login dispatch")
+				return 1
+			},
+			runLogout: func(args []string, quiet bool) int {
+				if quiet {
+					t.Fatal("quiet = true, want false")
+				}
+				if len(args) != 0 {
+					t.Fatalf("logout args = %v, want empty", args)
+				}
+				return 0
+			},
+		})
+		if code != 0 {
+			t.Fatalf("runCLIWithDeps() code = %d, want 0", code)
+		}
+	})
+}
+
+func TestRunCLIWithQuietSuppressesEnvWarnings(t *testing.T) {
+	const envKey = "TEST_CLI_QUIET_ENV_BOOL"
+	t.Setenv(envKey, "not-a-bool")
+
+	t.Run("quiet suppresses warnings", func(t *testing.T) {
+		old := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe() error = %v", err)
+		}
+		os.Stderr = w
+		t.Cleanup(func() {
+			os.Stderr = old
+			_ = r.Close()
+		})
+
+		code := runCLIWithDeps([]string{"vekil", "--quiet"}, cliDeps{
+			stderr: io.Discard,
+			runServe: func([]string, bool) int {
+				_ = getEnvBool(envKey, false)
+				return 0
+			},
+			runLogin:  func([]string, bool) int { return 0 },
+			runLogout: func([]string, bool) int { return 0 },
+		})
+		if code != 0 {
+			t.Fatalf("runCLIWithDeps() code = %d, want 0", code)
+		}
+
+		_ = w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		if got := buf.String(); got != "" {
+			t.Fatalf("stderr = %q, want empty", got)
+		}
+	})
+
+	t.Run("non-quiet keeps warnings", func(t *testing.T) {
+		old := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe() error = %v", err)
+		}
+		os.Stderr = w
+		t.Cleanup(func() {
+			os.Stderr = old
+			_ = r.Close()
+		})
+
+		code := runCLIWithDeps([]string{"vekil"}, cliDeps{
+			stderr: io.Discard,
+			runServe: func([]string, bool) int {
+				_ = getEnvBool(envKey, false)
+				return 0
+			},
+			runLogin:  func([]string, bool) int { return 0 },
+			runLogout: func([]string, bool) int { return 0 },
+		})
+		if code != 0 {
+			t.Fatalf("runCLIWithDeps() code = %d, want 0", code)
+		}
+
+		_ = w.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		if got := buf.String(); !strings.Contains(got, "warning: ignoring invalid "+envKey) {
+			t.Fatalf("stderr missing warning, got %q", got)
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -225,6 +225,101 @@ func TestCommandFromArgs(t *testing.T) {
 	}
 }
 
+func TestStripGlobalQuietFlags(t *testing.T) {
+	filtered, quiet, err := stripGlobalQuietFlags([]string{"vekil", "--quiet", "login", "--gh"})
+	if err != nil {
+		t.Fatalf("stripGlobalQuietFlags() error = %v", err)
+	}
+	if !quiet {
+		t.Fatal("quiet = false, want true")
+	}
+	if got, want := strings.Join(filtered, " "), "vekil login --gh"; got != want {
+		t.Fatalf("filtered args = %q, want %q", got, want)
+	}
+}
+
+func TestRunCLIWithQuietSuppressesLoginInfoButKeepsErrors(t *testing.T) {
+	t.Run("suppresses success output", func(t *testing.T) {
+		var stderr bytes.Buffer
+		fake := &fakeLoginAuthenticator{}
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe() error = %v", err)
+		}
+		os.Stdout = w
+		t.Cleanup(func() {
+			os.Stdout = oldStdout
+			_ = r.Close()
+		})
+
+		code := runCLIWithDeps([]string{"vekil", "--quiet", "login", "--gh"}, cliDeps{
+			stderr: &stderr,
+			runServe: func([]string, bool) int {
+				t.Fatal("unexpected serve dispatch")
+				return 1
+			},
+			runLogout: func([]string, bool) int {
+				t.Fatal("unexpected logout dispatch")
+				return 1
+			},
+			runLogin: func(args []string, quiet bool) int {
+				return runLoginWithDeps(args, loginDeps{
+					stderr: &stderr,
+					newAuthenticator: func(string) (loginAuthenticator, error) {
+						return fake, nil
+					},
+				}, quiet)
+			},
+		})
+		if code != 0 {
+			t.Fatalf("runCLIWithDeps() code = %d, want 0", code)
+		}
+		_ = w.Close()
+		var stdout bytes.Buffer
+		_, _ = stdout.ReadFrom(r)
+		if got := stdout.String(); got != "" {
+			t.Fatalf("stdout = %q, want empty", got)
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("stderr = %q, want empty", got)
+		}
+	})
+
+	t.Run("keeps error output", func(t *testing.T) {
+		var stderr bytes.Buffer
+		fake := &fakeLoginAuthenticator{
+			signInWithGitHubCLIErr: fmt.Errorf("boom"),
+		}
+
+		code := runCLIWithDeps([]string{"vekil", "--quiet", "login", "--gh"}, cliDeps{
+			stderr: &stderr,
+			runServe: func([]string, bool) int {
+				t.Fatal("unexpected serve dispatch")
+				return 1
+			},
+			runLogout: func([]string, bool) int {
+				t.Fatal("unexpected logout dispatch")
+				return 1
+			},
+			runLogin: func(args []string, quiet bool) int {
+				return runLoginWithDeps(args, loginDeps{
+					stderr: &stderr,
+					newAuthenticator: func(string) (loginAuthenticator, error) {
+						return fake, nil
+					},
+				}, quiet)
+			},
+		})
+		if code != 1 {
+			t.Fatalf("runCLIWithDeps() code = %d, want 1", code)
+		}
+		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
+			t.Fatalf("stderr missing error, got %q", got)
+		}
+	})
+}
+
 func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	for _, helpArg := range []string{"-h", "--help"} {
 		t.Run(helpArg, func(t *testing.T) {
@@ -237,7 +332,7 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 					constructed = true
 					return &fakeLoginAuthenticator{}, nil
 				},
-			})
+			}, false)
 
 			if code != 0 {
 				t.Fatalf("runLoginWithDeps(%q) code = %d, want 0", helpArg, code)
@@ -266,7 +361,7 @@ func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
 			constructed = true
 			return &fakeLoginAuthenticator{}, nil
 		},
-	})
+	}, false)
 
 	if code != 2 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 2", code)
@@ -290,7 +385,7 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 			gotTokenDir = tokenDir
 			return fake, nil
 		},
-	})
+	}, false)
 
 	if code != 0 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
@@ -330,7 +425,7 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 			openedURL = url
 			return nil
 		},
-	})
+	}, false)
 
 	if code != 0 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())


### PR DESCRIPTION
## Summary

Adds a `--quiet` (alias `-q`) global flag to the vekil CLI that suppresses non-error output. Errors continue to print to stderr.

## Behavior

- Global flag: stripped from argv only **before** the subcommand boundary, so subcommand argument values that happen to look like `-q` / `--quiet=false` are preserved.
- `serve`: log level is raised to at least `error`; interactive auth prompt output is suppressed.
- `login` / `logout`: informational messages routed to `io.Discard`; errors still print.
- `getEnvBool` / `getEnvInt` / `getEnvDuration` warnings are routed to `io.Discard` when quiet.
- Auth: `auth.Authenticator` gained `SetInteractiveOutput(io.Writer)` (defaults to `os.Stderr`).

## Tests

`main_test.go` covers:
- `--quiet`, `-q`, `--quiet=true`, `--quiet=false`
- subcommand-arg safety (quiet-like tokens after the subcommand are not stripped)
- login + logout/serve dispatch quiet behavior
- env warnings suppressed when quiet, preserved otherwise

## Validation

- `go build ./...` ✅
- `go test ./...` ✅

## Docs

- `docs/configuration.md` Generic Flags table updated.
