### PR TITLE
Add --quiet/-q flag to suppress non-error CLI output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet`, `-q` | n/a | `false` | Suppress non-error CLI output (errors still print to stderr) |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -26,18 +27,29 @@ const (
 	cliCommandLogout
 )
 
+var envWarningWriter io.Writer = os.Stderr
+
 func main() {
+	quiet, args, err := parseGlobalFlags(os.Args)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+	if quiet {
+		envWarningWriter = io.Discard
+	}
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch commandFromArgs(args) {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(args[2:], quiet)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(args[2:], quiet)
 		return
 	}
 
-	runServe()
+	runServe(args[1:], quiet)
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -71,19 +83,25 @@ type loginAuthenticator interface {
 }
 
 type loginDeps struct {
+	stdout           io.Writer
 	stderr           io.Writer
 	newAuthenticator func(string) (loginAuthenticator, error)
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, quiet bool) {
+	deps := defaultLoginDeps()
+	if quiet {
+		deps.stdout = io.Discard
+	}
+	if code := runLoginWithDeps(args, deps); code != 0 {
 		os.Exit(code)
 	}
 }
 
 func defaultLoginDeps() loginDeps {
 	return loginDeps{
+		stdout: os.Stdout,
 		stderr: os.Stderr,
 		newAuthenticator: func(tokenDir string) (loginAuthenticator, error) {
 			return auth.NewAuthenticator(tokenDir)
@@ -95,14 +113,12 @@ func defaultLoginDeps() loginDeps {
 func runLoginWithDeps(args []string, deps loginDeps) int {
 	deps = normalizeLoginDeps(deps)
 
-	opts, err := parseLoginOptions(args, deps.stderr)
+	opts, err := parseLoginOptions(args, deps.stdout)
 	if err != nil {
 		if err == flag.ErrHelp {
 			return 0
 		}
-		if err == errConflictingLoginFlags {
-			_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
-		}
+		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
 		return 2
 	}
 
@@ -118,13 +134,13 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(deps.stdout, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(deps.stdout, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +154,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(deps.stdout, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(deps.stdout, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(deps.stdout, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,11 +166,14 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(deps.stdout, "Login successful.")
 	return 0
 }
 
 func normalizeLoginDeps(deps loginDeps) loginDeps {
+	if deps.stdout == nil {
+		deps.stdout = io.Discard
+	}
 	if deps.stderr == nil {
 		deps.stderr = io.Discard
 	}
@@ -174,6 +193,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts := loginOptions{}
 	fs := flag.NewFlagSet("login", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	registerGlobalFlags(fs)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
@@ -191,23 +211,65 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	return opts, nil
 }
 
-func runLogout(args []string) {
-	fs := flag.NewFlagSet("logout", flag.ExitOnError)
-	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
-	fs.Parse(args) //nolint:errcheck
+type logoutOptions struct {
+	tokenDir string
+}
 
-	authenticator, err := auth.NewAuthenticator(*tokenDir)
+func runLogout(args []string, quiet bool) {
+	var stdout io.Writer = os.Stdout
+	if quiet {
+		stdout = io.Discard
+	}
+	if code := runLogoutWithWriters(args, stdout, os.Stderr); code != 0 {
+		os.Exit(code)
+	}
+}
+
+func runLogoutWithWriters(args []string, stdout, stderr io.Writer) int {
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	opts, err := parseLogoutOptions(args, stdout)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		if err == flag.ErrHelp {
+			return 0
+		}
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 2
+	}
+
+	authenticator, err := auth.NewAuthenticator(opts.tokenDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
 	}
 
 	if err := authenticator.SignOut(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	_, _ = fmt.Fprintln(stdout, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	return 0
+}
+
+func parseLogoutOptions(args []string, usageOut io.Writer) (logoutOptions, error) {
+	if usageOut == nil {
+		usageOut = io.Discard
+	}
+	opts := logoutOptions{}
+	fs := flag.NewFlagSet("logout", flag.ContinueOnError)
+	fs.SetOutput(usageOut)
+	registerGlobalFlags(fs)
+	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
+	}
+	opts.tokenDir = *tokenDir
+	return opts, nil
 }
 
 type serveFlags struct {
@@ -282,11 +344,24 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string, quiet bool) {
+	fs := flag.NewFlagSet("vekil", flag.ContinueOnError)
+	fs.SetOutput(os.Stdout)
+	registerGlobalFlags(fs)
+	serve := registerServeFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if quiet && logLevel < logger.LevelError {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
@@ -356,7 +431,7 @@ func getEnvBool(key string, fallback bool) bool {
 	}
 	parsed, err := strconv.ParseBool(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter, "warning: ignoring invalid %s=%q (expected bool), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -369,7 +444,7 @@ func getEnvInt(key string, fallback int) int {
 	}
 	parsed, err := strconv.Atoi(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter, "warning: ignoring invalid %s=%q (expected integer), using default %d\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
@@ -382,8 +457,48 @@ func getEnvDuration(key string, fallback time.Duration) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
+		_, _ = fmt.Fprintf(envWarningWriter, "warning: ignoring invalid %s=%q (expected duration like 5m), using default %v\n", key, v, fallback)
 		return fallback
 	}
 	return parsed
+}
+
+func parseGlobalFlags(args []string) (bool, []string, error) {
+	if len(args) == 0 {
+		return false, nil, nil
+	}
+
+	quiet := false
+	filtered := make([]string, 0, len(args))
+	filtered = append(filtered, args[0])
+
+	for _, arg := range args[1:] {
+		switch {
+		case arg == "--quiet", arg == "-q":
+			quiet = true
+		case strings.HasPrefix(arg, "--quiet="):
+			v := strings.TrimPrefix(arg, "--quiet=")
+			parsed, err := strconv.ParseBool(v)
+			if err != nil {
+				return false, nil, fmt.Errorf("invalid boolean value %q for --quiet", v)
+			}
+			quiet = parsed
+		case strings.HasPrefix(arg, "-q="):
+			v := strings.TrimPrefix(arg, "-q=")
+			parsed, err := strconv.ParseBool(v)
+			if err != nil {
+				return false, nil, fmt.Errorf("invalid boolean value %q for -q", v)
+			}
+			quiet = parsed
+		default:
+			filtered = append(filtered, arg)
+		}
+	}
+
+	return quiet, filtered, nil
+}
+
+func registerGlobalFlags(fs *flag.FlagSet) {
+	fs.Bool("quiet", false, "Suppress non-error CLI output")
+	fs.Bool("q", false, "Alias for --quiet")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -100,16 +100,18 @@ func TestGetEnvInt(t *testing.T) {
 func TestGetEnvWarnsOnInvalidValue(t *testing.T) {
 	const envKey = "TEST_WARN_VAR"
 
-	// Capture stderr to verify warning is emitted.
-	old := os.Stderr
+	// Capture warning writer to verify warning is emitted.
+	oldWarningWriter := envWarningWriter
+	defer func() {
+		envWarningWriter = oldWarningWriter
+	}()
 	r, w, _ := os.Pipe()
-	os.Stderr = w
+	envWarningWriter = w
 
 	t.Setenv(envKey, "not-a-bool")
 	getEnvBool(envKey, false)
 
 	_ = w.Close()
-	os.Stderr = old
 
 	var buf bytes.Buffer
 	_, _ = buf.ReadFrom(r)
@@ -228,10 +230,12 @@ func TestCommandFromArgs(t *testing.T) {
 func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	for _, helpArg := range []string{"-h", "--help"} {
 		t.Run(helpArg, func(t *testing.T) {
+			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 			constructed := false
 
 			code := runLoginWithDeps([]string{helpArg}, loginDeps{
+				stdout: &stdout,
 				stderr: &stderr,
 				newAuthenticator: func(string) (loginAuthenticator, error) {
 					constructed = true
@@ -246,7 +250,7 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 				t.Fatalf("help constructed an authenticator")
 			}
 
-			output := stderr.String()
+			output := stdout.String()
 			for _, want := range []string{"github-cli", "gh", "force"} {
 				if !strings.Contains(output, want) {
 					t.Fatalf("help output missing %q:\n%s", want, output)
@@ -257,10 +261,12 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 }
 
 func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
+	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	constructed := false
 
 	code := runLoginWithDeps([]string{"--github-cli", "--force"}, loginDeps{
+		stdout: &stdout,
 		stderr: &stderr,
 		newAuthenticator: func(string) (loginAuthenticator, error) {
 			constructed = true
@@ -280,11 +286,13 @@ func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {
 }
 
 func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
+	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	fake := &fakeLoginAuthenticator{}
 	var gotTokenDir string
 
 	code := runLoginWithDeps([]string{"--gh", "--token-dir", "/tmp/vekil-test-tokens"}, loginDeps{
+		stdout: &stdout,
 		stderr: &stderr,
 		newAuthenticator: func(tokenDir string) (loginAuthenticator, error) {
 			gotTokenDir = tokenDir
@@ -304,12 +312,13 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	if fake.refreshCalls != 0 || fake.requestDeviceCodeCalls != 0 || fake.pollForAuthorizationCalls != 0 {
 		t.Fatalf("unexpected auth flow calls: refresh=%d request=%d poll=%d", fake.refreshCalls, fake.requestDeviceCodeCalls, fake.pollForAuthorizationCalls)
 	}
-	if got := stderr.String(); !strings.Contains(got, "Login successful.") {
-		t.Fatalf("stderr missing success message, got %q", got)
+	if got := stdout.String(); !strings.Contains(got, "Login successful.") {
+		t.Fatalf("stdout missing success message, got %q", got)
 	}
 }
 
 func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
+	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	fake := &fakeLoginAuthenticator{
 		deviceCodeResponse: &auth.DeviceCodeResponse{
@@ -322,6 +331,7 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 	var openedURL string
 
 	code := runLoginWithDeps([]string{"--force"}, loginDeps{
+		stdout: &stdout,
 		stderr: &stderr,
 		newAuthenticator: func(string) (loginAuthenticator, error) {
 			return fake, nil
@@ -350,11 +360,73 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 	if openedURL != fake.deviceCodeResponse.VerificationURI {
 		t.Fatalf("opened URL = %q, want %q", openedURL, fake.deviceCodeResponse.VerificationURI)
 	}
-	output := stderr.String()
+	output := stdout.String()
 	for _, want := range []string{"Opening browser to https://github.com/login/device", "Enter code: ABCD-EFGH", "Login successful."} {
 		if !strings.Contains(output, want) {
-			t.Fatalf("stderr missing %q, got %q", want, output)
+			t.Fatalf("stdout missing %q, got %q", want, output)
 		}
+	}
+}
+
+func TestParseGlobalFlags(t *testing.T) {
+	quiet, filtered, err := parseGlobalFlags([]string{"vekil", "--quiet", "login", "--gh"})
+	if err != nil {
+		t.Fatalf("parseGlobalFlags() error = %v", err)
+	}
+	if !quiet {
+		t.Fatal("quiet should be enabled")
+	}
+	got := strings.Join(filtered, " ")
+	want := "vekil login --gh"
+	if got != want {
+		t.Fatalf("filtered args = %q, want %q", got, want)
+	}
+}
+
+func TestQuietSuppressesLoginStdout(t *testing.T) {
+	fake := &fakeLoginAuthenticator{}
+	makeDeps := func(stdout io.Writer) loginDeps {
+		return loginDeps{
+			stdout: stdout,
+			stderr: io.Discard,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return fake, nil
+			},
+		}
+	}
+
+	quiet, filtered, err := parseGlobalFlags([]string{"vekil", "login", "--gh"})
+	if err != nil {
+		t.Fatalf("parseGlobalFlags() error = %v", err)
+	}
+	if quiet {
+		t.Fatal("quiet should be disabled")
+	}
+	var normalOut bytes.Buffer
+	if code := runLoginWithDeps(filtered[2:], makeDeps(&normalOut)); code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+	}
+	if normalOut.Len() == 0 {
+		t.Fatal("expected stdout output without --quiet")
+	}
+
+	quiet, filtered, err = parseGlobalFlags([]string{"vekil", "--quiet", "login", "--gh"})
+	if err != nil {
+		t.Fatalf("parseGlobalFlags() error = %v", err)
+	}
+	if !quiet {
+		t.Fatal("quiet should be enabled")
+	}
+	var quietOut bytes.Buffer
+	deps := makeDeps(&quietOut)
+	if quiet {
+		deps.stdout = io.Discard
+	}
+	if code := runLoginWithDeps(filtered[2:], deps); code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0", code)
+	}
+	if quietOut.Len() != 0 {
+		t.Fatalf("expected no stdout output with --quiet, got %q", quietOut.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a global `--quiet` / `-q` flag to the `vekil` CLI that suppresses non-error stdout output. Errors continue to go to stderr.

## Changes

- **`main.go`**: Added `parseGlobalFlags` that strips `--quiet`/`-q` (and `=value` forms) from argv and returns the quiet mode. Threaded the flag through `runLogin`, `runLogout`, and `runServe`:
  - Login/logout: normal informational output goes to stdout; in quiet mode the writer becomes `io.Discard`. Errors still go to stderr.
  - Serve: logger level forced to at least `error` when quiet.
  - Env-parse warnings: writable `envWarningWriter` that becomes `io.Discard` in quiet mode.
- **`main_test.go`**: Added `TestParseGlobalFlags` and `TestQuietSuppressesLoginStdout`; updated existing login tests to reflect stdout vs stderr split.
- **`docs/configuration.md`**: Documented the new flag.

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (golang:1.25)

## Reviews

- Security review: APPROVED
- Quality review: APPROVED