### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("ReadFrom() error = %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestLoggerLevelErrorSuppressesDebugAndInfo(t *testing.T) {
+	output := captureStderr(t, func() {
+		log := New(LevelError)
+		log.Debug("debug message")
+		log.Info("info message")
+		log.Error("error message")
+	})
+
+	if strings.Contains(output, `"level":"debug"`) {
+		t.Fatalf("output should not contain debug logs, got %q", output)
+	}
+	if strings.Contains(output, `"level":"info"`) {
+		t.Fatalf("output should not contain info logs, got %q", output)
+	}
+	if !strings.Contains(output, `"level":"error"`) {
+		t.Fatalf("output should contain error logs, got %q", output)
+	}
+}
+
+func TestLoggerLevelErrorStillEmitsFatal(t *testing.T) {
+	output := captureStderr(t, func() {
+		log := New(LevelError)
+		log.log(LevelFatal, "fatal message", nil)
+	})
+
+	if !strings.Contains(output, `"level":"fatal"`) {
+		t.Fatalf("output should contain fatal logs, got %q", output)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", getEnvBool("QUIET", false), "Suppress non-error logs"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -282,11 +284,18 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+func (f serveFlags) loggerLevel() logger.Level {
+	if *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.loggerLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,45 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsQuietDefaultsToFalse(t *testing.T) {
+	serve := parseServeFlagsForTest(t)
+	if *serve.quiet {
+		t.Fatal("quiet should default to false")
+	}
+	if got := serve.loggerLevel(); got != logger.LevelInfo {
+		t.Fatalf("loggerLevel() = %v, want %v", got, logger.LevelInfo)
+	}
+}
+
+func TestServeFlagsQuietFromEnv(t *testing.T) {
+	t.Setenv("QUIET", "true")
+	serve := parseServeFlagsForTest(t)
+	if !*serve.quiet {
+		t.Fatal("QUIET=true should set quiet mode")
+	}
+	if got := serve.loggerLevel(); got != logger.LevelError {
+		t.Fatalf("loggerLevel() = %v, want %v", got, logger.LevelError)
+	}
+}
+
+func TestServeFlagsQuietCLIOverridesEnv(t *testing.T) {
+	t.Setenv("QUIET", "true")
+	serve := parseServeFlagsForTest(t, "--quiet=false", "--log-level=debug")
+	if *serve.quiet {
+		t.Fatal("--quiet=false should override QUIET=true")
+	}
+	if got := serve.loggerLevel(); got != logger.LevelDebug {
+		t.Fatalf("loggerLevel() = %v, want %v", got, logger.LevelDebug)
+	}
+}
+
+func TestServeFlagsQuietOverridesExplicitLogLevel(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet", "--log-level=debug")
+	if got := serve.loggerLevel(); got != logger.LevelError {
+		t.Fatalf("loggerLevel() = %v, want %v", got, logger.LevelError)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds a `--quiet` flag to vekil that suppresses non-error output when set, enabling a cleaner startup experience for production deployments.

## Changes
- **main.go**: Added `--quiet` flag (with `QUIET` env var support) that sets logger level to `LevelError` when enabled
- **main.go**: New `loggerLevel()` method ensures quiet mode overrides explicit `--log-level` settings  
- **main_test.go**: Four new tests verifying quiet flag behavior:
  - Default quiet=false
  - QUIET env var support
  - CLI flag override precedence
  - Quiet override of explicit log level
- **logger/logger_test.go**: Two new tests verifying error-level logging filters debug/info correctly

## Testing
- All existing tests pass: `go test ./...`
- All new tests pass (4 flag tests + 2 logger tests)
- Build succeeds: `go build ./...`

## Usage
```bash
# Enable quiet mode via CLI flag
vekil --quiet

# Or via environment variable
QUIET=true vekil

# Quiet mode suppresses Debug/Info but still shows Error/Fatal output
```

Fixes the request to add a --quiet flag that suppresses non-error output when set, with comprehensive test coverage.