### PR TITLE
Add minimal /metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+const metricsContentType = "text/plain; version=0.0.4; charset=utf-8"
+
+type httpMetrics struct {
+	requestsTotal atomic.Uint64
+	inFlight      atomic.Int64
+}
+
+func (m *httpMetrics) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.requestsTotal.Add(1)
+		m.inFlight.Add(1)
+		defer m.inFlight.Add(-1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *httpMetrics) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", metricsContentType)
+		_, _ = fmt.Fprintf(w, `# HELP vekil_http_requests_total Total HTTP requests handled by the Vekil server.
+# TYPE vekil_http_requests_total counter
+vekil_http_requests_total %d
+# HELP vekil_http_in_flight_requests Current in-flight HTTP requests handled by the Vekil server.
+# TYPE vekil_http_in_flight_requests gauge
+vekil_http_in_flight_requests %d
+`, m.requestsTotal.Load(), m.inFlight.Load())
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -86,20 +86,26 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	metrics := &httpMetrics{}
+
+	appMux := http.NewServeMux()
+	appMux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
+	appMux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
+	appMux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
+	appMux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
+	appMux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
+	appMux.HandleFunc("POST /models/", handler.HandleGeminiModels)
+	appMux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
+	appMux.HandleFunc("POST /v1/responses", handler.HandleResponses)
+	appMux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
+	appMux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
+	appMux.HandleFunc("GET /healthz", handler.HandleHealthz)
+	appMux.HandleFunc("GET /readyz", handler.HandleReadyz)
+	appMux.HandleFunc("GET /v1/models", handler.HandleModels)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
-	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
-	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
-	mux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
-	mux.HandleFunc("POST /v1/responses", handler.HandleResponses)
-	mux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
-	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
-	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
-	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
-	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.Handle("GET /metrics", metrics.handler())
+	mux.Handle("/", metrics.middleware(appMux))
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +97,54 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestNew_ExposesMetricsEndpoint(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	ts := httptest.NewServer(srv.httpServer.Handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close /healthz body: %v", err)
+	}
+
+	resp, err = http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /metrics body: %v", err)
+	}
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := resp.Header.Get("Content-Type"), metricsContentType; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+
+	text := string(body)
+	if !strings.Contains(text, "vekil_http_requests_total 1") {
+		t.Fatalf("expected request counter in metrics body, got %q", text)
+	}
+	if !strings.Contains(text, "vekil_http_in_flight_requests 0") {
+		t.Fatalf("expected in-flight gauge in metrics body, got %q", text)
 	}
 }


### PR DESCRIPTION
## Summary
- mount a lightweight `/metrics` endpoint on the existing HTTP server
- track one total request counter and one in-flight gauge around application routes
- add a focused server test covering the metrics response

## Testing
- `/tmp/goroot/go/bin/go test ./server -run TestNew_ExposesMetricsEndpoint -count=1`