### PR TITLE
Add --quiet flag to vekil

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | `QUIET` | `false` | Suppress non-error log output (overrides `--log-level`) |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", getEnvBool("QUIET", false), "Suppress non-error log output"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -282,11 +284,18 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+func (f serveFlags) resolvedLogLevel() logger.Level {
+	if *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.resolvedLogLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,72 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsResolvedLogLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		args []string
+		want string
+	}{
+		{
+			name: "default log level is info",
+			want: "info",
+		},
+		{
+			name: "explicit log level respected when quiet is false",
+			args: []string{"--log-level", "debug"},
+			want: "debug",
+		},
+		{
+			name: "quiet forces error log level",
+			args: []string{"--log-level", "debug", "--quiet"},
+			want: "error",
+		},
+		{
+			name: "quiet env can be disabled by cli override",
+			env: map[string]string{
+				"QUIET": "true",
+			},
+			args: []string{"--quiet=false", "--log-level", "debug"},
+			want: "debug",
+		},
+		{
+			name: "quiet env forces error by default",
+			env: map[string]string{
+				"QUIET": "true",
+			},
+			want: "error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			serve := parseServeFlagsForTest(t, tc.args...)
+			got := loggerLevelName(serve.resolvedLogLevel())
+			if got != tc.want {
+				t.Fatalf("resolvedLogLevel() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func loggerLevelName(level logger.Level) string {
+	switch level {
+	case logger.LevelDebug:
+		return "debug"
+	case logger.LevelInfo:
+		return "info"
+	case logger.LevelError:
+		return "error"
+	default:
+		return "unknown"
 	}
 }
 


### PR DESCRIPTION
## Add --quiet flag to vekil

Adds a `--quiet` flag that suppresses non-error output when set.

### Changes
- Added `--quiet` flag to serve command (with `QUIET` environment variable support)
- Implemented quiet mode by forcing log level to error when flag is enabled
- Added comprehensive test coverage for the flag and its interaction with log level settings

### Files Changed
- `main.go`: Added --quiet flag registration and log level resolution logic
- `main_test.go`: Added TestServeFlagsResolvedLogLevel test with multiple scenarios
- `docs/configuration.md`: Documented the new --quiet option

### Testing
- All existing tests pass
- New test covers: default behavior, explicit log levels, quiet override, environment variable precedence
- Build and format verification complete