### PR TITLE
Add minimal /metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+const (
+	requestsMetricName = "vekil_http_requests_total"
+	inflightMetricName = "vekil_http_in_flight_requests"
+)
+
+type metrics struct {
+	requests atomic.Uint64
+	inflight atomic.Int64
+}
+
+func newMetrics() *metrics {
+	return &metrics{}
+}
+
+func (m *metrics) instrument(next http.Handler) http.Handler {
+	if m == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		m.requests.Add(1)
+		m.inflight.Add(1)
+		defer m.inflight.Add(-1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handle(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	_, _ = fmt.Fprintf(w, "# HELP %s Total HTTP requests handled by Vekil.\n", requestsMetricName)
+	_, _ = fmt.Fprintf(w, "# TYPE %s counter\n", requestsMetricName)
+	_, _ = fmt.Fprintf(w, "%s %d\n", requestsMetricName, m.requests.Load())
+	_, _ = fmt.Fprintf(w, "# HELP %s Current in-flight HTTP requests.\n", inflightMetricName)
+	_, _ = fmt.Fprintf(w, "# TYPE %s gauge\n", inflightMetricName)
+	_, _ = fmt.Fprintf(w, "%s %d\n", inflightMetricName, m.inflight.Load())
+}

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMetricsHandlerReportsRequestsAndInflight(t *testing.T) {
+	metrics := newMetrics()
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /slow", func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("GET /metrics", metrics.handle)
+
+	handler := metrics.instrument(mux)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/slow", nil))
+	}()
+
+	<-started
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	body := rr.Body.String()
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := rr.Header().Get("Content-Type"), "text/plain; version=0.0.4; charset=utf-8"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	if !strings.Contains(body, requestsMetricName+" 1") {
+		t.Fatalf("expected request counter in metrics output, got %q", body)
+	}
+	if !strings.Contains(body, inflightMetricName+" 1") {
+		t.Fatalf("expected in-flight gauge while request is active, got %q", body)
+	}
+
+	close(release)
+	<-done
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if body := rr.Body.String(); !strings.Contains(body, inflightMetricName+" 0") {
+		t.Fatalf("expected in-flight gauge to return to zero, got %q", body)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -87,6 +87,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	}
 
 	mux := http.NewServeMux()
+	metrics := newMetrics()
 	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
 	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
@@ -100,12 +101,13 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.HandleFunc("GET /metrics", metrics.handle)
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.instrument(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,


### PR DESCRIPTION
## Summary
- mount a minimal `GET /metrics` endpoint on the existing HTTP server
- add one request counter and one in-flight gauge via lightweight server middleware
- add a focused server metrics test covering both the counter and in-flight gauge behavior

## Validation
- `git diff --check`
- Attempted: `go test ./server -run TestMetricsHandlerReportsRequestsAndInflight -count=1` *(blocked in this sandbox because the local Go runtime crashes before tests start)*