### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -72,6 +72,9 @@ type Authenticator struct {
 	// are expected to drive the flow themselves via RequestDeviceCode /
 	// PollForAuthorization.
 	DisableAutoDeviceFlow bool
+
+	// Quiet suppresses non-error output from automatic interactive auth flows.
+	Quiet bool
 }
 
 // DeviceCodeResponse is the response from GitHub's device code endpoint.
@@ -515,7 +518,9 @@ func (a *Authenticator) deviceCodeFlow(ctx context.Context) error {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
+	if !a.Quiet {
+		_, _ = fmt.Fprintf(os.Stderr, "Please visit %s and enter code: %s\n", dcResp.VerificationURI, dcResp.UserCode)
+	}
 
 	return a.pollForAuthorization(ctx, dcResp)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet`, `-q` | unset | `false` | Suppress non-error output |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	if !(*quiet || *q) {
+	if !*quiet && !*q {
 		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -112,19 +113,24 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
+	normalOutput := deps.stderr
+	if opts.quiet {
+		normalOutput = io.Discard
+	}
+
 	ctx := context.Background()
 	if opts.useGitHubCLI {
 		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(normalOutput, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(normalOutput, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +144,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(normalOutput, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(normalOutput, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(normalOutput, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +156,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(normalOutput, "Login successful.")
 	return 0
 }
 
@@ -178,6 +184,8 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
+	q := fs.Bool("q", false, "Alias for --quiet")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,6 +193,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet || *q
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
@@ -194,6 +203,8 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 func runLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
+	q := fs.Bool("q", false, "Alias for --quiet")
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,7 +218,9 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !(*quiet || *q) {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
@@ -216,6 +229,8 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
+	quietShort                      *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +256,8 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
+		quietShort:                      fs.Bool("q", false, "Alias for --quiet"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -258,6 +275,17 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
 	}
+}
+
+func (f serveFlags) quietMode() bool {
+	return (f.quiet != nil && *f.quiet) || (f.quietShort != nil && *f.quietShort)
+}
+
+func (f serveFlags) loggerLevel() logger.Level {
+	if f.quietMode() {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
 }
 
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
@@ -286,12 +314,13 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.loggerLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
 		log.Fatal("failed to initialize authenticator", logger.Err(err))
 	}
+	authenticator.Quiet = serve.quietMode()
 
 	providersCfg, err := proxy.LoadProvidersConfigFile(*serve.providersConfigPath)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -188,6 +189,30 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeQuietFlagSuppressesInfoButKeepsErrors(t *testing.T) {
+	quietServe := parseServeFlagsForTest(t, "--quiet")
+	quietOutput := captureStderr(t, func() {
+		log := logger.New(quietServe.loggerLevel())
+		log.Info("normal output")
+		log.Error("error output")
+	})
+	if strings.Contains(quietOutput, "normal output") {
+		t.Fatalf("--quiet output contains info message: %q", quietOutput)
+	}
+	if !strings.Contains(quietOutput, "error output") {
+		t.Fatalf("--quiet output missing error message: %q", quietOutput)
+	}
+
+	loudServe := parseServeFlagsForTest(t)
+	loudOutput := captureStderr(t, func() {
+		log := logger.New(loudServe.loggerLevel())
+		log.Info("normal output")
+	})
+	if !strings.Contains(loudOutput, "normal output") {
+		t.Fatalf("non-quiet output missing info message: %q", loudOutput)
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -309,6 +334,42 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	}
 }
 
+func TestRunLoginQuietSuppressesSuccessButKeepsErrors(t *testing.T) {
+	t.Run("success output suppressed", func(t *testing.T) {
+		var stderr bytes.Buffer
+		code := runLoginWithDeps([]string{"--quiet", "--gh"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{}, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("--quiet emitted success output: %q", got)
+		}
+	})
+
+	t.Run("errors still emitted", func(t *testing.T) {
+		var stderr bytes.Buffer
+		code := runLoginWithDeps([]string{"--quiet", "--gh"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{signInWithGitHubCLIErr: fmt.Errorf("boom")}, nil
+			},
+		})
+
+		if code != 1 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+		}
+		if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
+			t.Fatalf("--quiet error output = %q", got)
+		}
+	})
+}
+
 func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 	var stderr bytes.Buffer
 	fake := &fakeLoginAuthenticator{
@@ -356,6 +417,29 @@ func TestRunLoginForceSkipsRefreshAndStartsDeviceFlow(t *testing.T) {
 			t.Fatalf("stderr missing %q, got %q", want, output)
 		}
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
 }
 
 type fakeLoginAuthenticator struct {


### PR DESCRIPTION
## Summary
Adds a `--quiet` (with `-q` shorthand) flag to the vekil CLI that suppresses non-error/informational output when set. Error output is always preserved.

## Changes
- **Flag wiring:** Added `--quiet`/`-q` parsing for the `serve`, `login`, and `logout` paths.
- **Serve:** Uses error-level logging in quiet mode, suppressing info/debug logs.
- **Login/Logout:** Suppresses normal success/instruction output while preserving error messages.
- **Auth:** Automatic auth device-flow prompt is suppressed when quiet is enabled (`auth/authenticator.go`).
- **Docs:** Documented `--quiet`/`-q` in `docs/configuration.md`.
- **Tests:** Added tests covering quiet suppression and verifying error output is preserved (`main_test.go`).

## Validation
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass (validated on `golang:1.25`)

## Review
- Security review: APPROVED (no secret leakage; errors still surface in quiet mode)
- Quality review: APPROVED (flag wired consistently, focused tests, docs updated)

## Acceptance Criteria
- [x] `--quiet` flag wired into CLI argument parsing
- [x] Normal/informational output suppressed when set
- [x] Errors still surfaced when set
- [x] Test exercises the flag and passes

Files changed: `auth/authenticator.go`, `docs/configuration.md`, `main.go`, `main_test.go`