### PR TITLE
Add minimal metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -23,11 +23,11 @@ func (m *serverMetrics) middleware(next http.Handler) http.Handler {
 
 func (m *serverMetrics) handle(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = fmt.Fprintf(w, `# HELP vekil_http_requests_total Total HTTP requests handled by the server.
+	body := `# HELP vekil_http_requests_total Total HTTP requests handled by the server.
 # TYPE vekil_http_requests_total counter
-vekil_http_requests_total %d
+vekil_http_requests_total ` + strconv.FormatUint(m.requestsTotal.Load(), 10) + `
 # HELP vekil_http_requests_in_flight Current in-flight HTTP requests.
 # TYPE vekil_http_requests_in_flight gauge
-vekil_http_requests_in_flight %d
-`, m.requestsTotal.Load(), m.requestsInFlight.Load())
+vekil_http_requests_in_flight ` + strconv.FormatInt(m.requestsInFlight.Load(), 10) + "\n"
+	_, _ = w.Write([]byte(body))
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type serverMetrics struct {
+	requestsTotal    atomic.Uint64
+	requestsInFlight atomic.Int64
+}
+
+func (m *serverMetrics) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.requestsTotal.Add(1)
+		m.requestsInFlight.Add(1)
+		defer m.requestsInFlight.Add(-1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *serverMetrics) handle(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w, `# HELP vekil_http_requests_total Total HTTP requests handled by the server.
+# TYPE vekil_http_requests_total counter
+vekil_http_requests_total %d
+# HELP vekil_http_requests_in_flight Current in-flight HTTP requests.
+# TYPE vekil_http_requests_in_flight gauge
+vekil_http_requests_in_flight %d
+`, m.requestsTotal.Load(), m.requestsInFlight.Load())
+}

--- a/server/server.go
+++ b/server/server.go
@@ -86,6 +86,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 		return nil, err
 	}
 
+	metrics := &serverMetrics{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/messages/count_tokens", handler.HandleAnthropicMessagesCountTokens)
 	mux.HandleFunc("POST /v1/messages", handler.HandleAnthropicMessages)
@@ -100,12 +101,13 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /healthz", handler.HandleHealthz)
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
+	mux.HandleFunc("GET /metrics", metrics.handle)
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      metrics.middleware(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -41,6 +43,39 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "address already in use") {
 		t.Fatalf("expected address-in-use error, got %v", err)
+	}
+}
+
+func TestMetricsEndpointReportsRequestCounters(t *testing.T) {
+	srv, err := New(auth.NewTestAuthenticator("test-token"), logger.New(logger.ParseLevel("error")), "127.0.0.1", "0")
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	healthResp := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(healthResp, healthReq)
+	if healthResp.Code != http.StatusOK {
+		t.Fatalf("healthz status = %d, want %d", healthResp.Code, http.StatusOK)
+	}
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsResp := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(metricsResp, metricsReq)
+	if metricsResp.Code != http.StatusOK {
+		t.Fatalf("metrics status = %d, want %d", metricsResp.Code, http.StatusOK)
+	}
+
+	body := metricsResp.Body.String()
+	for _, want := range []string{
+		"# TYPE vekil_http_requests_total counter",
+		"vekil_http_requests_total 2",
+		"# TYPE vekil_http_requests_in_flight gauge",
+		"vekil_http_requests_in_flight 1",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics body missing %q:\n%s", want, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- mount GET /metrics on the existing HTTP server
- add a minimal Prometheus-style request counter and in-flight gauge
- cover the endpoint with a focused server test

## Validation
- git diff --check
- go test ./server -run TestMetricsEndpointReportsRequestCounters -count=1 *(fails: go not found in sandbox PATH)*