### PR TITLE
Add --quiet flag to suppress non-error CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ brew install --cask sozercan/repo/vekil
 > The app is not signed. Clear quarantine with `xattr -cr /Applications/Vekil.app`. Manual `vekil-macos-arm64.zip` downloads are also on [Releases](https://github.com/sozercan/vekil/releases/latest). See [Tray App (macOS/Linux)](docs/menubar.md).
 
 For explicit provider routing, start the proxy with `--providers-config /path/to/providers.{json,yaml}`.
+Use `--quiet` (or `-q`) to suppress non-error CLI output.
 
 **First-run auth** depends on your providers:
 

--- a/main.go
+++ b/main.go
@@ -26,18 +26,23 @@ const (
 	cliCommandLogout
 )
 
+var cliQuiet bool
+
 func main() {
+	args, quiet := stripGlobalQuietFlag(os.Args)
+	cliQuiet = quiet
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch commandFromArgs(args) {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(args[2:])
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(args[2:])
 		return
 	}
 
-	runServe()
+	runServe(args[1:])
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -55,10 +60,29 @@ func commandFromArgs(args []string) cliCommand {
 	}
 }
 
+func stripGlobalQuietFlag(args []string) ([]string, bool) {
+	if len(args) == 0 {
+		return args, false
+	}
+
+	filtered := make([]string, 0, len(args))
+	filtered = append(filtered, args[0])
+	quiet := false
+	for _, arg := range args[1:] {
+		if arg == "--quiet" || arg == "-q" {
+			quiet = true
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered, quiet
+}
+
 type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -105,6 +129,9 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		}
 		return 2
 	}
+	if opts.quiet {
+		cliQuiet = true
+	}
 
 	authenticator, err := deps.newAuthenticator(opts.tokenDir)
 	if err != nil {
@@ -118,13 +145,17 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		if !cliQuiet {
+			_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		}
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			if !cliQuiet {
+				_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			}
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +169,15 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	if !cliQuiet {
+		_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+		_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	}
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		if !cliQuiet {
+			_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		}
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +185,9 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	if !cliQuiet {
+		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	}
 	return 0
 }
 
@@ -178,6 +215,8 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", false, "Suppress non-error CLI output")
+	q := fs.Bool("q", false, "Alias for --quiet")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,6 +224,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet || *q
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
@@ -194,7 +234,12 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 func runLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error CLI output")
+	q := fs.Bool("q", false, "Alias for --quiet")
 	fs.Parse(args) //nolint:errcheck
+	if *quiet || *q {
+		cliQuiet = true
+	}
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
 	if err != nil {
@@ -207,10 +252,14 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !cliQuiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
+	quiet                           *bool
+	quietShort                      *bool
 	port                            *string
 	host                            *string
 	tokenDir                        *string
@@ -236,6 +285,8 @@ type serveFlags struct {
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
 	return serveFlags{
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error CLI output"),
+		quietShort:                      fs.Bool("q", false, "Alias for --quiet"),
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
@@ -282,11 +333,19 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string) {
+	fs := flag.NewFlagSet("vekil", flag.ExitOnError)
+	serve := registerServeFlags(fs)
+	fs.Parse(args) //nolint:errcheck
+	if *serve.quiet || *serve.quietShort {
+		cliQuiet = true
+	}
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	level := logger.ParseLevel(*serve.logLevel)
+	if cliQuiet && level < logger.LevelError {
+		level = logger.LevelError
+	}
+	log := logger.New(level)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
@@ -356,7 +415,9 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		if !cliQuiet {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed
@@ -369,7 +430,9 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		if !cliQuiet {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed
@@ -382,7 +445,9 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		if !cliQuiet {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed

--- a/main_test.go
+++ b/main_test.go
@@ -225,6 +225,16 @@ func TestCommandFromArgs(t *testing.T) {
 	}
 }
 
+func TestStripGlobalQuietFlag(t *testing.T) {
+	args, quiet := stripGlobalQuietFlag([]string{"vekil", "--quiet", "login", "--gh"})
+	if !quiet {
+		t.Fatal("quiet should be true when --quiet is provided")
+	}
+	if got, want := strings.Join(args, " "), "vekil login --gh"; got != want {
+		t.Fatalf("stripGlobalQuietFlag() args = %q, want %q", got, want)
+	}
+}
+
 func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	for _, helpArg := range []string{"-h", "--help"} {
 		t.Run(helpArg, func(t *testing.T) {
@@ -355,6 +365,32 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("stderr missing %q, got %q", want, output)
 		}
+	}
+}
+
+func TestRunLoginQuietSuppressesInformationalOutput(t *testing.T) {
+	prevQuiet := cliQuiet
+	cliQuiet = true
+	t.Cleanup(func() { cliQuiet = prevQuiet })
+
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{}
+
+	code := runLoginWithDeps([]string{"--gh"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	})
+
+	if code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+	}
+	if fake.signInWithGitHubCLICalls != 1 {
+		t.Fatalf("SignInWithGitHubCLI calls = %d, want 1", fake.signInWithGitHubCLICalls)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("quiet login should suppress non-error output, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `--quiet` / `-q` flag to the vekil CLI that suppresses non-error output while leaving error output on stderr intact.

## Changes
- `main.go`: Global root-level quiet handling (`stripGlobalQuietFlag`, `cliQuiet`) plus per-command flags for `serve`, `login`, `logout`. In quiet mode, serve raises log level to `error`; login/logout suppress informational messages; env-parse warnings are silenced.
- `main_test.go`: New tests `TestStripGlobalQuietFlag` and `TestRunLoginQuietSuppressesInformationalOutput`.
- `README.md`: Brief note documenting the new flag.

## Validation
- `go build ./... && go vet ./... && go test ./...` — all green.

## Reviews
- Security: APPROVED — no masking of error paths; quiet only suppresses informational output.
- Quality: APPROVED — idiomatic, tests cover flag parsing and suppression behavior.