### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -118,13 +119,17 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		if !opts.quiet {
+			_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		}
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			if !opts.quiet {
+				_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			}
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,10 +143,12 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	if !opts.quiet {
+		_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+		_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	}
 
-	if err := deps.openURL(dcResp.VerificationURI); err != nil {
+	if err := deps.openURL(dcResp.VerificationURI); err != nil && !opts.quiet {
 		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
@@ -150,7 +157,9 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	if !opts.quiet {
+		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	}
 	return 0
 }
 
@@ -178,6 +187,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,6 +195,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
@@ -194,6 +205,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 func runLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", false, "Suppress non-error output")
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,7 +219,9 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !*quiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
@@ -232,6 +246,7 @@ type serveFlags struct {
 	compactUpstreamChunkBytes       *int
 	compactUpstreamChunkConcurrency *int
 	compactUpstreamMaxAttempts      *int
+	quiet                           *bool
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
@@ -257,7 +272,15 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+		quiet:                           fs.Bool("quiet", false, "Suppress non-error output"),
 	}
+}
+
+func (f serveFlags) logLevelValue() logger.Level {
+	if f.quiet != nil && *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
 }
 
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
@@ -286,7 +309,7 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.logLevelValue())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -148,8 +148,18 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
 	}
 
-	if err := deps.openURL(dcResp.VerificationURI); err != nil && !opts.quiet {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+	if err := deps.openURL(dcResp.VerificationURI); err != nil {
+		if opts.quiet {
+			_, _ = fmt.Fprintf(
+				deps.stderr,
+				"Could not open browser automatically: %v\nPlease visit: %s\nEnter code: %s\n",
+				err,
+				dcResp.VerificationURI,
+				dcResp.UserCode,
+			)
+		} else {
+			_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		}
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -321,6 +321,41 @@ func TestRunLoginQuietSuppressesNonErrorOutput(t *testing.T) {
 			t.Fatalf("stderr missing error output, got %q", got)
 		}
 	})
+
+	t.Run("quiet reports browser open failure with fallback code", func(t *testing.T) {
+		var stderr bytes.Buffer
+		wantErr := errors.New("open failed")
+
+		code := runLoginWithDeps([]string{"--force", "--quiet"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{
+					deviceCodeResponse: &auth.DeviceCodeResponse{
+						DeviceCode:      "device-code",
+						UserCode:        "ABCD-EFGH",
+						VerificationURI: "https://github.com/login/device",
+						Interval:        1,
+					},
+				}, nil
+			},
+			openURL: func(string) error {
+				return wantErr
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		output := stderr.String()
+		for _, want := range []string{wantErr.Error(), "https://github.com/login/device", "ABCD-EFGH"} {
+			if !strings.Contains(output, want) {
+				t.Fatalf("stderr missing %q, got %q", want, output)
+			}
+		}
+		if strings.Contains(output, "Login successful.") {
+			t.Fatalf("quiet login wrote success output %q", output)
+		}
+	})
 }
 
 func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -188,6 +190,14 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeQuietOverridesLogLevel(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--log-level", "debug", "--quiet")
+
+	if got := serve.logLevelValue(); got != logger.LevelError {
+		t.Fatalf("logLevelValue() = %v, want %v", got, logger.LevelError)
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -247,13 +257,70 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 			}
 
 			output := stderr.String()
-			for _, want := range []string{"github-cli", "gh", "force"} {
+			for _, want := range []string{"github-cli", "gh", "force", "quiet"} {
 				if !strings.Contains(output, want) {
 					t.Fatalf("help output missing %q:\n%s", want, output)
 				}
 			}
 		})
 	}
+}
+
+func TestRunLoginQuietSuppressesNonErrorOutput(t *testing.T) {
+	t.Run("normal success output appears by default", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--github-cli"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{}, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		if got := stderr.String(); !strings.Contains(got, "Login successful.") {
+			t.Fatalf("stderr missing success output, got %q", got)
+		}
+	})
+
+	t.Run("quiet suppresses success output", func(t *testing.T) {
+		var stderr bytes.Buffer
+
+		code := runLoginWithDeps([]string{"--github-cli", "--quiet"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{}, nil
+			},
+		})
+
+		if code != 0 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+		if got := stderr.String(); got != "" {
+			t.Fatalf("quiet login wrote non-error output %q", got)
+		}
+	})
+
+	t.Run("quiet preserves error output", func(t *testing.T) {
+		var stderr bytes.Buffer
+		wantErr := errors.New("boom")
+
+		code := runLoginWithDeps([]string{"--github-cli", "--quiet"}, loginDeps{
+			stderr: &stderr,
+			newAuthenticator: func(string) (loginAuthenticator, error) {
+				return &fakeLoginAuthenticator{signInWithGitHubCLIErr: wantErr}, nil
+			},
+		})
+
+		if code != 1 {
+			t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+		}
+		if got := stderr.String(); !strings.Contains(got, wantErr.Error()) {
+			t.Fatalf("stderr missing error output, got %q", got)
+		}
+	})
 }
 
 func TestRunLoginRejectsGitHubCLIWithForceBeforeAuthConstruction(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds a `--quiet` flag to the `vekil` CLI that suppresses normal/non-error (informational) output while preserving error reporting and exit codes.

## Changes
- **`main.go`**
  - Adds a `--quiet` boolean flag to the `serve`, `login`, and `logout` flag sets, following existing flag conventions.
  - **serve**: when quiet, the logger level is raised to error-only, suppressing info/debug logs while preserving error/fatal logs.
  - **login/logout**: success/status informational messages are suppressed when quiet, while errors are still printed.
  - **Device-code login fallback**: if opening the browser fails, the failure is **always** reported to stderr (even under `--quiet`), and the fallback verification URL + user code are included so login can still be completed. Quiet only suppresses normal success-path info, never error/recovery output.
- **`main_test.go`**
  - serve quiet overrides debug log level to error-only.
  - login success output appears normally (non-quiet) and is suppressed with `--quiet`.
  - login error output is still preserved with `--quiet`.
  - quiet + browser-open failure still surfaces the error and fallback verification URL/user code on stderr.

## Behavior
- Default (no flag) behavior is unchanged.
- Errors and error exit codes continue to work under `--quiet`.

## Validation
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass on `golang:1.25` at the pushed commit.

## Review
- Security review: APPROVED (no secrets/tokens leaked; no auth errors hidden; no silent-failure path).
- Code-quality review: APPROVED (flag wiring correct/idiomatic; tests genuinely exercise quiet + error/fallback paths; default behavior unchanged).

🤖 Generated via Orka coordinated workflow (coder + validation + parallel security/quality review).