### PR TITLE
Add --quiet flag to vekil serve mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error log output"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -286,7 +288,7 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(effectiveServeLogLevel(logger.ParseLevel(*serve.logLevel), *serve.quiet))
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
@@ -340,6 +342,13 @@ func runServe() {
 		log.Fatal("shutdown error", logger.Err(err))
 	}
 	log.Info("server stopped")
+}
+
+func effectiveServeLogLevel(level logger.Level, quiet bool) logger.Level {
+	if quiet && level < logger.LevelError {
+		return logger.LevelError
+	}
+	return level
 }
 
 func getEnv(key, fallback string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,39 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeQuietSuppressesInfoButNotErrors(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet", "--log-level", "debug")
+	log := logger.New(effectiveServeLogLevel(logger.ParseLevel(*serve.logLevel), *serve.quiet))
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	log.Info("quiet-info-should-not-print")
+	log.Error("quiet-error-should-print")
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+	if strings.Contains(output, "quiet-info-should-not-print") {
+		t.Fatalf("quiet mode should suppress info logs, got output %q", output)
+	}
+	if !strings.Contains(output, "quiet-error-should-print") {
+		t.Fatalf("quiet mode should keep error logs, got output %q", output)
 	}
 }
 


### PR DESCRIPTION
## Add --quiet flag to vekil serve mode

This PR adds a `--quiet` flag that suppresses non-error output when set.

### Changes
- Added `--quiet` flag to serve mode
- Non-error logs (info, debug) are suppressed when the flag is used
- Error and fatal logs are always shown
- Added test `TestServeQuietSuppressesInfoButNotErrors` to verify the behavior

### Testing
- All existing tests pass
- New test verifies info logs are suppressed but error logs are shown with --quiet

### Files Changed
- `main.go`: Added quiet flag to serveFlags, implemented effectiveServeLogLevel() helper
- `main_test.go`: Added test for quiet flag behavior