### PR TITLE
Add basic metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -21,10 +21,12 @@ func (m *metrics) wrap(next http.Handler) http.Handler {
 	})
 }
 
-func (m *metrics) handle(w http.ResponseWriter, r *http.Request) {
+func (m *metrics) handle(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
-	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", atomic.LoadUint64(&m.requestsTotal))
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_in_flight gauge\n")
-	_, _ = fmt.Fprintf(w, "vekil_http_requests_in_flight %d\n", atomic.LoadInt64(&m.inFlight))
+	_, _ = w.Write([]byte(
+		"# TYPE vekil_http_requests_total counter\n" +
+			"vekil_http_requests_total " + strconv.FormatUint(atomic.LoadUint64(&m.requestsTotal), 10) + "\n" +
+			"# TYPE vekil_http_requests_in_flight gauge\n" +
+			"vekil_http_requests_in_flight " + strconv.FormatInt(atomic.LoadInt64(&m.inFlight), 10) + "\n",
+	))
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type metrics struct {
+	requestsTotal uint64
+	inFlight      int64
+}
+
+func (m *metrics) wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddUint64(&m.requestsTotal, 1)
+		atomic.AddInt64(&m.inFlight, 1)
+		defer atomic.AddInt64(&m.inFlight, -1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", atomic.LoadUint64(&m.requestsTotal))
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_in_flight gauge\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_requests_in_flight %d\n", atomic.LoadInt64(&m.inFlight))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -86,6 +86,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	metrics := &metrics{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
@@ -98,6 +99,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /v1/responses", handler.HandleResponsesWebSocket)
 	mux.HandleFunc("POST /v1/memories/trace_summarize", handler.HandleMemorySummarize)
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
+	mux.HandleFunc("GET /metrics", metrics.handle)
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
 
@@ -105,7 +107,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.wrap(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,6 +14,38 @@ import (
 	"github.com/sozercan/vekil/logger"
 	"github.com/sozercan/vekil/proxy"
 )
+
+func TestMetricsEndpointReportsRequestCountAndInFlight(t *testing.T) {
+	srv, err := New(auth.NewTestAuthenticator("test-token"), logger.New(logger.ParseLevel("error")), "127.0.0.1", "0")
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	srv.httpServer.Handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	text := string(body)
+	for _, want := range []string{
+		"# TYPE vekil_http_requests_total counter\n",
+		"vekil_http_requests_total 2\n",
+		"# TYPE vekil_http_requests_in_flight gauge\n",
+		"vekil_http_requests_in_flight 1\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("metrics body missing %q; got:\n%s", want, text)
+		}
+	}
+}
 
 func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
- Mount a Prometheus-style GET /metrics endpoint on the existing server
- Add atomic request total and in-flight request metrics
- Cover the endpoint with a focused server test

## Test
- PATH=/tmp/go-install/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games GOROOT=/tmp/go-install/go go test ./server -run TestMetricsEndpointReportsRequestCountAndInFlight -count=1