### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | none | `false` | Suppress non-error output |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,17 +28,44 @@ const (
 )
 
 func main() {
+	args, quiet := extractGlobalQuiet(os.Args)
+
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	switch commandFromArgs(args) {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(args[2:], quiet)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(args[2:], quiet)
 		return
 	}
 
-	runServe()
+	runServe(args[1:], quiet)
+}
+
+func extractGlobalQuiet(args []string) ([]string, bool) {
+	if len(args) == 0 {
+		return args, false
+	}
+
+	quiet := false
+	out := make([]string, 0, len(args))
+	out = append(out, args[0])
+	for _, arg := range args[1:] {
+		if arg == "--quiet" {
+			quiet = true
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "--quiet="); ok {
+			parsed, err := strconv.ParseBool(value)
+			if err == nil {
+				quiet = parsed
+				continue
+			}
+		}
+		out = append(out, arg)
+	}
+	return out, quiet
 }
 
 func commandFromArgs(args []string) cliCommand {
@@ -59,6 +87,7 @@ type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -72,12 +101,15 @@ type loginAuthenticator interface {
 
 type loginDeps struct {
 	stderr           io.Writer
+	quiet            bool
 	newAuthenticator func(string) (loginAuthenticator, error)
 	openURL          func(string) error
 }
 
-func runLogin(args []string) {
-	if code := runLoginWithDeps(args, defaultLoginDeps()); code != 0 {
+func runLogin(args []string, quiet bool) {
+	deps := defaultLoginDeps()
+	deps.quiet = quiet
+	if code := runLoginWithDeps(args, deps); code != 0 {
 		os.Exit(code)
 	}
 }
@@ -95,7 +127,7 @@ func defaultLoginDeps() loginDeps {
 func runLoginWithDeps(args []string, deps loginDeps) int {
 	deps = normalizeLoginDeps(deps)
 
-	opts, err := parseLoginOptions(args, deps.stderr)
+	opts, err := parseLoginOptions(args, deps.stderr, deps.quiet)
 	if err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -113,18 +145,22 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 	}
 
 	ctx := context.Background()
+	info := deps.stderr
+	if opts.quiet {
+		info = io.Discard
+	}
 	if opts.useGitHubCLI {
 		if err := authenticator.SignInWithGitHubCLI(ctx); err != nil {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		_, _ = fmt.Fprintln(info, "Login successful.")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			_, _ = fmt.Fprintln(info, "Already logged in.")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +174,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	_, _ = fmt.Fprintf(info, "Opening browser to %s\n", dcResp.VerificationURI)
+	_, _ = fmt.Fprintf(info, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		_, _ = fmt.Fprintf(info, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +186,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	_, _ = fmt.Fprintln(info, "Login successful.")
 	return 0
 }
 
@@ -167,7 +203,7 @@ func normalizeLoginDeps(deps loginDeps) loginDeps {
 	return deps
 }
 
-func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
+func parseLoginOptions(args []string, stderr io.Writer, quietDefault bool) (loginOptions, error) {
 	if stderr == nil {
 		stderr = io.Discard
 	}
@@ -178,6 +214,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := fs.Bool("quiet", quietDefault, "suppress non-error output")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,15 +222,17 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
 	return opts, nil
 }
 
-func runLogout(args []string) {
+func runLogout(args []string, quietDefault bool) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := fs.Bool("quiet", quietDefault, "suppress non-error output")
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,7 +246,9 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	if !*quiet {
+		_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	}
 }
 
 type serveFlags struct {
@@ -232,9 +273,14 @@ type serveFlags struct {
 	compactUpstreamChunkBytes       *int
 	compactUpstreamChunkConcurrency *int
 	compactUpstreamMaxAttempts      *int
+	quiet                           *bool
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
+	return registerServeFlagsWithQuietDefault(fs, false)
+}
+
+func registerServeFlagsWithQuietDefault(fs *flag.FlagSet, quietDefault bool) serveFlags {
 	return serveFlags{
 		port:                            fs.String("port", getEnv("PORT", "1337"), "Listen port"),
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
@@ -257,6 +303,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+		quiet:                           fs.Bool("quiet", quietDefault, "suppress non-error output"),
 	}
 }
 
@@ -282,11 +329,16 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
-func runServe() {
-	serve := registerServeFlags(flag.CommandLine)
-	flag.Parse()
+func runServe(args []string, quietDefault bool) {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	serve := registerServeFlagsWithQuietDefault(fs, quietDefault)
+	fs.Parse(args) //nolint:errcheck
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if *serve.quiet {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -188,6 +189,14 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeFlagsQuietCanBeEnabled(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet")
+
+	if !*serve.quiet {
+		t.Fatal("--quiet should enable quiet mode")
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -225,6 +234,17 @@ func TestCommandFromArgs(t *testing.T) {
 	}
 }
 
+func TestExtractGlobalQuiet(t *testing.T) {
+	args, quiet := extractGlobalQuiet([]string{"vekil", "--quiet", "login"})
+
+	if !quiet {
+		t.Fatal("extractGlobalQuiet quiet = false, want true")
+	}
+	if got := strings.Join(args, " "); got != "vekil login" {
+		t.Fatalf("extractGlobalQuiet args = %q, want %q", got, "vekil login")
+	}
+}
+
 func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 	for _, helpArg := range []string{"-h", "--help"} {
 		t.Run(helpArg, func(t *testing.T) {
@@ -247,7 +267,7 @@ func TestRunLoginHelpIncludesAuthFlags(t *testing.T) {
 			}
 
 			output := stderr.String()
-			for _, want := range []string{"github-cli", "gh", "force"} {
+			for _, want := range []string{"github-cli", "gh", "force", "quiet"} {
 				if !strings.Contains(output, want) {
 					t.Fatalf("help output missing %q:\n%s", want, output)
 				}
@@ -306,6 +326,46 @@ func TestRunLoginGHAliasUsesGitHubCLI(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "Login successful.") {
 		t.Fatalf("stderr missing success message, got %q", got)
+	}
+}
+
+func TestRunLoginQuietSuppressesSuccessOutput(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{}
+
+	code := runLoginWithDeps([]string{"--quiet", "--github-cli"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	})
+
+	if code != 0 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("quiet login wrote non-error output %q, want empty", got)
+	}
+}
+
+func TestRunLoginQuietPreservesErrorOutput(t *testing.T) {
+	var stderr bytes.Buffer
+	fake := &fakeLoginAuthenticator{
+		signInWithGitHubCLIErr: errors.New("boom"),
+	}
+
+	code := runLoginWithDeps([]string{"--quiet", "--github-cli"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return fake, nil
+		},
+	})
+
+	if code != 1 {
+		t.Fatalf("runLoginWithDeps() code = %d, want 1", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
+		t.Fatalf("quiet login suppressed error output, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds a global `--quiet` flag to the `vekil` CLI that suppresses non-error (informational/stdout) output when set, while preserving error output and non-zero exit behavior.

## Changes
- **main.go**: Added the global `--quiet` flag and gated informational output (serve, login, logout) through it. Error/fatal output and exit behavior are preserved.
- **main_test.go**: Added a test exercising the flag — asserts informational output is suppressed when `--quiet` is set and that error output is preserved.
- **docs/configuration.md**: Documented the `--quiet` flag with a clear static description ("suppress non-error output").

## Acceptance criteria
- [x] Global `--quiet` boolean flag available (inherited by subcommands)
- [x] Non-error output suppressed when set
- [x] Error output and non-zero exit behavior preserved when set
- [x] Behavior unchanged when flag is not set
- [x] Go test exercises the flag
- [x] Help text/docs use a clear static description (not user/key/prompt-derived)

## Validation
- `go build ./...` — OK
- `go vet ./...` — clean
- `go test ./...` — all packages pass (golang:1.25, immutable commit `af33739`)

## Review
- Security review: APPROVED (no secret exposure, error paths preserved, static help text)
- Quality review: APPROVED (correct gating, error preservation, meaningful tests, docs)

🤖 Generated via Orka coordinated workflow (coder → validation → parallel security & quality review → PR).