### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | `QUIET` | `false` | Suppress non-error output (only errors are logged) |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", getEnvBool("QUIET", false), "Suppress non-error output (only errors are logged)"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -282,11 +284,18 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+func effectiveLogLevel(logLevel string, quiet bool) logger.Level {
+	if quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(logLevel)
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(effectiveLogLevel(*serve.logLevel, *serve.quiet))
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -130,6 +131,57 @@ func parseServeFlagsForTest(t *testing.T, args ...string) serveFlags {
 		t.Fatalf("parse serve flags: %v", err)
 	}
 	return serve
+}
+
+func TestEffectiveLogLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel string
+		quiet    bool
+		want     logger.Level
+	}{
+		{name: "info", logLevel: "info", quiet: false, want: logger.LevelInfo},
+		{name: "debug", logLevel: "debug", quiet: false, want: logger.LevelDebug},
+		{name: "error", logLevel: "error", quiet: false, want: logger.LevelError},
+		{name: "quiet overrides debug", logLevel: "debug", quiet: true, want: logger.LevelError},
+		{name: "quiet overrides info", logLevel: "info", quiet: true, want: logger.LevelError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveLogLevel(tc.logLevel, tc.quiet); got != tc.want {
+				t.Fatalf("effectiveLogLevel(%q, %v) = %v, want %v", tc.logLevel, tc.quiet, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServeFlagsQuiet(t *testing.T) {
+	t.Setenv("QUIET", "")
+
+	defaultServe := parseServeFlagsForTest(t)
+	if *defaultServe.quiet {
+		t.Fatal("quiet should be disabled by default")
+	}
+
+	cliServe := parseServeFlagsForTest(t, "--quiet")
+	if !*cliServe.quiet {
+		t.Fatal("--quiet should enable quiet mode")
+	}
+}
+
+func TestServeFlagsQuietEnvDefault(t *testing.T) {
+	t.Setenv("QUIET", "true")
+
+	envServe := parseServeFlagsForTest(t)
+	if !*envServe.quiet {
+		t.Fatal("QUIET=true should enable quiet mode")
+	}
+
+	cliServe := parseServeFlagsForTest(t, "--quiet=false")
+	if *cliServe.quiet {
+		t.Fatal("--quiet=false should override QUIET=true")
+	}
 }
 
 func TestServeFlagsCopilotHeaderEnvDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a --quiet / QUIET serve flag that forces effective logging to error-only
- use the effective log level when constructing the serve logger
- document the flag and test quiet/log-level precedence

## Tests
- gofmt -l .
- make build
- make vet
- make test