### PR TITLE
feat(cli): add --quiet/-q flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,8 +204,8 @@ func runLoginWithDeps(args []string, deps loginDeps, global globalOptions) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(nonErrorOutput, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(nonErrorOutput, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
 		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
@@ -258,24 +258,59 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 }
 
 func runLogout(args []string, global globalOptions) {
+	if code := runLogoutWithDeps(args, logoutDeps{
+		stderr: os.Stderr,
+		newAuthenticator: func(tokenDir string) (logoutAuthenticator, error) {
+			return auth.NewAuthenticator(tokenDir)
+		},
+	}, global); code != 0 {
+		os.Exit(code)
+	}
+}
+
+type logoutAuthenticator interface {
+	SignOut() error
+}
+
+type logoutDeps struct {
+	stderr           io.Writer
+	newAuthenticator func(string) (logoutAuthenticator, error)
+}
+
+func runLogoutWithDeps(args []string, deps logoutDeps, global globalOptions) int {
+	deps = normalizeLogoutDeps(deps)
+
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
 	fs.Parse(args) //nolint:errcheck
 
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
+	authenticator, err := deps.newAuthenticator(*tokenDir)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
 	if err := authenticator.SignOut(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		return 1
 	}
 
 	if !global.quiet {
-		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+		_, _ = fmt.Fprintln(deps.stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 	}
+	return 0
+}
+
+func normalizeLogoutDeps(deps logoutDeps) logoutDeps {
+	if deps.stderr == nil {
+		deps.stderr = io.Discard
+	}
+	if deps.newAuthenticator == nil {
+		deps.newAuthenticator = func(tokenDir string) (logoutAuthenticator, error) {
+			return auth.NewAuthenticator(tokenDir)
+		}
+	}
+	return deps
 }
 
 type serveFlags struct {
@@ -355,10 +390,7 @@ func runServe(args []string, global globalOptions) {
 	serve := registerServeFlags(fs)
 	fs.Parse(args) //nolint:errcheck
 
-	logLevel := logger.ParseLevel(*serve.logLevel)
-	if global.quiet && logLevel < logger.LevelError {
-		logLevel = logger.LevelError
-	}
+	logLevel := resolveServeLogLevel(*serve.logLevel, global.quiet)
 	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
@@ -413,6 +445,14 @@ func runServe(args []string, global globalOptions) {
 		log.Fatal("shutdown error", logger.Err(err))
 	}
 	log.Info("server stopped")
+}
+
+func resolveServeLogLevel(logLevel string, quiet bool) logger.Level {
+	parsed := logger.ParseLevel(logLevel)
+	if quiet && parsed < logger.LevelError {
+		return logger.LevelError
+	}
+	return parsed
 }
 
 func getEnv(key, fallback string) string {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -26,18 +27,28 @@ const (
 	cliCommandLogout
 )
 
+type globalOptions struct {
+	quiet bool
+}
+
 func main() {
+	global, args, err := parseGlobalOptions(os.Args, os.Stderr)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch commandFromArgs(args) {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(args[2:], global)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(args[2:], global)
 		return
 	}
 
-	runServe()
+	runServe(args[1:], global)
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -53,6 +64,57 @@ func commandFromArgs(args []string) cliCommand {
 	default:
 		return cliCommandServe
 	}
+}
+
+func parseGlobalOptions(args []string, stderr io.Writer) (globalOptions, []string, error) {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	opts := globalOptions{}
+	if len(args) == 0 {
+		return opts, args, nil
+	}
+
+	remaining := make([]string, 0, len(args))
+	remaining = append(remaining, args[0])
+
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "-q", "--quiet", "-quiet":
+			opts.quiet = true
+			continue
+		case "--":
+			remaining = append(remaining, args[i:]...)
+			return opts, remaining, nil
+		}
+
+		if consumed, value, err := parseQuietAssignment(arg); consumed {
+			if err != nil {
+				return opts, nil, err
+			}
+			opts.quiet = value
+			continue
+		}
+
+		remaining = append(remaining, arg)
+	}
+
+	return opts, remaining, nil
+}
+
+func parseQuietAssignment(arg string) (bool, bool, error) {
+	for _, prefix := range []string{"--quiet=", "-quiet=", "-q="} {
+		if strings.HasPrefix(arg, prefix) {
+			value, err := strconv.ParseBool(strings.TrimPrefix(arg, prefix))
+			if err != nil {
+				return true, false, fmt.Errorf("invalid value for %s: %w", strings.TrimSuffix(prefix, "="), err)
+			}
+			return true, value, nil
+		}
+	}
+	return false, false, nil
 }
 
 type loginOptions struct {
@@ -76,8 +138,8 @@ type loginDeps struct {
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, global globalOptions) {
+	if code := runLoginWithDeps(args, defaultLoginDeps(), global); code != 0 {
 		os.Exit(code)
 	}
 }
@@ -92,8 +154,12 @@ func defaultLoginDeps() loginDeps {
 	}
 }
 
-func runLoginWithDeps(args []string, deps loginDeps) int {
+func runLoginWithDeps(args []string, deps loginDeps, global globalOptions) int {
 	deps = normalizeLoginDeps(deps)
+	nonErrorOutput := deps.stderr
+	if global.quiet {
+		nonErrorOutput = io.Discard
+	}
 
 	opts, err := parseLoginOptions(args, deps.stderr)
 	if err != nil {
@@ -118,13 +184,13 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(nonErrorOutput, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(nonErrorOutput, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,8 +204,8 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(nonErrorOutput, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(nonErrorOutput, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
 		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
@@ -150,7 +216,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(nonErrorOutput, "Login successful.")
 	return 0
 }
 
@@ -191,7 +257,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	return opts, nil
 }
 
-func runLogout(args []string) {
+func runLogout(args []string, global globalOptions) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
 	fs.Parse(args) //nolint:errcheck
@@ -207,7 +273,9 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !global.quiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
@@ -282,11 +350,16 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string, global globalOptions) {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	serve := registerServeFlags(fs)
+	fs.Parse(args) //nolint:errcheck
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if global.quiet && logLevel < logger.LevelError {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type globalOptions struct {
 }
 
 func main() {
-	global, args, err := parseGlobalOptions(os.Args, os.Stderr)
+	global, args, err := parseGlobalOptions(os.Args)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
@@ -66,11 +66,7 @@ func commandFromArgs(args []string) cliCommand {
 	}
 }
 
-func parseGlobalOptions(args []string, stderr io.Writer) (globalOptions, []string, error) {
-	if stderr == nil {
-		stderr = io.Discard
-	}
-
+func parseGlobalOptions(args []string) (globalOptions, []string, error) {
 	opts := globalOptions{}
 	if len(args) == 0 {
 		return opts, args, nil

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -444,6 +445,126 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 	}
 }
 
+func TestRunLoginQuietStillShowsInteractiveDeviceCodePrompt(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{
+		refreshErr: auth.ErrNotAuthenticated,
+		deviceCodeResponse: &auth.DeviceCodeResponse{
+			DeviceCode:      "device-code",
+			UserCode:        "ABCD-EFGH",
+			VerificationURI: "https://github.com/login/device",
+			Interval:        1,
+		},
+	}
+
+	code := runLoginWithDeps(nil, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+		openURL: func(string) error {
+			return fmt.Errorf("no browser")
+		},
+	}, globalOptions{quiet: true})
+
+	if code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+	}
+	output := stderr.String()
+	for _, want := range []string{
+		"Opening browser to https://github.com/login/device",
+		"Enter code: ABCD-EFGH",
+		"Could not open browser automatically, please visit the URL above.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("stderr missing %q, got %q", want, output)
+		}
+	}
+	if strings.Contains(output, "Login successful.") {
+		t.Fatalf("expected quiet mode to suppress success message, got %q", output)
+	}
+}
+
+func TestRunLogoutQuietSuppressesNonErrorOutput(t *testing.T) {
+	t.Run("success quiet has no output", func(t *testing.T) {
+		var stderr bytes.Buffer
+		fake := &fakeLogoutAuthenticator{}
+
+		code := runLogoutWithDeps(nil, logoutDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (logoutAuthenticator, error) {
+				return fake, nil
+			},
+		}, globalOptions{quiet: true})
+
+		if code != 0 {
+			t.Fatalf("runLogoutWithDeps() code = %d, want 0", code)
+		}
+		if fake.signOutCalls != 1 {
+			t.Fatalf("SignOut calls = %d, want 1", fake.signOutCalls)
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("expected quiet logout output to be empty, got %q", got)
+		}
+	})
+
+	t.Run("failure still prints errors", func(t *testing.T) {
+		var stderr bytes.Buffer
+		fake := &fakeLogoutAuthenticator{signOutErr: fmt.Errorf("boom")}
+
+		code := runLogoutWithDeps(nil, logoutDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (logoutAuthenticator, error) {
+				return fake, nil
+			},
+		}, globalOptions{quiet: true})
+
+		if code != 1 {
+			t.Fatalf("runLogoutWithDeps() code = %d, want 1", code)
+		}
+		if !strings.Contains(stderr.String(), "error: boom") {
+			t.Fatalf("expected quiet logout to keep error output, got %q", stderr.String())
+		}
+	})
+}
+
+func TestRunServeQuietClampsLogLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel string
+		quiet    bool
+		want     logger.Level
+	}{
+		{
+			name:     "quiet clamps info to error",
+			logLevel: "info",
+			quiet:    true,
+			want:     logger.LevelError,
+		},
+		{
+			name:     "quiet keeps error",
+			logLevel: "error",
+			quiet:    true,
+			want:     logger.LevelError,
+		},
+		{
+			name:     "non quiet preserves default info",
+			logLevel: "info",
+			quiet:    false,
+			want:     logger.LevelInfo,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveServeLogLevel(tc.logLevel, tc.quiet)
+			if got != tc.want {
+				t.Fatalf("resolveServeLogLevel(%q, %v) = %v, want %v", tc.logLevel, tc.quiet, got, tc.want)
+			}
+		})
+	}
+}
+
 type fakeLoginAuthenticator struct {
 	signInWithGitHubCLICalls int
 	signInWithGitHubCLIErr   error
@@ -459,6 +580,16 @@ type fakeLoginAuthenticator struct {
 	pollForAuthorizationCalls int
 	polledDeviceCode          *auth.DeviceCodeResponse
 	pollForAuthorizationErr   error
+}
+
+type fakeLogoutAuthenticator struct {
+	signOutCalls int
+	signOutErr   error
+}
+
+func (f *fakeLogoutAuthenticator) SignOut() error {
+	f.signOutCalls++
+	return f.signOutErr
 }
 
 func (f *fakeLoginAuthenticator) SignInWithGitHubCLI(context.Context) error {

--- a/main_test.go
+++ b/main_test.go
@@ -255,7 +255,7 @@ func TestParseGlobalOptionsQuiet(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			opts, gotArgs, err := parseGlobalOptions(tc.args, io.Discard)
+			opts, gotArgs, err := parseGlobalOptions(tc.args)
 			if err != nil {
 				t.Fatalf("parseGlobalOptions() error = %v", err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -225,6 +225,49 @@ func TestCommandFromArgs(t *testing.T) {
 	}
 }
 
+func TestParseGlobalOptionsQuiet(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantQuiet bool
+		wantArgs  []string
+	}{
+		{
+			name:      "quiet before subcommand",
+			args:      []string{"vekil", "--quiet", "login"},
+			wantQuiet: true,
+			wantArgs:  []string{"vekil", "login"},
+		},
+		{
+			name:      "quiet after subcommand",
+			args:      []string{"vekil", "login", "-q"},
+			wantQuiet: true,
+			wantArgs:  []string{"vekil", "login"},
+		},
+		{
+			name:      "quiet explicit false",
+			args:      []string{"vekil", "--quiet=false", "login"},
+			wantQuiet: false,
+			wantArgs:  []string{"vekil", "login"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, gotArgs, err := parseGlobalOptions(tc.args, io.Discard)
+			if err != nil {
+				t.Fatalf("parseGlobalOptions() error = %v", err)
+			}
+			if opts.quiet != tc.wantQuiet {
+				t.Fatalf("quiet = %v, want %v", opts.quiet, tc.wantQuiet)
+			}
+			if strings.Join(gotArgs, "|") != strings.Join(tc.wantArgs, "|") {
+				t.Fatalf("args = %v, want %v", gotArgs, tc.wantArgs)
+			}
+		})
+	}
+}
+
 func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	for _, helpArg := range []string{"-h", "--help"} {
 		t.Run(helpArg, func(t *testing.T) {
@@ -237,7 +280,7 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 					constructed = true
 					return &fakeLoginAuthenticator{}, nil
 				},
-			})
+			}, globalOptions{})
 
 			if code != 0 {
 				t.Fatalf("runLoginWithDeps(%q) code = %d, want 0", helpArg, code)
@@ -266,7 +309,7 @@ func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
 			constructed = true
 			return &fakeLoginAuthenticator{}, nil
 		},
-	})
+	}, globalOptions{})
 
 	if code != 2 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 2", code)
@@ -290,7 +333,7 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 			gotTokenDir = tokenDir
 			return fake, nil
 		},
-	})
+	}, globalOptions{})
 
 	if code != 0 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
@@ -306,6 +349,49 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "Login successful.") {
 		t.Fatalf("stderr missing success message, got %q", got)
+	}
+}
+
+func TestRunLoginQuietSuppressesNonErrorOutput(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{}
+
+	code := runLoginWithDeps([]string{"--gh"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	}, globalOptions{quiet: true})
+
+	if code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+	}
+	if fake.signInWithGitHubCLICalls != 1 {
+		t.Fatalf("SignInWithGitHubCLI calls = %d, want 1", fake.signInWithGitHubCLICalls)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("expected quiet login output to be empty, got %q", got)
+	}
+}
+
+func TestRunLoginQuietStillShowsErrors(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{
+		signInWithGitHubCLIErr: fmt.Errorf("boom"),
+	}
+
+	code := runLoginWithDeps([]string{"--gh"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	}, globalOptions{quiet: true})
+
+	if code != 1 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "error signing in with GitHub CLI: boom") {
+		t.Fatalf("expected quiet login to keep error output, got %q", stderr.String())
 	}
 }
 
@@ -330,7 +416,7 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 			openedURL = url
 			return nil
 		},
-	})
+	}, globalOptions{})
 
 	if code != 0 {
 		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())


### PR DESCRIPTION
## Summary

Adds a global `--quiet` / `-q` flag to the vekil CLI that suppresses non-error output while preserving errors and required interactive prompts.

## Changes

- New `globalOptions{quiet}` parsed in `main.go` via `parseGlobalOptions` (supports `--quiet`, `-q`, `--quiet=false`, etc.)
- `runLogin` / `runLoginWithDeps`: suppresses informational lines like `Login successful.` and `Already logged in.` when quiet. **Device-code URL and user code are always printed** so interactive login remains usable.
- `runLogout` (refactored to `runLogoutWithDeps` for testability): suppresses success line in quiet mode; errors still printed.
- `runServe`: new `resolveServeLogLevel(level, quiet)` helper clamps the log level to at least `error` when `--quiet` is set; default behavior unchanged otherwise.

## Tests

- `TestParseGlobalOptionsQuiet`
- `TestRunLoginQuietSuppressesNonErrorOutput`
- `TestRunLoginQuietStillShowsErrors`
- `TestRunLoginQuietStillShowsInteractiveDeviceCodePrompt`
- `TestRunLogoutQuietSuppressesNonErrorOutput`
- `TestRunServeQuietClampsLogLevel`

## Validation

- `go vet ./...` ✅
- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass on golang:1.25)
- Two reviewer rounds; final reviewer verdict: **LGTM**.