### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,9 +59,31 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
+
+type cliOutput struct {
+	stderr io.Writer
+	info   io.Writer
+}
+
+func newCLIOutput(stderr io.Writer, quiet bool) cliOutput {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	info := stderr
+	if quiet {
+		info = io.Discard
+	}
+
+	return cliOutput{
+		stderr: stderr,
+		info:   info,
+	}
+}
 
 type loginAuthenticator interface {
 	SignInWithGitHubCLI(context.Context) error
@@ -106,51 +128,53 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 2
 	}
 
+	out := newCLIOutput(deps.stderr, opts.quiet)
+
 	authenticator, err := deps.newAuthenticator(opts.tokenDir)
 	if err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(out.stderr, "error: %v\n", err)
 		return 1
 	}
 
 	ctx := context.Background()
 	if opts.useGitHubCLI {
 		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
-			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
+			_, _ = fmt.Fprintf(out.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(out.info, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(out.info, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
-			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
+			_, _ = fmt.Fprintf(out.stderr, "error refreshing existing login: %v\n", err)
 			return 1
 		}
 	}
 
 	dcResp, err := authenticator.RequestDeviceCode(ctx)
 	if err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "error requesting device code: %v\n", err)
+		_, _ = fmt.Fprintf(out.stderr, "error requesting device code: %v\n", err)
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(out.info, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(out.info, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(out.info, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "error: %v\n", err)
+		_, _ = fmt.Fprintf(out.stderr, "error: %v\n", err)
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(out.info, "Login successful.")
 	return 0
 }
 
@@ -178,6 +202,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,6 +210,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
@@ -194,6 +220,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 func runLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,7 +234,8 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	out := newCLIOutput(os.Stderr, *quiet)
+	_, _ = fmt.Fprintln(out.info, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 }
 
 type serveFlags struct {
@@ -216,6 +244,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +270,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -282,11 +312,18 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+func effectiveServeLogLevel(configured logger.Level, quiet bool) logger.Level {
+	if quiet && configured < logger.LevelError {
+		return logger.LevelError
+	}
+	return configured
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(effectiveServeLogLevel(logger.ParseLevel(*serve.logLevel), *serve.quiet))
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -188,6 +189,25 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeFlagsQuietCanBeEnabled(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet")
+	if !*serve.quiet {
+		t.Fatal("--quiet should enable quiet mode")
+	}
+}
+
+func TestEffectiveServeLogLevelQuietSuppressesInfo(t *testing.T) {
+	if got := effectiveServeLogLevel(logger.ParseLevel("info"), true); got != logger.LevelError {
+		t.Fatalf("effectiveServeLogLevel(info, true) = %v, want %v", got, logger.LevelError)
+	}
+	if got := effectiveServeLogLevel(logger.ParseLevel("error"), true); got != logger.LevelError {
+		t.Fatalf("effectiveServeLogLevel(error, true) = %v, want %v", got, logger.LevelError)
+	}
+	if got := effectiveServeLogLevel(logger.ParseLevel("debug"), false); got != logger.LevelDebug {
+		t.Fatalf("effectiveServeLogLevel(debug, false) = %v, want %v", got, logger.LevelDebug)
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -247,7 +267,7 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 			}
 
 			output := stderr.String()
-			for _, want := range []string{"github-cli", "gh", "force"} {
+			for _, want := range []string{"github-cli", "gh", "force", "quiet"} {
 				if !strings.Contains(output, want) {
 					t.Fatalf("help output missing %q:\n%s", want, output)
 				}
@@ -306,6 +326,65 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "Login successful.") {
 		t.Fatalf("stderr missing success message, got %q", got)
+	}
+}
+
+func TestRunLoginQuietSuppressesInformationalOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantOutput bool
+	}{
+		{
+			name:       "default emits informational output",
+			args:       []string{"--gh"},
+			wantOutput: true,
+		},
+		{
+			name:       "quiet suppresses informational output",
+			args:       []string{"--gh", "--quiet"},
+			wantOutput: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			fake := &fakeLoginAuthenticator{}
+
+			code := runLoginWithDeps(tc.args, loginDeps{
+				stderr: &stderr,
+				newAuthenticator: func(string) (loginAuthenticator, error) {
+					return fake, nil
+				},
+			})
+
+			if code != 0 {
+				t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			gotOutput := strings.Contains(stderr.String(), "Login successful.")
+			if gotOutput != tc.wantOutput {
+				t.Fatalf("Login successful output present = %v, want %v; stderr=%q", gotOutput, tc.wantOutput, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunLoginQuietStillEmitsErrors(t *testing.T) {
+	var stderr bytes.Buffer
+
+	code := runLoginWithDeps([]string{"--gh", "--quiet"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return &fakeLoginAuthenticator{signInWithGitHubCLIErr: fmt.Errorf("boom")}, nil
+		},
+	})
+
+	if code != 1 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "error signing in with GitHub CLI: boom") {
+		t.Fatalf("stderr missing error output, got %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `--quiet` boolean flag to the vekil CLI that suppresses non-error (informational/progress) output while preserving error output and the program's primary structured behavior.

## Changes

- `main.go`
  - New `--quiet` persistent flag (default `false`) with help text `Suppress non-error output`.
  - Available on default serve mode (`vekil --quiet`), `vekil login --quiet`, and `vekil logout --quiet`.
  - Serve mode routes quiet through the existing logger by elevating the effective log level to `error` (preserves errors/fatals, suppresses info/debug). Implemented via `effectiveServeLogLevel`.
  - Login/logout use a small shared CLI output helper (`newCLIOutput`) so informational messages are discarded in quiet mode while errors continue to flow to stderr.

- `main_test.go`
  - `TestServeFlagsQuietCanBeEnabled`
  - `TestEffectiveServeLogLevelQuietSuppressesInfo`
  - `TestRunLoginQuietSuppressesInformationalOutput`
  - `TestRunLoginQuietStillEmitsErrors`
  - Help-output test extended to assert `quiet` is documented.

## Validation

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./... -count=1` — all packages pass (vekil, auth, cmd/menubar, proxy, server)

## Reviews

- Security review: APPROVE — no secret exposure or error suppression in security-sensitive paths.
- Quality review: APPROVE — clean abstraction, focused diff, good test coverage of acceptance criteria.

## Acceptance criteria

- [x] `--quiet` flag exists on the CLI
- [x] Suppresses non-error output when set
- [x] Default (without flag) behavior unchanged
- [x] Test exercises the flag (suppression + errors-still-emitted)
- [x] Clear help text
- [x] Minimal, focused change; existing tests still pass