### PR TITLE
refactor(proxy): deepen provider and responses architecture

### DIFF
--- a/proxy/provider_endpoint_policy.go
+++ b/proxy/provider_endpoint_policy.go
@@ -1,0 +1,157 @@
+package proxy
+
+// providerEndpointPolicy keeps provider-kind endpoint decisions in one module.
+// Routing code should ask providerRuntime for endpoint behavior instead of
+// duplicating provider-type switch statements at each call site.
+type providerEndpointPolicy struct {
+	defaultPaths                 providerEndpointPaths
+	staticModelEndpoints         []string
+	dynamicModelEndpoints        []string
+	routedRequestEndpoints       []string
+	unknownModelEndpoints        []string
+	discoveredModelEndpoints     []string
+	allowAnyRoutedRequest        bool
+	allowAnyUnknownModel         bool
+	allowAnyDiscoveredModelEntry bool
+}
+
+func providerEndpointPolicyFor(kind providerType) providerEndpointPolicy {
+	paths := providerEndpointPaths{
+		chatCompletions: providerEndpointChatCompletions,
+		responses:       providerEndpointResponses,
+		messages:        providerEndpointMessages,
+		models:          providerEndpointModels,
+	}
+
+	switch kind {
+	case providerTypeOpenAICodex:
+		paths.chatCompletions = ""
+		paths.messages = ""
+		return providerEndpointPolicy{
+			defaultPaths:             paths,
+			staticModelEndpoints:     endpointList(providerEndpointResponses),
+			dynamicModelEndpoints:    endpointList(providerEndpointResponses),
+			routedRequestEndpoints:   endpointList(providerEndpointResponses),
+			unknownModelEndpoints:    endpointList(providerEndpointResponses),
+			discoveredModelEndpoints: endpointList(providerEndpointResponses),
+		}
+	case providerTypeOpenAICompatible:
+		return providerEndpointPolicy{
+			defaultPaths:                 paths,
+			staticModelEndpoints:         endpointList(providerEndpointChatCompletions),
+			dynamicModelEndpoints:        endpointList(providerEndpointChatCompletions),
+			routedRequestEndpoints:       endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			unknownModelEndpoints:        endpointList(providerEndpointChatCompletions),
+			allowAnyDiscoveredModelEntry: true,
+		}
+	case providerTypeAnthropicCompatible:
+		return providerEndpointPolicy{
+			defaultPaths:             paths,
+			staticModelEndpoints:     endpointList(providerEndpointMessages),
+			dynamicModelEndpoints:    endpointList(providerEndpointMessages),
+			routedRequestEndpoints:   endpointList(providerEndpointMessages),
+			unknownModelEndpoints:    endpointList(providerEndpointMessages),
+			discoveredModelEndpoints: endpointList(providerEndpointMessages),
+		}
+	case providerTypeCopilot:
+		return providerEndpointPolicy{
+			defaultPaths:                 paths,
+			staticModelEndpoints:         endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			allowAnyRoutedRequest:        true,
+			allowAnyUnknownModel:         true,
+			allowAnyDiscoveredModelEntry: true,
+		}
+	case providerTypeAzureOpenAI:
+		return providerEndpointPolicy{
+			defaultPaths:                 paths,
+			staticModelEndpoints:         endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			allowAnyRoutedRequest:        true,
+			allowAnyUnknownModel:         true,
+			allowAnyDiscoveredModelEntry: true,
+		}
+	default:
+		return providerEndpointPolicy{
+			defaultPaths:                 paths,
+			staticModelEndpoints:         endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			allowAnyRoutedRequest:        true,
+			allowAnyUnknownModel:         true,
+			allowAnyDiscoveredModelEntry: true,
+		}
+	}
+}
+
+func endpointList(endpoints ...string) []string {
+	return append([]string(nil), endpoints...)
+}
+
+func (p providerEndpointPolicy) defaultEndpointPaths() providerEndpointPaths {
+	return p.defaultPaths
+}
+
+func (p providerEndpointPolicy) defaultStaticEndpoints() []string {
+	return endpointList(p.staticModelEndpoints...)
+}
+
+func (p providerEndpointPolicy) defaultDynamicEndpoints() []string {
+	return endpointList(p.dynamicModelEndpoints...)
+}
+
+func (p providerEndpointPolicy) supportsRoutedRequest(endpoint string) bool {
+	if p.allowAnyRoutedRequest {
+		return true
+	}
+	return supportsEndpoint(p.routedRequestEndpoints, endpoint)
+}
+
+func (p providerEndpointPolicy) allowsUnknownModelEndpoint(endpoint string) bool {
+	if p.allowAnyUnknownModel {
+		return true
+	}
+	return supportsEndpoint(p.unknownModelEndpoints, endpoint)
+}
+
+func (p providerEndpointPolicy) acceptsDiscoveredModelEndpoint(endpoint string) bool {
+	if p.allowAnyDiscoveredModelEntry {
+		return true
+	}
+	return supportsEndpoint(p.discoveredModelEndpoints, endpoint)
+}
+
+func (p *providerRuntime) endpointPolicy() providerEndpointPolicy {
+	if p == nil {
+		return providerEndpointPolicy{}
+	}
+	return providerEndpointPolicyFor(p.kind)
+}
+
+func (p *providerRuntime) supportsEndpoint(endpoint string) bool {
+	if p == nil {
+		return false
+	}
+	return p.endpointPolicy().supportsRoutedRequest(endpoint)
+}
+
+func (p *providerRuntime) allowsUnknownModelEndpoint(endpoint string) bool {
+	if p == nil {
+		return false
+	}
+	if p.endpointPolicy().allowAnyUnknownModel {
+		return true
+	}
+	return providerUsesDynamicModels(p) && p.endpointPolicy().allowsUnknownModelEndpoint(endpoint)
+}
+
+func (p *providerRuntime) acceptsDiscoveredModelEndpoint(endpoint string) bool {
+	if p == nil {
+		return false
+	}
+	return p.endpointPolicy().acceptsDiscoveredModelEndpoint(endpoint)
+}
+
+func (p *providerRuntime) defaultStaticModelEndpoints() []string {
+	return p.endpointPolicy().defaultStaticEndpoints()
+}
+
+func (p *providerRuntime) defaultDynamicModelEndpoints() []string {
+	return p.endpointPolicy().defaultDynamicEndpoints()
+}

--- a/proxy/provider_endpoint_policy_test.go
+++ b/proxy/provider_endpoint_policy_test.go
@@ -1,0 +1,190 @@
+package proxy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProviderEndpointPolicyDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		kind           providerType
+		wantStatic     []string
+		wantDynamic    []string
+		wantChatPath   string
+		wantMessages   string
+		wantModelsPath string
+	}{
+		{
+			name:           "copilot keeps legacy open routing paths",
+			kind:           providerTypeCopilot,
+			wantStatic:     []string{providerEndpointChatCompletions, providerEndpointResponses},
+			wantChatPath:   providerEndpointChatCompletions,
+			wantMessages:   providerEndpointMessages,
+			wantModelsPath: providerEndpointModels,
+		},
+		{
+			name:           "azure static models default to OpenAI routes",
+			kind:           providerTypeAzureOpenAI,
+			wantStatic:     []string{providerEndpointChatCompletions, providerEndpointResponses},
+			wantChatPath:   providerEndpointChatCompletions,
+			wantMessages:   providerEndpointMessages,
+			wantModelsPath: providerEndpointModels,
+		},
+		{
+			name:           "openai codex is responses only",
+			kind:           providerTypeOpenAICodex,
+			wantStatic:     []string{providerEndpointResponses},
+			wantDynamic:    []string{providerEndpointResponses},
+			wantMessages:   "",
+			wantModelsPath: providerEndpointModels,
+		},
+		{
+			name:           "openai compatible static and dynamic default to chat",
+			kind:           providerTypeOpenAICompatible,
+			wantStatic:     []string{providerEndpointChatCompletions},
+			wantDynamic:    []string{providerEndpointChatCompletions},
+			wantChatPath:   providerEndpointChatCompletions,
+			wantMessages:   providerEndpointMessages,
+			wantModelsPath: providerEndpointModels,
+		},
+		{
+			name:           "anthropic compatible defaults to messages",
+			kind:           providerTypeAnthropicCompatible,
+			wantStatic:     []string{providerEndpointMessages},
+			wantDynamic:    []string{providerEndpointMessages},
+			wantChatPath:   providerEndpointChatCompletions,
+			wantMessages:   providerEndpointMessages,
+			wantModelsPath: providerEndpointModels,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &providerRuntime{kind: tt.kind}
+			if got := provider.defaultStaticModelEndpoints(); !reflect.DeepEqual(got, tt.wantStatic) {
+				t.Fatalf("defaultStaticModelEndpoints() = %v, want %v", got, tt.wantStatic)
+			}
+			if got := provider.defaultDynamicModelEndpoints(); !reflect.DeepEqual(got, tt.wantDynamic) {
+				t.Fatalf("defaultDynamicModelEndpoints() = %v, want %v", got, tt.wantDynamic)
+			}
+
+			paths := providerEndpointPolicyFor(tt.kind).defaultEndpointPaths()
+			if paths.chatCompletions != tt.wantChatPath {
+				t.Fatalf("chatCompletions path = %q, want %q", paths.chatCompletions, tt.wantChatPath)
+			}
+			if paths.messages != tt.wantMessages {
+				t.Fatalf("messages path = %q, want %q", paths.messages, tt.wantMessages)
+			}
+			if paths.models != tt.wantModelsPath {
+				t.Fatalf("models path = %q, want %q", paths.models, tt.wantModelsPath)
+			}
+		})
+	}
+}
+
+func TestProviderEndpointPolicyRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		provider            providerRuntime
+		endpoint            string
+		wantSupports        bool
+		wantUnknownModel    bool
+		wantDiscoveredModel bool
+	}{
+		{
+			name:                "copilot preserves legacy passthrough",
+			provider:            providerRuntime{kind: providerTypeCopilot},
+			endpoint:            providerEndpointMessages,
+			wantSupports:        true,
+			wantUnknownModel:    true,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "azure preserves legacy unknown model routing",
+			provider:            providerRuntime{kind: providerTypeAzureOpenAI},
+			endpoint:            providerEndpointResponses,
+			wantSupports:        true,
+			wantUnknownModel:    true,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "openai codex routes responses only",
+			provider:            providerRuntime{kind: providerTypeOpenAICodex},
+			endpoint:            providerEndpointResponses,
+			wantSupports:        true,
+			wantUnknownModel:    true,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "openai codex rejects chat",
+			provider:            providerRuntime{kind: providerTypeOpenAICodex},
+			endpoint:            providerEndpointChatCompletions,
+			wantSupports:        false,
+			wantUnknownModel:    false,
+			wantDiscoveredModel: false,
+		},
+		{
+			name:                "static openai compatible supports responses but rejects unknown models",
+			provider:            providerRuntime{kind: providerTypeOpenAICompatible, modelDiscovery: providerModelDiscoveryStatic},
+			endpoint:            providerEndpointResponses,
+			wantSupports:        true,
+			wantUnknownModel:    false,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "dynamic openai compatible allows unknown chat models",
+			provider:            providerRuntime{kind: providerTypeOpenAICompatible, modelDiscovery: providerModelDiscoveryOpenAI},
+			endpoint:            providerEndpointChatCompletions,
+			wantSupports:        true,
+			wantUnknownModel:    true,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "dynamic openai compatible still rejects unknown responses models",
+			provider:            providerRuntime{kind: providerTypeOpenAICompatible, modelDiscovery: providerModelDiscoveryOpenAI},
+			endpoint:            providerEndpointResponses,
+			wantSupports:        true,
+			wantUnknownModel:    false,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "dynamic anthropic compatible allows unknown messages models",
+			provider:            providerRuntime{kind: providerTypeAnthropicCompatible, modelDiscovery: providerModelDiscoveryOpenAI},
+			endpoint:            providerEndpointMessages,
+			wantSupports:        true,
+			wantUnknownModel:    true,
+			wantDiscoveredModel: true,
+		},
+		{
+			name:                "anthropic compatible rejects chat everywhere",
+			provider:            providerRuntime{kind: providerTypeAnthropicCompatible, modelDiscovery: providerModelDiscoveryOpenAI},
+			endpoint:            providerEndpointChatCompletions,
+			wantSupports:        false,
+			wantUnknownModel:    false,
+			wantDiscoveredModel: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.provider.supportsEndpoint(tt.endpoint); got != tt.wantSupports {
+				t.Fatalf("supportsEndpoint(%q) = %v, want %v", tt.endpoint, got, tt.wantSupports)
+			}
+			if got := tt.provider.allowsUnknownModelEndpoint(tt.endpoint); got != tt.wantUnknownModel {
+				t.Fatalf("allowsUnknownModelEndpoint(%q) = %v, want %v", tt.endpoint, got, tt.wantUnknownModel)
+			}
+			if got := tt.provider.acceptsDiscoveredModelEndpoint(tt.endpoint); got != tt.wantDiscoveredModel {
+				t.Fatalf("acceptsDiscoveredModelEndpoint(%q) = %v, want %v", tt.endpoint, got, tt.wantDiscoveredModel)
+			}
+		})
+	}
+}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -314,6 +314,27 @@ func (ps *providerSetup) lookupModel(model string) (providerModel, bool) {
 	return pm, ok
 }
 
+func (ps *providerSetup) addProviderModels(providerID string, models []providerModel) error {
+	if ps == nil {
+		return nil
+	}
+
+	provider := ps.providerByID(providerID)
+	models = filterProviderModels(provider, models)
+
+	ps.modelsMu.Lock()
+	defer ps.modelsMu.Unlock()
+
+	return mergeProviderModels(ps.models, models)
+}
+
+func (ps *providerSetup) addStaticProviderModels(providerID string) error {
+	if ps == nil {
+		return nil
+	}
+	return ps.addProviderModels(providerID, orderedStaticProviderModels(ps.providerByID(providerID)))
+}
+
 func (ps *providerSetup) replaceProviderModels(providerID string, models []providerModel) error {
 	if ps == nil {
 		return nil
@@ -333,14 +354,24 @@ func (ps *providerSetup) replaceProviderModels(providerID string, models []provi
 		next[publicID] = model
 	}
 
-	for _, model := range models {
-		if existing, exists := next[model.publicID]; exists && existing.providerID != model.providerID {
-			return providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
-		}
-		next[model.publicID] = model
+	if err := mergeProviderModels(next, models); err != nil {
+		return err
 	}
 
 	ps.models = next
+	return nil
+}
+
+func mergeProviderModels(dst map[string]providerModel, models []providerModel) error {
+	for _, model := range models {
+		if existing, exists := dst[model.publicID]; exists {
+			if existing.providerID == model.providerID {
+				continue
+			}
+			return providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
+		}
+		dst[model.publicID] = model
+	}
 	return nil
 }
 
@@ -390,15 +421,9 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 	needsDynamicModelValidation := len(providers) > 1 && hasDynamicProvider(providers)
 
 	if !needsDynamicModelValidation {
-		for _, provider := range providers {
-			for _, model := range filterProviderModels(provider, orderedStaticProviderModels(provider)) {
-				if existing, exists := setup.models[model.publicID]; exists {
-					if existing.providerID == model.providerID {
-						continue
-					}
-					return nil, providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
-				}
-				setup.models[model.publicID] = model
+		for _, providerID := range providerOrder {
+			if err := setup.addStaticProviderModels(providerID); err != nil {
+				return nil, err
 			}
 		}
 		return setup, nil
@@ -414,11 +439,8 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 	for _, providerID := range providerOrder {
 		provider := providers[providerID]
 		if !providerUsesDynamicModels(provider) {
-			for _, model := range filterProviderModels(provider, orderedStaticProviderModels(provider)) {
-				if existing, exists := setup.models[model.publicID]; exists {
-					return nil, providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
-				}
-				setup.models[model.publicID] = model
+			if err := setup.addStaticProviderModels(providerID); err != nil {
+				return nil, err
 			}
 			continue
 		}
@@ -427,14 +449,8 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 		if err != nil {
 			return nil, fmt.Errorf("load models for provider %q: %w", provider.id, err)
 		}
-		for _, model := range filterProviderModels(provider, result.models) {
-			if existing, exists := setup.models[model.publicID]; exists {
-				if existing.providerID == model.providerID {
-					continue
-				}
-				return nil, providerModelCollisionError(model.publicID, existing.providerID, model.providerID)
-			}
-			setup.models[model.publicID] = model
+		if err := setup.addProviderModels(providerID, result.models); err != nil {
+			return nil, err
 		}
 	}
 

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -55,9 +55,6 @@ const (
 	providerEndpointModels          = "/models"
 )
 
-var defaultStaticProviderEndpoints = []string{providerEndpointChatCompletions, providerEndpointResponses}
-var defaultOpenAICompatibleProviderEndpoints = []string{providerEndpointChatCompletions}
-var defaultAnthropicCompatibleProviderEndpoints = []string{providerEndpointMessages}
 var openAICodexProviderEndpoints = []string{providerEndpointResponses}
 
 // ProvidersConfig configures optional non-Copilot upstream providers.
@@ -274,7 +271,7 @@ func defaultProviderSetup(h *ProxyHandler) *providerSetup {
 				kind:          providerTypeCopilot,
 				isDefault:     true,
 				baseURL:       strings.TrimRight(h.copilotURL, "/"),
-				paths:         defaultProviderEndpointPaths(providerTypeCopilot),
+				paths:         providerEndpointPolicyFor(providerTypeCopilot).defaultEndpointPaths(),
 				includeModels: map[string]struct{}{},
 				excludeModels: map[string]struct{}{},
 				staticModels:  map[string]providerModel{},
@@ -520,7 +517,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		id:             id,
 		kind:           kind,
 		isDefault:      cfg.Default,
-		paths:          defaultProviderEndpointPaths(kind),
+		paths:          providerEndpointPolicyFor(kind).defaultEndpointPaths(),
 		modelDiscovery: providerModelDiscoveryStatic,
 		includeModels:  make(map[string]struct{}, len(cfg.IncludeModels)),
 		excludeModels:  make(map[string]struct{}, len(cfg.ExcludeModels)),
@@ -602,7 +599,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		if len(cfg.Models) == 0 {
 			return nil, fmt.Errorf("provider %q must configure at least one model", id)
 		}
-		if err := addStaticProviderModels(runtime, cfg.Models, defaultStaticEndpointsForProvider(kind)); err != nil {
+		if err := addStaticProviderModels(runtime, cfg.Models, runtime.defaultStaticModelEndpoints()); err != nil {
 			return nil, err
 		}
 	case providerTypeOpenAICodex:
@@ -656,7 +653,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		if modelDiscovery == providerModelDiscoveryStatic && len(cfg.Models) == 0 {
 			return nil, fmt.Errorf("provider %q must configure at least one model when model_discovery is static", id)
 		}
-		if err := addStaticProviderModels(runtime, cfg.Models, defaultStaticEndpointsForProvider(kind)); err != nil {
+		if err := addStaticProviderModels(runtime, cfg.Models, runtime.defaultStaticModelEndpoints()); err != nil {
 			return nil, err
 		}
 	}
@@ -686,33 +683,8 @@ func addStaticProviderModels(runtime *providerRuntime, models []ProviderModelCon
 	return nil
 }
 
-func defaultStaticEndpointsForProvider(kind providerType) []string {
-	switch kind {
-	case providerTypeOpenAICompatible:
-		return defaultOpenAICompatibleProviderEndpoints
-	case providerTypeAnthropicCompatible:
-		return defaultAnthropicCompatibleProviderEndpoints
-	default:
-		return defaultStaticProviderEndpoints
-	}
-}
-
-func defaultProviderEndpointPaths(kind providerType) providerEndpointPaths {
-	paths := providerEndpointPaths{
-		chatCompletions: providerEndpointChatCompletions,
-		responses:       providerEndpointResponses,
-		messages:        providerEndpointMessages,
-		models:          providerEndpointModels,
-	}
-	if kind == providerTypeOpenAICodex {
-		paths.chatCompletions = ""
-		paths.messages = ""
-	}
-	return paths
-}
-
 func configuredProviderEndpointPaths(kind providerType, cfg ProviderConfig) (providerEndpointPaths, error) {
-	paths := defaultProviderEndpointPaths(kind)
+	paths := providerEndpointPolicyFor(kind).defaultEndpointPaths()
 
 	var err error
 	if paths.chatCompletions, err = normalizeProviderPath(cfg.ChatCompletionsPath, paths.chatCompletions, "chat_completions_path"); err != nil {
@@ -1764,7 +1736,7 @@ func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]pro
 
 		supportedEndpoints := normalizeDynamicProviderEndpoints(provider, parsed.SupportedEndpoints)
 		if len(supportedEndpoints) == 0 {
-			supportedEndpoints = defaultDynamicProviderEndpoints(provider)
+			supportedEndpoints = provider.defaultDynamicModelEndpoints()
 		}
 		disabled := strings.EqualFold(parsed.Policy.State, "disabled")
 		if index, duplicate := indexByID[publicID]; duplicate {
@@ -1804,20 +1776,6 @@ func openRouterModelSupportsTools(supportedParams []string) bool {
 	return false
 }
 
-func defaultDynamicProviderEndpoints(provider *providerRuntime) []string {
-	if provider == nil {
-		return nil
-	}
-	switch provider.kind {
-	case providerTypeOpenAICompatible:
-		return append([]string(nil), defaultOpenAICompatibleProviderEndpoints...)
-	case providerTypeAnthropicCompatible:
-		return append([]string(nil), defaultAnthropicCompatibleProviderEndpoints...)
-	default:
-		return nil
-	}
-}
-
 func mergeDiscoveredProviderModelsWithStaticConfig(provider *providerRuntime, discovered []providerModel) []providerModel {
 	if provider == nil || len(discovered) == 0 || len(provider.staticConfigs) == 0 {
 		return discovered
@@ -1832,7 +1790,7 @@ func mergeDiscoveredProviderModelsWithStaticConfig(provider *providerRuntime, di
 		}
 
 		for _, cfg := range configs {
-			staticModel, err := buildStaticProviderModel(provider.id, cfg, defaultStaticEndpointsForProvider(provider.kind))
+			staticModel, err := buildStaticProviderModel(provider.id, cfg, provider.defaultStaticModelEndpoints())
 			if err != nil {
 				continue
 			}
@@ -1877,7 +1835,7 @@ func decodeOllamaModelsFromBody(provider *providerRuntime, body []byte) ([]provi
 		return nil, err
 	}
 
-	defaultEndpoints := defaultDynamicProviderEndpoints(provider)
+	defaultEndpoints := provider.defaultDynamicModelEndpoints()
 	models := make([]providerModel, 0, len(upstream.Models))
 	seen := make(map[string]struct{}, len(upstream.Models))
 	for _, raw := range upstream.Models {
@@ -2104,7 +2062,7 @@ func normalizeDynamicProviderEndpoints(provider *providerRuntime, endpoints []st
 		if endpoint == "" {
 			continue
 		}
-		if provider != nil && provider.kind == providerTypeAnthropicCompatible && endpoint != providerEndpointMessages {
+		if provider != nil && !provider.acceptsDiscoveredModelEndpoint(endpoint) {
 			continue
 		}
 		if _, exists := seen[endpoint]; exists {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -68,6 +68,61 @@ func responsesUpstreamHeaders(extraHeaders http.Header, stream bool) http.Header
 	return headers
 }
 
+type preparedResponsesRequest struct {
+	body            []byte
+	extraHeaders    http.Header
+	upstreamHeaders http.Header
+	headerToolScope string
+	streaming       bool
+}
+
+func (h *ProxyHandler) prepareResponsesRequest(ctx context.Context, r *http.Request, bodyBytes []byte) preparedResponsesRequest {
+	extraHeaders := responsesExtraHeadersFromRequest(r)
+	headerToolScope := toolExecutionScopeFromHeaders(extraHeaders)
+	requestToolScope := responsesRequestToolExecutionScope(headerToolScope, bodyBytes)
+
+	bodyBytes = h.rewriteResponsesRequestBodyWithToolOptimizers(ctx, bodyBytes, "responses", true, h.toolContexts, requestToolScope)
+	streaming := responsesRequestStreams(bodyBytes)
+
+	return preparedResponsesRequest{
+		body:            bodyBytes,
+		extraHeaders:    extraHeaders,
+		upstreamHeaders: responsesUpstreamHeaders(extraHeaders, streaming),
+		headerToolScope: headerToolScope,
+		streaming:       streaming,
+	}
+}
+
+func responsesRequestStreams(bodyBytes []byte) bool {
+	var partial struct {
+		Stream *bool `json:"stream,omitempty"`
+	}
+	_ = json.Unmarshal(bodyBytes, &partial)
+	return partial.Stream != nil && *partial.Stream
+}
+
+func (h *ProxyHandler) postPreparedResponsesRequest(ctx context.Context, req preparedResponsesRequest) (*http.Response, error) {
+	resp, err := h.postResponsesWithHeaders(ctx, req.body, req.upstreamHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return h.maybeRetryCompactedResponsesRequest(ctx, req.body, req.extraHeaders, req.upstreamHeaders, resp)
+}
+
+func (h *ProxyHandler) writeResponsesUpstreamRequestFailure(w http.ResponseWriter, endpoint string, err error) {
+	statusCode := upstreamStatusCode(err, http.StatusBadGateway)
+	h.log.Error("upstream request failed", logger.F("endpoint", endpoint), logger.Err(err))
+	if statusCode == http.StatusBadRequest {
+		writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
+		return
+	}
+	if statusCode == http.StatusInternalServerError {
+		writeOpenAIError(w, statusCode, "authentication failed", "server_error")
+		return
+	}
+	writeOpenAIUpstreamRequestFailure(w, statusCode, err)
+}
+
 // HandleResponses handles POST /v1/responses by forwarding the request to
 // Copilot's responses endpoint with only auth headers injected.
 func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
@@ -79,23 +134,12 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = r.Body.Close() }()
 
-	extraHeaders := responsesExtraHeadersFromRequest(r)
-	headerToolScope := toolExecutionScopeFromHeaders(extraHeaders)
-	requestToolScope := responsesRequestToolExecutionScope(headerToolScope, bodyBytes)
+	prepared := h.prepareResponsesRequest(r.Context(), r, bodyBytes)
 
-	bodyBytes = h.rewriteResponsesRequestBodyWithToolOptimizers(r.Context(), bodyBytes, "responses", true, h.toolContexts, requestToolScope)
-
-	var partial struct {
-		Stream *bool `json:"stream,omitempty"`
-	}
-	_ = json.Unmarshal(bodyBytes, &partial)
-	isStreaming := partial.Stream != nil && *partial.Stream
-	upstreamHeaders := responsesUpstreamHeaders(extraHeaders, isStreaming)
-
-	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(isStreaming)
+	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(prepared.streaming)
 	defer upstreamCancel()
 
-	if compactionResp, handled, err := h.maybeBuildResponsesCompactionTriggerResponse(upstreamCtx, bodyBytes, extraHeaders, isStreaming); handled || err != nil {
+	if compactionResp, handled, err := h.maybeBuildResponsesCompactionTriggerResponse(upstreamCtx, prepared.body, prepared.extraHeaders, prepared.streaming); handled || err != nil {
 		if err != nil {
 			statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 			h.log.Error("upstream request failed", logger.F("endpoint", "responses/compaction_trigger"), logger.Err(err))
@@ -110,44 +154,19 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.postResponsesWithHeaders(upstreamCtx, bodyBytes, upstreamHeaders)
+	resp, err := h.postPreparedResponsesRequest(upstreamCtx, prepared)
 	if err != nil {
-		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
-		h.log.Error("upstream request failed", logger.F("endpoint", "responses"), logger.Err(err))
-		if statusCode == http.StatusBadRequest {
-			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
-			return
-		}
-		if statusCode == http.StatusInternalServerError {
-			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
-			return
-		}
-		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
-		return
-	}
-	resp, err = h.maybeRetryCompactedResponsesRequest(upstreamCtx, bodyBytes, extraHeaders, upstreamHeaders, resp)
-	if err != nil {
-		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
-		h.log.Error("upstream request failed", logger.F("endpoint", "responses"), logger.Err(err))
-		if statusCode == http.StatusBadRequest {
-			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
-			return
-		}
-		if statusCode == http.StatusInternalServerError {
-			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
-			return
-		}
-		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
+		h.writeResponsesUpstreamRequestFailure(w, "responses", err)
 		return
 	}
 
-	if isStreaming && resp.StatusCode == http.StatusOK {
-		model := extractRequestModel(bodyBytes)
-		peekAndForwardResponses(h, w, r, resp, upstreamCancel, model, headerToolScope)
+	if prepared.streaming && resp.StatusCode == http.StatusOK {
+		model := extractRequestModel(prepared.body)
+		peekAndForwardResponses(h, w, r, resp, upstreamCancel, model, prepared.headerToolScope)
 		return
 	}
 
-	h.writeResponsesUpstreamResponse(w, resp, h.toolContexts, headerToolScope)
+	h.writeResponsesUpstreamResponse(w, resp, h.toolContexts, prepared.headerToolScope)
 }
 
 // compactPrompt is the system instruction used when the upstream does not

--- a/proxy/responses_handler_test.go
+++ b/proxy/responses_handler_test.go
@@ -1,6 +1,14 @@
 package proxy
 
-import "testing"
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
+)
 
 func TestExtractResponsesOutputText(t *testing.T) {
 	body := []byte(`{
@@ -28,5 +36,71 @@ func TestExtractResponsesOutputText(t *testing.T) {
 func TestExtractResponsesOutputText_InvalidJSON(t *testing.T) {
 	if _, err := extractResponsesOutputText([]byte(`{`)); err == nil {
 		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestResponsesRequestStreams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{name: "stream true", body: []byte(`{"stream":true}`), want: true},
+		{name: "stream false", body: []byte(`{"stream":false}`), want: false},
+		{name: "stream omitted", body: []byte(`{"input":"hi"}`), want: false},
+		{name: "invalid json", body: []byte(`{`), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := responsesRequestStreams(tt.body); got != tt.want {
+				t.Fatalf("responsesRequestStreams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrepareResponsesRequestBuildsHeaderAndStreamingPlan(t *testing.T) {
+	t.Parallel()
+
+	handler, err := NewProxyHandler(auth.NewTestAuthenticator("test-token"), logger.New(logger.LevelInfo))
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+
+	body := []byte(`{"model":"gpt-test","stream":true,"input":"hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	req.Header.Add("X-OpenAI-Subagent", "  worker-1  ")
+	req.Header.Add("X-OpenAI-Subagent", "   ")
+	req.Header.Set("X-Codex-Window-Id", " window-123 ")
+	req.Header.Set("X-Ignored-By-Proxy", "ignored")
+
+	prepared := handler.prepareResponsesRequest(req.Context(), req, body)
+	if !bytes.Equal(prepared.body, body) {
+		t.Fatalf("prepared body = %s, want unchanged %s", prepared.body, body)
+	}
+	if !prepared.streaming {
+		t.Fatal("prepared.streaming = false, want true")
+	}
+	if got := prepared.headerToolScope; got != "codex:|window-123" {
+		t.Fatalf("headerToolScope = %q, want codex:|window-123", got)
+	}
+	if got := prepared.extraHeaders.Values("X-OpenAI-Subagent"); len(got) != 1 || got[0] != "worker-1" {
+		t.Fatalf("extra X-OpenAI-Subagent values = %v, want [worker-1]", got)
+	}
+	if got := prepared.extraHeaders.Get("X-Codex-Window-Id"); got != "window-123" {
+		t.Fatalf("extra X-Codex-Window-Id = %q, want window-123", got)
+	}
+	if got := prepared.extraHeaders.Get("X-Ignored-By-Proxy"); got != "" {
+		t.Fatalf("unexpected forwarded ignored header %q", got)
+	}
+	if got := prepared.upstreamHeaders.Get("Accept"); got != "text/event-stream" {
+		t.Fatalf("upstream Accept = %q, want text/event-stream", got)
+	}
+	if got := prepared.extraHeaders.Get("Accept"); got != "" {
+		t.Fatalf("extra Accept mutated to %q, want empty", got)
 	}
 }

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -347,11 +347,7 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 
 	if request.Generate != nil && !*request.Generate {
 		responseID := "vekil-ws-" + uuid.NewString()
-		if plan.hasCompactionTrigger() {
-			s.turnState = ""
-		}
-		resetHistory, historyInput := plan.historyUpdateInput()
-		s.rememberResponse(resetHistory, responseID, plan.signature, historyInput, nil)
+		s.rememberPlannedResponse(plan, responseID, nil)
 		s.logRequestMetrics(h, request, responseID, metrics)
 		if err := s.writeJSON(map[string]interface{}{
 			"type": "response.created",
@@ -422,11 +418,7 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 		return err
 	}
 
-	resetHistory, historyInput := plan.historyUpdateInput()
-	if plan.hasCompactionTrigger() {
-		s.turnState = ""
-	}
-	s.rememberResponse(resetHistory, responseID, plan.signature, historyInput, outputItems)
+	s.rememberPlannedResponse(plan, responseID, outputItems)
 	metrics = s.maybeAutoCompactHistory(h, request, metrics)
 	s.logRequestMetrics(h, request, responseID, metrics)
 	return nil
@@ -610,6 +602,14 @@ func (s *responsesWebSocketSession) rememberResponse(resetHistory bool, response
 	}
 	s.historyItems = append(s.historyItems, currentInput...)
 	s.historyItems = append(s.historyItems, outputItems...)
+}
+
+func (s *responsesWebSocketSession) rememberPlannedResponse(plan responsesWebSocketRequestPlan, responseID string, outputItems []json.RawMessage) {
+	if plan.hasCompactionTrigger() {
+		s.turnState = ""
+	}
+	resetHistory, historyInput := plan.historyUpdateInput()
+	s.rememberResponse(resetHistory, responseID, plan.signature, historyInput, outputItems)
 }
 
 func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -3210,3 +3210,66 @@ func inputTextFromMessage(t *testing.T, item map[string]interface{}) string {
 	}
 	return text
 }
+
+func TestResponsesWebSocketRememberPlannedResponseAppendsInputAndOutput(t *testing.T) {
+	t.Parallel()
+
+	session := &responsesWebSocketSession{
+		turnState:    "turn-state-1",
+		historyItems: []json.RawMessage{json.RawMessage(`{"type":"message","id":"old"}`)},
+	}
+	plan := responsesWebSocketRequestPlan{
+		signature:    "sig-1",
+		currentInput: []json.RawMessage{json.RawMessage(`{"type":"message","id":"new"}`)},
+	}
+	outputItems := []json.RawMessage{json.RawMessage(`{"type":"message","id":"out"}`)}
+
+	session.rememberPlannedResponse(plan, "resp-1", outputItems)
+
+	if session.turnState != "turn-state-1" {
+		t.Fatalf("turnState = %q, want preserved turn-state-1", session.turnState)
+	}
+	if session.lastResponseID != "resp-1" {
+		t.Fatalf("lastResponseID = %q, want resp-1", session.lastResponseID)
+	}
+	if session.lastSignature != "sig-1" {
+		t.Fatalf("lastSignature = %q, want sig-1", session.lastSignature)
+	}
+	if got, want := len(session.historyItems), 3; got != want {
+		t.Fatalf("history item count = %d, want %d", got, want)
+	}
+	if string(session.historyItems[1]) != string(plan.currentInput[0]) {
+		t.Fatalf("history current input = %s, want %s", session.historyItems[1], plan.currentInput[0])
+	}
+	if string(session.historyItems[2]) != string(outputItems[0]) {
+		t.Fatalf("history output = %s, want %s", session.historyItems[2], outputItems[0])
+	}
+}
+
+func TestResponsesWebSocketRememberPlannedResponseResetsCompactionTrigger(t *testing.T) {
+	t.Parallel()
+
+	session := &responsesWebSocketSession{
+		turnState:    "turn-state-1",
+		historyItems: []json.RawMessage{json.RawMessage(`{"type":"message","id":"old"}`)},
+	}
+	plan := responsesWebSocketRequestPlan{
+		signature:    "sig-compact",
+		currentInput: []json.RawMessage{json.RawMessage(`{"type":"compaction_trigger"}`)},
+	}
+
+	session.rememberPlannedResponse(plan, "resp-compact", nil)
+
+	if session.turnState != "" {
+		t.Fatalf("turnState = %q, want cleared", session.turnState)
+	}
+	if session.lastResponseID != "resp-compact" {
+		t.Fatalf("lastResponseID = %q, want resp-compact", session.lastResponseID)
+	}
+	if session.lastSignature != "sig-compact" {
+		t.Fatalf("lastSignature = %q, want sig-compact", session.lastSignature)
+	}
+	if len(session.historyItems) != 0 {
+		t.Fatalf("historyItems = %s, want reset empty history", session.historyItems)
+	}
+}

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -127,7 +127,7 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 	if provider == nil {
 		return nil, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
 	}
-	if !providerSupportsEndpoint(provider, endpoint) {
+	if !provider.supportsEndpoint(endpoint) {
 		return nil, nil, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("provider %q does not support %s", provider.id, endpoint),
@@ -139,7 +139,7 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
 		}
 	}
-	if !known && !providerAllowsUnknownModelEndpoint(provider, endpoint) {
+	if !known && !provider.allowsUnknownModelEndpoint(endpoint) {
 		return nil, nil, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
@@ -151,36 +151,6 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 		return nil, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 	}
 	return provider, rewrittenBody, nil
-}
-
-func providerSupportsEndpoint(provider *providerRuntime, endpoint string) bool {
-	if provider == nil {
-		return false
-	}
-	switch provider.kind {
-	case providerTypeOpenAICodex:
-		return supportsEndpoint(openAICodexProviderEndpoints, endpoint)
-	case providerTypeOpenAICompatible:
-		return endpoint == providerEndpointChatCompletions || endpoint == providerEndpointResponses
-	case providerTypeAnthropicCompatible:
-		return endpoint == providerEndpointMessages
-	default:
-		return true
-	}
-}
-
-func providerAllowsUnknownModelEndpoint(provider *providerRuntime, endpoint string) bool {
-	if provider == nil {
-		return false
-	}
-	switch provider.kind {
-	case providerTypeOpenAICompatible:
-		return providerUsesDynamicModels(provider) && endpoint == providerEndpointChatCompletions
-	case providerTypeAnthropicCompatible:
-		return providerUsesDynamicModels(provider) && endpoint == providerEndpointMessages
-	default:
-		return true
-	}
 }
 
 func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body []byte) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- Centralize provider endpoint policy so default endpoints, routing support, unknown-model behavior, and discovered-model filtering live behind one provider-runtime seam.
- Consolidate provider model registry updates so filtering and collision handling are shared by static setup, dynamic setup, and refresh paths.
- Make Responses request preparation explicit by separating header extraction, stream detection, optimizer rewrites, dispatch/retry, and upstream failure mapping.
- Centralize websocket planned-response memory updates so normal and compaction-trigger turns use the same session-state seam.

## Why

The proxy had several shallow modules where provider ownership, endpoint capability, Responses dispatch, and websocket session mutation were spread across call sites. These refactors improve locality and make the test seams better match the behavior callers depend on.

## Validation

- `go test ./proxy -run 'TestProviderEndpointPolicy|TestResolveProviderRequest|TestBuildProvidersGeneric|TestDecode' -count=1`
- `go test ./proxy -run 'TestResponsesRequestStreams|TestPrepareResponsesRequestBuildsHeaderAndStreamingPlan|TestHandleResponses' -count=1`
- `go test ./proxy -run 'TestResponsesWebSocketRememberPlannedResponse|TestResponsesWebSocket.*Turn|TestResponsesWebSocket.*Compaction' -count=1`
- `make test`
- `make build`
- `./vekil --help`

## Autoreview

Each commit was autoreviewed before commit with:

```bash
python3 /Users/sozercan/.codex/skills/autoreview/scripts/autoreview --mode local --parallel-tests "make test"
```

Every autoreview run reported `autoreview clean: no accepted/actionable findings reported`.

## Progress log

Detailed progress and the completion audit are tracked locally in `/tmp/refactor-vekil.md`.
