### PR TITLE
feat: add --quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,8 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
+	quietShort                      *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +243,8 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
+		quietShort:                      fs.Bool("q", false, "Alias for --quiet"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -258,6 +262,13 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
 	}
+}
+
+func (f serveFlags) logLevelSetting() logger.Level {
+	if *f.quiet || *f.quietShort {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
 }
 
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
@@ -286,7 +297,7 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.logLevelSetting())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -217,7 +218,6 @@ type serveFlags struct {
 	providersConfigPath             *string
 	logLevel                        *string
 	quiet                           *bool
-	quietShort                      *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -236,15 +236,20 @@ type serveFlags struct {
 	compactUpstreamMaxAttempts      *int
 }
 
+var suppressEnvWarnings bool
+
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
+	var quiet bool
+	fs.BoolVar(&quiet, "quiet", false, "Suppress non-error output")
+	fs.BoolVar(&quiet, "q", false, "Alias for --quiet")
+
 	return serveFlags{
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
-		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
-		quietShort:                      fs.Bool("q", false, "Alias for --quiet"),
+		quiet:                           &quiet,
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -265,7 +270,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 }
 
 func (f serveFlags) logLevelSetting() logger.Level {
-	if *f.quiet || *f.quietShort {
+	if *f.quiet {
 		return logger.LevelError
 	}
 	return logger.ParseLevel(*f.logLevel)
@@ -294,6 +299,7 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 }
 
 func runServe() {
+	suppressEnvWarnings = argsContainQuietFlag(os.Args[1:])
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -353,6 +359,18 @@ func runServe() {
 	log.Info("server stopped")
 }
 
+func argsContainQuietFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if arg == "--quiet" || arg == "-q" || strings.HasPrefix(arg, "--quiet=") || strings.HasPrefix(arg, "-q=") {
+			return true
+		}
+	}
+	return false
+}
+
 func getEnv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -367,7 +385,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		envWarningf("warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -380,7 +398,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		envWarningf("warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -393,8 +411,15 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		envWarningf("warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
+}
+
+func envWarningf(format string, args ...any) {
+	if suppressEnvWarnings {
+		return
+	}
+	_, _ = fmt.Fprintf(os.Stderr, format, args...)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -100,6 +100,9 @@ func TestGetEnvInt(t *testing.T) {
 
 func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	const envKey = "TEST_WARN_VAR"
+	previous := suppressEnvWarnings
+	suppressEnvWarnings = false
+	t.Cleanup(func() { suppressEnvWarnings = previous })
 
 	// Capture stderr to verify warning is emitted.
 	old := os.Stderr
@@ -237,6 +240,44 @@ func TestServeFlagsQuietSuppressesNonErrorLogs(t *testing.T) {
 			}
 			if gotError := strings.Contains(output, `"msg":"error message"`); gotError != tc.wantError {
 				t.Fatalf("error output presence = %v, want %v; output=%q", gotError, tc.wantError, output)
+			}
+		})
+	}
+}
+
+func TestServeFlagsQuietAndShortQuietShareSameValue(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "--quiet sets -q value",
+			args: []string{"--quiet"},
+		},
+		{
+			name: "-q sets --quiet value",
+			args: []string{"-q"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			serve := registerServeFlags(fs)
+
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatalf("parse serve flags: %v", err)
+			}
+
+			if !*serve.quiet {
+				t.Fatalf("serve.quiet = false, want true")
+			}
+			if got := fs.Lookup("quiet").Value.String(); got != "true" {
+				t.Fatalf("quiet flag value = %q, want true", got)
+			}
+			if got := fs.Lookup("q").Value.String(); got != "true" {
+				t.Fatalf("q flag value = %q, want true", got)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,59 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsQuietSuppressesNonErrorLogs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantInfo  bool
+		wantError bool
+		wantLevel logger.Level
+	}{
+		{
+			name:      "default includes info and error",
+			wantInfo:  true,
+			wantError: true,
+			wantLevel: logger.LevelInfo,
+		},
+		{
+			name:      "quiet suppresses info but keeps error",
+			args:      []string{"--quiet"},
+			wantInfo:  false,
+			wantError: true,
+			wantLevel: logger.LevelError,
+		},
+		{
+			name:      "short quiet suppresses info but keeps error",
+			args:      []string{"-q"},
+			wantInfo:  false,
+			wantError: true,
+			wantLevel: logger.LevelError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serve := parseServeFlagsForTest(t, tc.args...)
+			if got := serve.logLevelSetting(); got != tc.wantLevel {
+				t.Fatalf("logLevelSetting() = %v, want %v", got, tc.wantLevel)
+			}
+
+			log := logger.New(serve.logLevelSetting())
+			output := captureStderr(t, func() {
+				log.Info("info message")
+				log.Error("error message")
+			})
+
+			if gotInfo := strings.Contains(output, `"msg":"info message"`); gotInfo != tc.wantInfo {
+				t.Fatalf("info output presence = %v, want %v; output=%q", gotInfo, tc.wantInfo, output)
+			}
+			if gotError := strings.Contains(output, `"msg":"error message"`); gotError != tc.wantError {
+				t.Fatalf("error output presence = %v, want %v; output=%q", gotError, tc.wantError, output)
+			}
+		})
 	}
 }
 
@@ -402,4 +456,25 @@ func (f *fakeLoginAuthenticator) PollForAuthorization(_ context.Context, dcResp 
 	f.pollForAuthorizationCalls++
 	f.polledDeviceCode = dcResp
 	return f.pollForAuthorizationErr
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	_ = r.Close()
+	return buf.String()
 }


### PR DESCRIPTION
## Summary
Adds a `--quiet` (alias `-q`) flag to vekil's serve command that suppresses non-error output while keeping errors on stderr.

## Changes
- `main.go`:
  - New persistent serve flag `--quiet` with shorthand `-q`, both bound to the same `bool` via `fs.BoolVar` (idiomatic alias).
  - `serveFlags.logLevelSetting()` forces logger level to `error` when quiet is set; otherwise uses existing `--log-level` behavior.
  - Pre-flag-parse detection of `--quiet`/`-q` in `os.Args` so env-parse warnings emitted by `getEnvBool/getEnvInt/getEnvDuration` during flag registration are also suppressed via a new `envWarningf` helper.
  - Errors continue to surface on stderr unchanged.
- `main_test.go`:
  - `TestServeFlagsQuietSuppressesNonErrorLogs` — verifies default logs include info+error, while `--quiet` and `-q` suppress info but preserve error.
  - `TestServeFlagsQuietAndShortQuietShareSameValue` — asserts `--quiet` and `-q` bind to the same variable in both directions.

## Validation
- `gofmt -w`, `go build ./...`, `go vet ./...`, `go test ./...` all pass (locally and in container `golang:1.25`).

## Review
Two review rounds; reviewer requested unifying the alias onto a single variable and ensuring quiet also covered env-parse warnings. Both addressed; final review: LGTM.