### PR TITLE
Add basic /metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type metrics struct {
+	requestsTotal    atomic.Int64
+	requestsInFlight atomic.Int64
+}
+
+func (m *metrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.requestsTotal.Add(1)
+		m.requestsInFlight.Add(1)
+		defer m.requestsInFlight.Add(-1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(
+		w,
+		"# HELP vekil_http_requests_total Total HTTP requests served.\n"+
+			"# TYPE vekil_http_requests_total counter\n"+
+			"vekil_http_requests_total %d\n"+
+			"# HELP vekil_http_requests_in_flight Current in-flight HTTP requests.\n"+
+			"# TYPE vekil_http_requests_in_flight gauge\n"+
+			"vekil_http_requests_in_flight %d\n",
+		m.requestsTotal.Load(),
+		m.requestsInFlight.Load(),
+	)
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -21,17 +22,15 @@ func (m *metrics) instrument(next http.Handler) http.Handler {
 	})
 }
 
-func (m *metrics) handleMetrics(w http.ResponseWriter, r *http.Request) {
+func (m *metrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = fmt.Fprintf(
+	_, _ = io.WriteString(
 		w,
 		"# HELP vekil_http_requests_total Total HTTP requests served.\n"+
 			"# TYPE vekil_http_requests_total counter\n"+
-			"vekil_http_requests_total %d\n"+
+			"vekil_http_requests_total "+strconv.FormatInt(m.requestsTotal.Load(), 10)+"\n"+
 			"# HELP vekil_http_requests_in_flight Current in-flight HTTP requests.\n"+
 			"# TYPE vekil_http_requests_in_flight gauge\n"+
-			"vekil_http_requests_in_flight %d\n",
-		m.requestsTotal.Load(),
-		m.requestsInFlight.Load(),
+			"vekil_http_requests_in_flight "+strconv.FormatInt(m.requestsInFlight.Load(), 10)+"\n",
 	)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -86,7 +86,9 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	metrics := &metrics{}
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /metrics", metrics.handleMetrics)
 	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
 	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
@@ -105,7 +107,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.instrument(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +96,40 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestNew_MountsMetricsEndpoint(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthzReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	healthzRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthzRec, healthzReq)
+	if healthzRec.Code != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", healthzRec.Code, http.StatusOK)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "vekil_http_requests_total 2") {
+		t.Fatalf("expected request counter in metrics body, got %q", body)
+	}
+	if !strings.Contains(body, "vekil_http_requests_in_flight 1") {
+		t.Fatalf("expected in-flight gauge in metrics body, got %q", body)
 	}
 }


### PR DESCRIPTION
## Summary
- mount a minimal \/metrics endpoint on the existing HTTP server
- track one total request counter and one in-flight gauge via lightweight server instrumentation
- add a focused server test covering the metrics output

## Testing
- GOROOT=/tmp/go1.26.4/go PATH=/tmp/go1.26.4/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games /tmp/go1.26.4/go/bin/go test ./server -run TestNew_MountsMetricsEndpoint -count=1