### PR TITLE
fix(security): Raw upstream error response bodies are written to proxy error logs

### DIFF
--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -273,7 +273,8 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		h.log.Error("upstream error",
 			logger.F("endpoint", "anthropic"),
 			logger.F("status", resp.StatusCode),
-			logger.F("body", string(errBody)),
+			logger.F("error_summary", summarizeUpstreamErrorBody(errBody)),
+			logger.F("response_bytes", len(errBody)),
 			logger.F("request_bytes", len(oaiBody)),
 		)
 		writeAnthropicError(w, resp.StatusCode, "api_error", formatUpstreamErrorMessage(resp.StatusCode, errBody))

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -788,6 +788,47 @@ func TestHandleAnthropicUpstreamError(t *testing.T) {
 	}
 }
 
+func TestHandleAnthropicUpstreamErrorLogOmitsRawBody(t *testing.T) {
+	const sensitive = "super-secret-prompt"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprintf(w, `{"error":{"message":"bad request","type":"invalid_request_error"},"prompt":%q}`, sensitive)
+	})
+
+	oldStderr := os.Stderr
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = writePipe
+	defer func() {
+		os.Stderr = oldStderr
+		_ = readPipe.Close()
+	}()
+
+	anthropicReq := `{
+		"model": "claude-sonnet-4",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(anthropicReq))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	_ = writePipe.Close()
+	os.Stderr = oldStderr
+	logs, _ := io.ReadAll(readPipe)
+	if strings.Contains(string(logs), sensitive) {
+		t.Fatalf("upstream error log included raw response body: %s", logs)
+	}
+	if !strings.Contains(string(logs), "error_summary") || !strings.Contains(string(logs), "response_bytes") {
+		t.Fatalf("upstream error log missing sanitized metadata: %s", logs)
+	}
+}
+
 func TestHandleOpenAIChatCompletions(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/chat/completions" {


### PR DESCRIPTION
Security remediation for finding `fnd_65e5f379fa57`.

Summary:
Several provider translation paths read up to 4096 bytes of a non-200 upstream response and log it verbatim as the structured field "body". Because Vekil proxies configurable LLM providers, these error payloads can contain provider-returned details, request echoes, or other sensitive diagnostic content, and will be persisted wherever stderr logs are collected.

Root cause:
Error handling logs raw upstream response bodies instead of only bounded, sanitized metadata or a redacted summary.

Remediation guidance:
Avoid logging raw upstream bodies. Reuse the existing upstream error summarization/redaction path or log status, endpoint, byte count, and a correlation ID; if details are needed, redact secrets and prompt-like fields before logging.
