### PR TITLE
fix(security): Release path embeds Sparkle from an unverified network download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,11 @@ APP_CGO_LDFLAGS = -F$(abspath $(SPARKLE_UNPACK_DIR)) -Wl,-rpath,@executable_path
 SPARKLE_VERSION := 2.9.0
 SPARKLE_BUILD_DIR := .build/sparkle
 SPARKLE_ARCHIVE := $(SPARKLE_BUILD_DIR)/Sparkle-$(SPARKLE_VERSION).tar.xz
+SPARKLE_ARCHIVE_OK := $(SPARKLE_ARCHIVE).sha256-ok
 SPARKLE_UNPACK_DIR := $(SPARKLE_BUILD_DIR)/unpacked
 SPARKLE_FRAMEWORK := $(SPARKLE_UNPACK_DIR)/Sparkle.framework
 SPARKLE_DOWNLOAD_URL := https://github.com/sparkle-project/Sparkle/releases/download/$(SPARKLE_VERSION)/Sparkle-$(SPARKLE_VERSION).tar.xz
+SPARKLE_SHA256 := 01e0f0ebf6614061ea816d414de50f937d64ffa6822ad572243031ca3676fe19
 SPARKLE_FEED_URL ?= https://github.com/sozercan/vekil/releases/latest/download/appcast.xml
 SPARKLE_PUBLIC_ED_KEY ?=
 
@@ -24,7 +26,11 @@ $(SPARKLE_ARCHIVE):
 	@mkdir -p "$(SPARKLE_BUILD_DIR)"
 	curl -fL "$(SPARKLE_DOWNLOAD_URL)" -o "$(SPARKLE_ARCHIVE)"
 
-$(SPARKLE_FRAMEWORK): $(SPARKLE_ARCHIVE)
+$(SPARKLE_ARCHIVE_OK): $(SPARKLE_ARCHIVE)
+	printf '%s  %s\n' "$(SPARKLE_SHA256)" "$(SPARKLE_ARCHIVE)" | shasum -a 256 -c -
+	@touch "$(SPARKLE_ARCHIVE_OK)"
+
+$(SPARKLE_FRAMEWORK): $(SPARKLE_ARCHIVE_OK)
 	@rm -rf "$(SPARKLE_UNPACK_DIR)"
 	@mkdir -p "$(SPARKLE_UNPACK_DIR)"
 	tar -xf "$(SPARKLE_ARCHIVE)" -C "$(SPARKLE_UNPACK_DIR)"


### PR DESCRIPTION
Security remediation for finding `fnd_56974b8ed3ed`.

Summary:
The macOS app build path downloads Sparkle directly from GitHub at build time and immediately unpacks and links it into the shipped app, but no checksum or signature verification is performed before release publishing. If that download is tampered with, the release workflow can publish a trojaned updater framework inside the official macOS artifact.

Root cause:
The build process trusts a mutable network fetch for a security-sensitive framework without verifying artifact authenticity or integrity before packaging and release upload.

Remediation guidance:
Pin Sparkle to a verified checksum or signature, fail the build on mismatch, and preferably vendor the trusted artifact or verify the upstream release signature before extraction.
