### PR TITLE
Add minimal /metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type httpMetrics struct {
+	requestsTotal atomic.Uint64
+	inFlight      atomic.Int64
+}
+
+func (m *httpMetrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		m.requestsTotal.Add(1)
+		m.inFlight.Add(1)
+		defer m.inFlight.Add(-1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *httpMetrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w,
+		"# HELP vekil_http_requests_total Total HTTP requests handled by the server.\n"+
+			"# TYPE vekil_http_requests_total counter\n"+
+			"vekil_http_requests_total %d\n"+
+			"# HELP vekil_http_in_flight_requests Current in-flight HTTP requests.\n"+
+			"# TYPE vekil_http_in_flight_requests gauge\n"+
+			"vekil_http_in_flight_requests %d\n",
+		m.requestsTotal.Load(),
+		m.inFlight.Load(),
+	)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -24,40 +24,6 @@ type options struct {
 	proxyOptions []proxy.Option
 }
 
-type httpMetrics struct {
-	requestsTotal atomic.Uint64
-	inFlight      atomic.Int64
-}
-
-func (m *httpMetrics) instrument(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/metrics" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		m.requestsTotal.Add(1)
-		m.inFlight.Add(1)
-		defer m.inFlight.Add(-1)
-
-		next.ServeHTTP(w, r)
-	})
-}
-
-func (m *httpMetrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = fmt.Fprintf(w,
-		"# HELP vekil_http_requests_total Total HTTP requests handled by the server.\n"+
-			"# TYPE vekil_http_requests_total counter\n"+
-			"vekil_http_requests_total %d\n"+
-			"# HELP vekil_http_in_flight_requests Current in-flight HTTP requests.\n"+
-			"# TYPE vekil_http_in_flight_requests gauge\n"+
-			"vekil_http_in_flight_requests %d\n",
-		m.requestsTotal.Load(),
-		m.inFlight.Load(),
-	)
-}
-
 // Option customizes server creation.
 type Option func(*options)
 

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,40 @@ type options struct {
 	proxyOptions []proxy.Option
 }
 
+type httpMetrics struct {
+	requestsTotal atomic.Uint64
+	inFlight      atomic.Int64
+}
+
+func (m *httpMetrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		m.requestsTotal.Add(1)
+		m.inFlight.Add(1)
+		defer m.inFlight.Add(-1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *httpMetrics) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w,
+		"# HELP vekil_http_requests_total Total HTTP requests handled by the server.\n"+
+			"# TYPE vekil_http_requests_total counter\n"+
+			"vekil_http_requests_total %d\n"+
+			"# HELP vekil_http_in_flight_requests Current in-flight HTTP requests.\n"+
+			"# TYPE vekil_http_in_flight_requests gauge\n"+
+			"vekil_http_in_flight_requests %d\n",
+		m.requestsTotal.Load(),
+		m.inFlight.Load(),
+	)
+}
+
 // Option customizes server creation.
 type Option func(*options)
 
@@ -87,6 +121,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	}
 
 	mux := http.NewServeMux()
+	metrics := &httpMetrics{}
 	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
 	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
@@ -100,12 +135,13 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.HandleFunc("GET /metrics", metrics.handleMetrics)
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.instrument(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +97,47 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestMetricsEndpointTracksRequests(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	healthResp := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthResp, healthReq)
+	if healthResp.Code != http.StatusOK {
+		t.Fatalf("healthz status = %d, want %d", healthResp.Code, http.StatusOK)
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsResp := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsResp, metricsReq)
+
+	if metricsResp.Code != http.StatusOK {
+		t.Fatalf("metrics status = %d, want %d", metricsResp.Code, http.StatusOK)
+	}
+	if got := metricsResp.Header().Get("Content-Type"); got != "text/plain; version=0.0.4; charset=utf-8" {
+		t.Fatalf("metrics content type = %q, want Prometheus text format", got)
+	}
+
+	body, err := io.ReadAll(metricsResp.Result().Body)
+	if err != nil {
+		t.Fatalf("failed to read metrics body: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "vekil_http_requests_total 1\n") {
+		t.Fatalf("metrics body missing request counter:\n%s", text)
+	}
+	if !strings.Contains(text, "vekil_http_in_flight_requests 0\n") {
+		t.Fatalf("metrics body missing in-flight gauge:\n%s", text)
 	}
 }


### PR DESCRIPTION
## Summary
- mount a minimal `/metrics` endpoint on the existing HTTP server
- track a total request counter and an in-flight request gauge
- add one focused server test covering metrics output after a request

## Validation
- `git diff --check`
- Go toolchain was not available in this sandbox, so `go test` could not be run here
