### PR TITLE
Add quiet serve flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", getEnvBool("QUIET", false), "Suppress non-error output (only errors are logged)"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -258,6 +260,15 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
 	}
+}
+
+// effectiveLogLevel returns the log level to use, accounting for --quiet,
+// which raises the threshold to error so only errors and fatals are emitted.
+func (f serveFlags) effectiveLogLevel() logger.Level {
+	if f.quiet != nil && *f.quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(*f.logLevel)
 }
 
 func (f serveFlags) copilotHeaderConfig() proxy.CopilotHeaderConfig {
@@ -286,7 +297,7 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(serve.effectiveLogLevel())
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,56 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestServeFlagsQuiet(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		envQuiet string
+		want     logger.Level
+		wantFlag bool
+	}{
+		{
+			name:     "default uses info",
+			want:     logger.ParseLevel("info"),
+			wantFlag: false,
+		},
+		{
+			name:     "quiet raises threshold to error",
+			args:     []string{"--quiet"},
+			want:     logger.LevelError,
+			wantFlag: true,
+		},
+		{
+			name:     "quiet wins over debug log level",
+			args:     []string{"--quiet", "--log-level", "debug"},
+			want:     logger.LevelError,
+			wantFlag: true,
+		},
+		{
+			name:     "env quiet default",
+			envQuiet: "true",
+			want:     logger.LevelError,
+			wantFlag: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envQuiet != "" {
+				t.Setenv("QUIET", tc.envQuiet)
+			}
+
+			serve := parseServeFlagsForTest(t, tc.args...)
+			if got := serve.effectiveLogLevel(); got != tc.want {
+				t.Fatalf("effectiveLogLevel() = %v, want %v", got, tc.want)
+			}
+			if got := *serve.quiet; got != tc.wantFlag {
+				t.Fatalf("quiet = %v, want %v", got, tc.wantFlag)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a serve-mode `--quiet` flag (and `QUIET` env default) that raises logging to errors/fatals only.
- Use the effective log level when constructing the serve logger.
- Cover default, CLI, debug override, and env quiet behavior in tests.

## Validation
- `gofmt -l main.go main_test.go`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
