### PR TITLE
feat: add global --quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,17 +28,23 @@ const (
 )
 
 func main() {
+	quiet, args, err := extractGlobalQuietFlag(os.Args)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch commandFromArgs(args) {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(args[2:], quiet)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(args[2:], quiet)
 		return
 	}
 
-	runServe()
+	runServe(args[1:], quiet)
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -59,6 +66,7 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -76,8 +84,8 @@ type loginDeps struct {
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, globalQuiet bool) {
+	if code := runLoginWithDeps(args, defaultLoginDeps(), globalQuiet); code != 0 {
 		os.Exit(code)
 	}
 }
@@ -92,7 +100,7 @@ func defaultLoginDeps() loginDeps {
 	}
 }
 
-func runLoginWithDeps(args []string, deps loginDeps) int {
+func runLoginWithDeps(args []string, deps loginDeps, globalQuiet bool) int {
 	deps = normalizeLoginDeps(deps)
 
 	opts, err := parseLoginOptions(args, deps.stderr)
@@ -105,6 +113,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		}
 		return 2
 	}
+	quiet := globalQuiet || opts.quiet
 
 	authenticator, err := deps.newAuthenticator(opts.tokenDir)
 	if err != nil {
@@ -118,13 +127,17 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		if !quiet {
+			_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		}
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			if !quiet {
+				_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			}
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +151,15 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	if !quiet {
+		_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+		_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	}
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		if !quiet {
+			_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		}
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +167,9 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	if !quiet {
+		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	}
 	return 0
 }
 
@@ -178,6 +197,8 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
+	q := fs.Bool("q", false, "Alias for --quiet")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,15 +206,18 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet || *q
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
 	return opts, nil
 }
 
-func runLogout(args []string) {
+func runLogout(args []string, globalQuiet bool) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
+	q := fs.Bool("q", false, "Alias for --quiet")
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,10 +231,14 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !(globalQuiet || *quiet || *q) {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
+	quiet                           *bool
+	quietShort                      *bool
 	port                            *string
 	host                            *string
 	tokenDir                        *string
@@ -236,6 +264,8 @@ type serveFlags struct {
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
 	return serveFlags{
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
+		quietShort:                      fs.Bool("q", false, "Alias for --quiet"),
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
@@ -260,6 +290,10 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 	}
 }
 
+func (f serveFlags) quietEnabled(globalQuiet bool) bool {
+	return globalQuiet || *f.quiet || *f.quietShort
+}
+
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
 	return proxy.CopilotHeaderConfig{
 		EditorVersion:       *f.copilotEditorVersion,
@@ -282,11 +316,16 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string, globalQuiet bool) {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	serve := registerServeFlags(fs)
+	fs.Parse(args) //nolint:errcheck
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if serve.quietEnabled(globalQuiet) && logLevel < logger.LevelError {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
@@ -340,6 +379,41 @@ func runServe() {
 		log.Fatal("shutdown error", logger.Err(err))
 	}
 	log.Info("server stopped")
+}
+
+func extractGlobalQuietFlag(args []string) (bool, []string, error) {
+	if len(args) == 0 {
+		return false, args, nil
+	}
+
+	quiet := false
+	filtered := make([]string, 0, len(args))
+	filtered = append(filtered, args[0])
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--":
+			filtered = append(filtered, args[i:]...)
+			return quiet, filtered, nil
+		case arg == "--quiet", arg == "-q":
+			quiet = true
+		case strings.HasPrefix(arg, "--quiet="):
+			parsed, err := strconv.ParseBool(strings.TrimPrefix(arg, "--quiet="))
+			if err != nil {
+				return false, nil, fmt.Errorf("invalid value for --quiet: %q", strings.TrimPrefix(arg, "--quiet="))
+			}
+			quiet = parsed
+		case strings.HasPrefix(arg, "-q="):
+			parsed, err := strconv.ParseBool(strings.TrimPrefix(arg, "-q="))
+			if err != nil {
+				return false, nil, fmt.Errorf("invalid value for --quiet: %q", strings.TrimPrefix(arg, "-q="))
+			}
+			quiet = parsed
+		default:
+			filtered = append(filtered, arg)
+		}
+	}
+	return quiet, filtered, nil
 }
 
 func getEnv(key, fallback string) string {

--- a/main.go
+++ b/main.go
@@ -69,6 +69,11 @@ type loginOptions struct {
 	quiet        bool
 }
 
+type logoutOptions struct {
+	tokenDir string
+	quiet    bool
+}
+
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
 
 type loginAuthenticator interface {
@@ -82,6 +87,15 @@ type loginDeps struct {
 	stderr           io.Writer
 	newAuthenticator func(string) (loginAuthenticator, error)
 	openURL          func(string) error
+}
+
+type logoutAuthenticator interface {
+	SignOut() error
+}
+
+type logoutDeps struct {
+	stderr           io.Writer
+	newAuthenticator func(string) (logoutAuthenticator, error)
 }
 
 func runLogin(args []string, globalQuiet bool) {
@@ -214,26 +228,76 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 }
 
 func runLogout(args []string, globalQuiet bool) {
-	fs := flag.NewFlagSet("logout", flag.ExitOnError)
-	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	quiet := fs.Bool("quiet", false, "Suppress non-error output")
-	q := fs.Bool("q", false, "Alias for --quiet")
-	fs.Parse(args) //nolint:errcheck
+	if code := runLogoutWithDeps(args, defaultLogoutDeps(), globalQuiet); code != 0 {
+		os.Exit(code)
+	}
+}
 
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
+func defaultLogoutDeps() logoutDeps {
+	return logoutDeps{
+		stderr: os.Stderr,
+		newAuthenticator: func(tokenDir string) (logoutAuthenticator, error) {
+			return auth.NewAuthenticator(tokenDir)
+		},
+	}
+}
+
+func runLogoutWithDeps(args []string, deps logoutDeps, globalQuiet bool) int {
+	deps = normalizeLogoutDeps(deps)
+
+	opts, err := parseLogoutOptions(args, deps.stderr)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+
+	authenticator, err := deps.newAuthenticator(opts.tokenDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
 	if err := authenticator.SignOut(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
-	if !(globalQuiet || *quiet || *q) {
-		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !(globalQuiet || opts.quiet) {
+		_, _ = fmt.Fprintln(deps.stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 	}
+
+	return 0
+}
+
+func normalizeLogoutDeps(deps logoutDeps) logoutDeps {
+	if deps.stderr == nil {
+		deps.stderr = io.Discard
+	}
+	if deps.newAuthenticator == nil {
+		deps.newAuthenticator = defaultLogoutDeps().newAuthenticator
+	}
+	return deps
+}
+
+func parseLogoutOptions(args []string, stderr io.Writer) (logoutOptions, error) {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	opts := logoutOptions{}
+	fs := flag.NewFlagSet("logout", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
+	q := fs.Bool("q", false, "Alias for --quiet")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
+	}
+
+	opts.tokenDir = *tokenDir
+	opts.quiet = *quiet || *q
+	return opts, nil
 }
 
 type serveFlags struct {
@@ -262,7 +326,7 @@ type serveFlags struct {
 	compactUpstreamMaxAttempts      *int
 }
 
-func registerServeFlags(fs *flag.FlagSet) serveFlags {
+func registerServeFlags(fs *flag.FlagSet, quiet bool) serveFlags {
 	return serveFlags{
 		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 		quietShort:                      fs.Bool("q", false, "Alias for --quiet"),
@@ -271,22 +335,22 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
-		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
+		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDurationWithQuiet("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout(), quiet), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
 		copilotUserAgent:                fs.String("copilot-user-agent", getEnv("COPILOT_USER_AGENT", ""), "Upstream Copilot user-agent header"),
 		copilotIntegrationID:            fs.String("copilot-integration-id", getEnv("COPILOT_INTEGRATION_ID", ""), "Upstream Copilot copilot-integration-id header"),
 		copilotGitHubAPIVersion:         fs.String("copilot-github-api-version", getEnv("COPILOT_GITHUB_API_VERSION", ""), "Upstream Copilot x-github-api-version header"),
 		copilotOpenAIIntent:             fs.String("copilot-openai-intent", getEnv("COPILOT_OPENAI_INTENT", ""), "Upstream Copilot openai-intent header"),
-		responsesWSEnabled:              fs.Bool("responses-ws-enabled", getEnvBool("RESPONSES_WS_ENABLED", false), "Enable proxy-owned Codex websocket bridge on GET /v1/responses"),
-		responsesWSTurnStateDelta:       fs.Bool("responses-ws-turn-state-delta", getEnvBool("RESPONSES_WS_TURN_STATE_DELTA", false), "Attempt delta-only replay when upstream returns X-Codex-Turn-State"),
-		responsesWSDisableAutoCompact:   fs.Bool("responses-ws-disable-auto-compact", getEnvBool("RESPONSES_WS_DISABLE_AUTO_COMPACT", false), "Disable automatic websocket-session history compaction"),
-		responsesWSCompactMaxItems:      fs.Int("responses-ws-auto-compact-max-items", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_ITEMS", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxItems), "Auto-compact websocket session history after this many items"),
-		responsesWSCompactMaxBytes:      fs.Int("responses-ws-auto-compact-max-bytes", getEnvInt("RESPONSES_WS_AUTO_COMPACT_MAX_BYTES", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxBytes), "Auto-compact websocket session history after this many raw bytes"),
-		responsesWSCompactKeepTail:      fs.Int("responses-ws-auto-compact-keep-tail", getEnvInt("RESPONSES_WS_AUTO_COMPACT_KEEP_TAIL", proxy.DefaultResponsesWebSocketConfig().AutoCompactKeepTail), "When auto-compacting websocket history, keep this many most recent items verbatim"),
-		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
-		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
-		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+		responsesWSEnabled:              fs.Bool("responses-ws-enabled", getEnvBoolWithQuiet("RESPONSES_WS_ENABLED", false, quiet), "Enable proxy-owned Codex websocket bridge on GET /v1/responses"),
+		responsesWSTurnStateDelta:       fs.Bool("responses-ws-turn-state-delta", getEnvBoolWithQuiet("RESPONSES_WS_TURN_STATE_DELTA", false, quiet), "Attempt delta-only replay when upstream returns X-Codex-Turn-State"),
+		responsesWSDisableAutoCompact:   fs.Bool("responses-ws-disable-auto-compact", getEnvBoolWithQuiet("RESPONSES_WS_DISABLE_AUTO_COMPACT", false, quiet), "Disable automatic websocket-session history compaction"),
+		responsesWSCompactMaxItems:      fs.Int("responses-ws-auto-compact-max-items", getEnvIntWithQuiet("RESPONSES_WS_AUTO_COMPACT_MAX_ITEMS", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxItems, quiet), "Auto-compact websocket session history after this many items"),
+		responsesWSCompactMaxBytes:      fs.Int("responses-ws-auto-compact-max-bytes", getEnvIntWithQuiet("RESPONSES_WS_AUTO_COMPACT_MAX_BYTES", proxy.DefaultResponsesWebSocketConfig().AutoCompactMaxBytes, quiet), "Auto-compact websocket session history after this many raw bytes"),
+		responsesWSCompactKeepTail:      fs.Int("responses-ws-auto-compact-keep-tail", getEnvIntWithQuiet("RESPONSES_WS_AUTO_COMPACT_KEEP_TAIL", proxy.DefaultResponsesWebSocketConfig().AutoCompactKeepTail, quiet), "When auto-compacting websocket history, keep this many most recent items verbatim"),
+		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvIntWithQuiet("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes(), quiet), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
+		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvIntWithQuiet("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency(), quiet), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
+		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvIntWithQuiet("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts(), quiet), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
 	}
 }
 
@@ -318,13 +382,10 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 
 func runServe(args []string, globalQuiet bool) {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	serve := registerServeFlags(fs)
+	serve := registerServeFlags(fs, globalQuiet)
 	fs.Parse(args) //nolint:errcheck
 
-	logLevel := logger.ParseLevel(*serve.logLevel)
-	if serve.quietEnabled(globalQuiet) && logLevel < logger.LevelError {
-		logLevel = logger.LevelError
-	}
+	logLevel := effectiveServeLogLevel(logger.ParseLevel(*serve.logLevel), serve.quietEnabled(globalQuiet))
 	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
@@ -381,6 +442,13 @@ func runServe(args []string, globalQuiet bool) {
 	log.Info("server stopped")
 }
 
+func effectiveServeLogLevel(level logger.Level, quiet bool) logger.Level {
+	if quiet && level < logger.LevelError {
+		return logger.LevelError
+	}
+	return level
+}
+
 func extractGlobalQuietFlag(args []string) (bool, []string, error) {
 	if len(args) == 0 {
 		return false, args, nil
@@ -424,39 +492,57 @@ func getEnv(key, fallback string) string {
 }
 
 func getEnvBool(key string, fallback bool) bool {
+	return getEnvBoolWithQuiet(key, fallback, false)
+}
+
+func getEnvBoolWithQuiet(key string, fallback bool, quiet bool) bool {
 	v := getEnv(key, "")
 	if v == "" {
 		return fallback
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		if !quiet {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed
 }
 
 func getEnvInt(key string, fallback int) int {
+	return getEnvIntWithQuiet(key, fallback, false)
+}
+
+func getEnvIntWithQuiet(key string, fallback int, quiet bool) int {
 	v := getEnv(key, "")
 	if v == "" {
 		return fallback
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		if !quiet {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed
 }
 
 func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	return getEnvDurationWithQuiet(key, fallback, false)
+}
+
+func getEnvDurationWithQuiet(key string, fallback time.Duration, quiet bool) time.Duration {
 	v := getEnv(key, "")
 	if v == "" {
 		return fallback
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		if !quiet {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		}
 		return fallback
 	}
 	return parsed

--- a/main_test.go
+++ b/main_test.go
@@ -237,7 +237,7 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 					constructed = true
 					return &fakeLoginAuthenticator{}, nil
 				},
-			})
+			}, false)
 
 			if code != 0 {
 				t.Fatalf("runLoginWithDeps(%q) code = %d, want 0", helpArg, code)
@@ -266,7 +266,7 @@ func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
 			constructed = true
 			return &fakeLoginAuthenticator{}, nil
 		},
-	})
+	}, false)
 
 	if code != 2 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 2", code)
@@ -290,7 +290,7 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 			gotTokenDir = tokenDir
 			return fake, nil
 		},
-	})
+	}, false)
 
 	if code != 0 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
@@ -330,7 +330,7 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 			openedURL = url
 			return nil
 		},
-	})
+	}, false)
 
 	if code != 0 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
@@ -355,6 +355,91 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("stderr missing %q, got %q", want, output)
 		}
+	}
+}
+
+func TestRunLoginQuietSuppressesNonErrorOutput(t *testing.T) {
+	fake := &fakeLoginAuthenticator{}
+
+	var normalStderr bytes.Buffer
+	if code := runLoginWithDeps(nil, loginDeps{
+		stderr: &normalStderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	}, false); code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+	}
+	if got := normalStderr.String(); !strings.Contains(got, "Already logged in.") {
+		t.Fatalf("expected normal output to contain status message, got %q", got)
+	}
+
+	var quietStderr bytes.Buffer
+	if code := runLoginWithDeps([]string{"--quiet"}, loginDeps{
+		stderr: &quietStderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	}, false); code != 0 {
+		t.Fatalf("runLoginWithDeps(--quiet) code = %d, want 0", code)
+	}
+	if got := quietStderr.String(); got != "" {
+		t.Fatalf("expected quiet output to be empty, got %q", got)
+	}
+}
+
+func TestExtractGlobalQuietFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantQuiet    bool
+		wantArgs     []string
+		wantErrMatch string
+	}{
+		{
+			name:      "quiet before subcommand",
+			args:      []string{"vekil", "--quiet", "login", "--force"},
+			wantQuiet: true,
+			wantArgs:  []string{"vekil", "login", "--force"},
+		},
+		{
+			name:      "short quiet after subcommand",
+			args:      []string{"vekil", "login", "-q"},
+			wantQuiet: true,
+			wantArgs:  []string{"vekil", "login"},
+		},
+		{
+			name:      "explicit false keeps output",
+			args:      []string{"vekil", "--quiet=false", "login"},
+			wantQuiet: false,
+			wantArgs:  []string{"vekil", "login"},
+		},
+		{
+			name:         "invalid quiet value errors",
+			args:         []string{"vekil", "--quiet=maybe", "login"},
+			wantErrMatch: `invalid value for --quiet: "maybe"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotQuiet, gotArgs, err := extractGlobalQuietFlag(tc.args)
+			if tc.wantErrMatch != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrMatch) {
+					t.Fatalf("extractGlobalQuietFlag(%v) err = %v, want match %q", tc.args, err, tc.wantErrMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractGlobalQuietFlag(%v) unexpected err: %v", tc.args, err)
+			}
+			if gotQuiet != tc.wantQuiet {
+				t.Fatalf("extractGlobalQuietFlag(%v) quiet = %v, want %v", tc.args, gotQuiet, tc.wantQuiet)
+			}
+			if strings.Join(gotArgs, "\x00") != strings.Join(tc.wantArgs, "\x00") {
+				t.Fatalf("extractGlobalQuietFlag(%v) args = %v, want %v", tc.args, gotArgs, tc.wantArgs)
+			}
+		})
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -121,11 +122,33 @@ func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	}
 }
 
+func TestRegisterServeFlagsQuietSuppressesEnvWarnings(t *testing.T) {
+	const envKey = "RESPONSES_WS_ENABLED"
+	t.Setenv(envKey, "not-a-bool")
+
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	_ = registerServeFlags(fs, true)
+
+	_ = w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if got := buf.String(); got != "" {
+		t.Fatalf("expected no stderr output in quiet mode, got %q", got)
+	}
+}
+
 func parseServeFlagsForTest(t *testing.T, args ...string) serveFlags {
 	t.Helper()
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	serve := registerServeFlags(fs)
+	serve := registerServeFlags(fs, false)
 	if err := fs.Parse(args); err != nil {
 		t.Fatalf("parse serve flags: %v", err)
 	}
@@ -388,6 +411,93 @@ func TestRunLoginQuietSuppressesNonErrorOutput(t *testing.T) {
 	}
 }
 
+func TestRunLoginQuietStillPrintsErrors(t *testing.T) {
+	var stderr bytes.Buffer
+
+	code := runLoginWithDeps([]string{"--quiet"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return nil, fmt.Errorf("boom")
+		},
+	}, false)
+
+	if code != 1 {
+		t.Fatalf("runLoginWithDeps(--quiet) code = %d, want 1", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "error: boom") {
+		t.Fatalf("stderr missing error output, got %q", got)
+	}
+}
+
+func TestRunLogoutQuietSuppressesSuccessOutput(t *testing.T) {
+	var normalStderr bytes.Buffer
+	if code := runLogoutWithDeps(nil, logoutDeps{
+		stderr: &normalStderr,
+		newAuthenticator: func(string) (logoutAuthenticator, error) {
+			return &fakeLogoutAuthenticator{}, nil
+		},
+	}, false); code != 0 {
+		t.Fatalf("runLogoutWithDeps() code = %d, want 0", code)
+	}
+	if got := normalStderr.String(); !strings.Contains(got, "Logged out.") {
+		t.Fatalf("expected normal output to contain logout message, got %q", got)
+	}
+
+	var quietStderr bytes.Buffer
+	if code := runLogoutWithDeps([]string{"--quiet"}, logoutDeps{
+		stderr: &quietStderr,
+		newAuthenticator: func(string) (logoutAuthenticator, error) {
+			return &fakeLogoutAuthenticator{}, nil
+		},
+	}, false); code != 0 {
+		t.Fatalf("runLogoutWithDeps(--quiet) code = %d, want 0", code)
+	}
+	if got := quietStderr.String(); got != "" {
+		t.Fatalf("expected quiet output to be empty, got %q", got)
+	}
+}
+
+func TestRunLogoutQuietStillPrintsErrors(t *testing.T) {
+	var stderr bytes.Buffer
+
+	code := runLogoutWithDeps([]string{"--quiet"}, logoutDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (logoutAuthenticator, error) {
+			return &fakeLogoutAuthenticator{signOutErr: fmt.Errorf("logout failed")}, nil
+		},
+	}, false)
+
+	if code != 1 {
+		t.Fatalf("runLogoutWithDeps(--quiet) code = %d, want 1", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "error: logout failed") {
+		t.Fatalf("stderr missing error output, got %q", got)
+	}
+}
+
+func TestEffectiveServeLogLevelQuietSuppression(t *testing.T) {
+	tests := []struct {
+		name  string
+		level string
+		quiet bool
+		want  string
+	}{
+		{name: "info upgraded to error when quiet", level: "info", quiet: true, want: "error"},
+		{name: "debug upgraded to error when quiet", level: "debug", quiet: true, want: "error"},
+		{name: "error remains error when quiet", level: "error", quiet: true, want: "error"},
+		{name: "info stays info when not quiet", level: "info", quiet: false, want: "info"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveServeLogLevel(logger.ParseLevel(tc.level), tc.quiet)
+			if got != logger.ParseLevel(tc.want) {
+				t.Fatalf("effectiveServeLogLevel(%q, quiet=%v) = %v, want %v", tc.level, tc.quiet, got, logger.ParseLevel(tc.want))
+			}
+		})
+	}
+}
+
 func TestExtractGlobalQuietFlag(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -487,4 +597,12 @@ func (f *fakeLoginAuthenticator) PollForAuthorization(_ context.Context, dcResp 
 	f.pollForAuthorizationCalls++
 	f.polledDeviceCode = dcResp
 	return f.pollForAuthorizationErr
+}
+
+type fakeLogoutAuthenticator struct {
+	signOutErr error
+}
+
+func (f *fakeLogoutAuthenticator) SignOut() error {
+	return f.signOutErr
 }


### PR DESCRIPTION
Adds a global `--quiet` / `-q` flag to vekil that suppresses non-error output. Errors continue to be printed.

## Changes
- Global `--quiet` / `-q` flag parsed in `main()` and routed to login, logout, and serve subcommands
- Env-helper warnings (`getEnvBool/Int/Duration`) suppressed when quiet is set
- Serve mode forces effective logger level to at least `error` when quiet
- Login/logout informational stdout suppressed when quiet; errors still emitted

## Tests
- `TestRunLoginQuietSuppressesNonErrorOutput`
- `TestExtractGlobalQuietFlag`
- `TestEffectiveServeLogLevelQuietSuppression`
- `TestRunLogoutQuietSuppressesSuccessOutput`
- `TestRunLoginQuietStillPrintsErrors`
- `TestRunLogoutQuietStillPrintsErrors`
- `TestRegisterServeFlagsQuietSuppressesEnvWarnings`

## Validation
- `go build ./...` ✅
- `go test ./...` ✅
- Reviewer: LGTM