### PR TITLE
Add minimal /metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -32,6 +33,10 @@ func (m *metrics) instrument(next http.Handler) http.Handler {
 func (m *metrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\nvekil_http_requests_total %d\n", m.requestsTotal.Load())
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_inflight_requests gauge\nvekil_http_inflight_requests %d\n", m.inflightRequest.Load())
+	_, _ = io.WriteString(w, "# TYPE vekil_http_requests_total counter\nvekil_http_requests_total ")
+	_, _ = io.WriteString(w, strconv.FormatUint(m.requestsTotal.Load(), 10))
+	_, _ = io.WriteString(w, "\n")
+	_, _ = io.WriteString(w, "# TYPE vekil_http_inflight_requests gauge\nvekil_http_inflight_requests ")
+	_, _ = io.WriteString(w, strconv.FormatInt(m.inflightRequest.Load(), 10))
+	_, _ = io.WriteString(w, "\n")
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type metrics struct {
+	requestsTotal   atomic.Uint64
+	inflightRequest atomic.Int64
+}
+
+func newMetrics() *metrics {
+	return &metrics{}
+}
+
+func (m *metrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		m.requestsTotal.Add(1)
+		m.inflightRequest.Add(1)
+		defer m.inflightRequest.Add(-1)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\nvekil_http_requests_total %d\n", m.requestsTotal.Load())
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_inflight_requests gauge\nvekil_http_inflight_requests %d\n", m.inflightRequest.Load())
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,9 +1,8 @@
 package server
 
 import (
-	"io"
+	"fmt"
 	"net/http"
-	"strconv"
 	"sync/atomic"
 )
 
@@ -33,10 +32,6 @@ func (m *metrics) instrument(next http.Handler) http.Handler {
 func (m *metrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
-	_, _ = io.WriteString(w, "# TYPE vekil_http_requests_total counter\nvekil_http_requests_total ")
-	_, _ = io.WriteString(w, strconv.FormatUint(m.requestsTotal.Load(), 10))
-	_, _ = io.WriteString(w, "\n")
-	_, _ = io.WriteString(w, "# TYPE vekil_http_inflight_requests gauge\nvekil_http_inflight_requests ")
-	_, _ = io.WriteString(w, strconv.FormatInt(m.inflightRequest.Load(), 10))
-	_, _ = io.WriteString(w, "\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\nvekil_http_requests_total %d\n", m.requestsTotal.Load())
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_inflight_requests gauge\nvekil_http_inflight_requests %d\n", m.inflightRequest.Load())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -86,6 +86,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	metrics := newMetrics()
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
@@ -100,12 +101,13 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.HandleFunc("GET /metrics", metrics.handleMetrics)
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.instrument(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"io"
 	"net"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +96,43 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestNew_ExposesMetricsCounterAndInflightGauge(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthReq := httptest.NewRequest("GET", "/healthz", nil)
+	healthRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthRec, healthReq)
+	if healthRec.Code != 200 {
+		t.Fatalf("expected /healthz status 200, got %d", healthRec.Code)
+	}
+
+	metricsReq := httptest.NewRequest("GET", "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsRec, metricsReq)
+	if metricsRec.Code != 200 {
+		t.Fatalf("expected /metrics status 200, got %d", metricsRec.Code)
+	}
+
+	body, err := io.ReadAll(metricsRec.Body)
+	if err != nil {
+		t.Fatalf("failed reading metrics response body: %v", err)
+	}
+	output := string(body)
+	if !strings.Contains(output, "vekil_http_requests_total 1") {
+		t.Fatalf("expected request counter metric in output, got %q", output)
+	}
+	if !strings.Contains(output, "vekil_http_inflight_requests 0") {
+		t.Fatalf("expected inflight gauge metric in output, got %q", output)
 	}
 }


### PR DESCRIPTION
## Summary
- mount a new `GET /metrics` route on the existing HTTP server
- add minimal in-process instrumentation with one request counter and one in-flight gauge
- add a focused server test that exercises `/healthz` and validates `/metrics` output

## Validation
- unable to run `go test` in this sandbox because `go` is not installed (`/bin/sh: 1: go: not found`)