### PR TITLE
Add basic metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type metrics struct {
+	requestsTotal uint64
+	inFlight      int64
+}
+
+func (m *metrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddUint64(&m.requestsTotal, 1)
+		atomic.AddInt64(&m.inFlight, 1)
+		defer atomic.AddInt64(&m.inFlight, -1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w, "# HELP vekil_http_requests_total Total HTTP requests handled by Vekil.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", atomic.LoadUint64(&m.requestsTotal))
+	_, _ = fmt.Fprintf(w, "# HELP vekil_http_in_flight_requests HTTP requests currently being handled by Vekil.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_in_flight_requests gauge\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_in_flight_requests %d\n", atomic.LoadInt64(&m.inFlight))
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -23,10 +23,10 @@ func (m *metrics) instrument(next http.Handler) http.Handler {
 
 func (m *metrics) handle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = fmt.Fprintf(w, "# HELP vekil_http_requests_total Total HTTP requests handled by Vekil.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
-	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", atomic.LoadUint64(&m.requestsTotal))
-	_, _ = fmt.Fprintf(w, "# HELP vekil_http_in_flight_requests HTTP requests currently being handled by Vekil.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_in_flight_requests gauge\n")
-	_, _ = fmt.Fprintf(w, "vekil_http_in_flight_requests %d\n", atomic.LoadInt64(&m.inFlight))
+	_, _ = w.Write([]byte("# HELP vekil_http_requests_total Total HTTP requests handled by Vekil.\n"))
+	_, _ = w.Write([]byte("# TYPE vekil_http_requests_total counter\n"))
+	_, _ = w.Write([]byte("vekil_http_requests_total " + strconv.FormatUint(atomic.LoadUint64(&m.requestsTotal), 10) + "\n"))
+	_, _ = w.Write([]byte("# HELP vekil_http_in_flight_requests HTTP requests currently being handled by Vekil.\n"))
+	_, _ = w.Write([]byte("# TYPE vekil_http_in_flight_requests gauge\n"))
+	_, _ = w.Write([]byte("vekil_http_in_flight_requests " + strconv.FormatInt(atomic.LoadInt64(&m.inFlight), 10) + "\n"))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -86,20 +86,25 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	appMux := http.NewServeMux()
+	appMux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
+	appMux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
+	appMux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
+	appMux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
+	appMux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
+	appMux.HandleFunc("POST /models/", handler.HandleGeminiModels)
+	appMux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
+	appMux.HandleFunc("POST /v1/responses", handler.HandleResponses)
+	appMux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
+	appMux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
+	appMux.HandleFunc("GET /healthz", handler.HandleHealthz)
+	appMux.HandleFunc("GET /readyz", handler.HandleReadyz)
+	appMux.HandleFunc("GET /v1/models", handler.HandleModels)
+
+	metrics := &metrics{}
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
-	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
-	mux.HandleFunc("POST /v1/chat/completions", handler.HandleOpenAIChatCompletions)
-	mux.HandleFunc("POST /v1beta/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /models/", handler.HandleGeminiModels)
-	mux.HandleFunc("POST /v1/responses/compact", handler.HandleCompact)
-	mux.HandleFunc("POST /v1/responses", handler.HandleResponses)
-	mux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
-	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
-	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
-	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
-	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.HandleFunc("GET /metrics", metrics.handle)
+	mux.Handle("/", metrics.instrument(appMux))
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -41,6 +43,44 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "address already in use") {
 		t.Fatalf("expected address-in-use error, got %v", err)
+	}
+}
+
+func TestNew_MountsMetricsEndpoint(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	healthRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthRec, healthReq)
+	if healthRec.Code != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", healthRec.Code, http.StatusOK)
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsRec, metricsReq)
+	if metricsRec.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", metricsRec.Code, http.StatusOK)
+	}
+
+	body := metricsRec.Body.String()
+	for _, want := range []string{
+		"# TYPE vekil_http_requests_total counter",
+		"vekil_http_requests_total 1",
+		"# TYPE vekil_http_in_flight_requests gauge",
+		"vekil_http_in_flight_requests 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("GET /metrics body missing %q:\n%s", want, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- mount a basic Prometheus-style /metrics endpoint
- track total HTTP requests and in-flight HTTP requests
- add a focused server test for the mounted metrics endpoint

## Validation
- GOROOT=/tmp/go-install/go PATH=/tmp/go-install/go/bin:$PATH go test ./server -count=1