### PR TITLE
fix: harden proxy compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,24 +22,7 @@ Run session benchmark: `go test ./proxy/ -run '^$' -bench 'BenchmarkResponsesSes
 
 ## Documentation
 
-Documentation is intentionally split under `docs/` into small, single-purpose files:
-
-| File | Scope |
-|------|-------|
-| `README.md` | Short landing page only |
-| `docs/README.md` | Documentation index and doc map |
-| `docs/getting-started.md` | install, run, first auth, deployment entry points |
-| `docs/configuration.md` | configuration map, generic flags/env vars, Copilot header overrides |
-| `docs/provider-routing.md` | provider auth, JSON/YAML routing, model ownership, endpoint allowlists |
-| `docs/tool-optimizers.md` | optional shell command rewrite and tool-output reduction config |
-| `docs/responses-websocket.md` | Codex-style websocket bridge tuning and compaction knobs |
-| `docs/clients.md` | copy-paste client examples |
-| `docs/api.md` | concise endpoint map and compatibility links |
-| `docs/gemini.md` | Gemini translation compatibility details |
-| `docs/responses.md` | OpenAI Responses, compact, and memory shim details |
-| `docs/architecture.md` | package boundaries and design notes |
-| `docs/menubar.md` | macOS/Linux tray app usage |
-| `docs/development.md` | build, test, benchmark, CI |
+Per-doc scope and update triggers live in `docs/README.md` (the authoritative doc map). Keep that file indexed whenever docs are added, removed, or behavior changes.
 
 Documentation update rules:
 
@@ -50,27 +33,17 @@ Documentation update rules:
 
 ## Architecture
 
-| Package | Purpose |
-|---------|---------|
-| `main.go` | CLI entry, flags (including JSON/YAML providers config), signal handling |
-| `auth/` | GitHub OAuth device code flow and Copilot token caching/refresh (`sync.RWMutex` + double-check) |
-| `proxy/chat_handlers.go` | Anthropic and OpenAI chat handlers, including forced-streaming aggregation for tool calls |
-| `proxy/responses_handler.go` | OpenAI Responses passthrough plus Codex compatibility endpoints (`/v1/responses/compact`, `/v1/memories/trace_summarize`) |
-| `proxy/tool_optimizer*.go`, `proxy/optimizer_*.go` | Optional `/v1/responses` tool optimizer configuration and provider adapters for shell command rewrite/output reduction |
-| `proxy/handler.go` | Shared proxy plumbing: health/ready/models handlers, request-body decoding, provider-aware model catalogs, provider headers, caches |
-| `proxy/providers.go` | JSON/YAML provider config loading, model ownership, Azure metadata overlay, endpoint allowlists, and routing state |
-| `proxy/upstream_http.go` | Provider selection, public→upstream model rewriting, and provider-specific upstream HTTP dispatch |
-| `proxy/openai_codex_auth.go` | OpenAI Codex CLI auth.json loading, refresh, and request credentials |
-| `proxy/gemini_handler.go` | Gemini-native HTTP handlers and countTokens probe flow |
-| `proxy/gemini.go` | Gemini↔OpenAI request/response translation and validation |
-| `proxy/gemini_streaming.go` | OpenAI SSE → Gemini SSE translation |
-| `proxy/translator.go` | Bidirectional Anthropic↔OpenAI request/response translation |
-| `proxy/streaming.go` | SSE stream translation (OpenAI→Anthropic events) and aggregation |
-| `proxy/retry.go` | Exponential backoff on 429/502/503/504 |
-| `models/` | Data-only structs for Anthropic and OpenAI API types (no logic) |
-| `logger/` | Structured JSON logger to stderr |
-| `server/` | HTTP server lifecycle (`Start`/`Stop`/`IsRunning`) |
-| `cmd/menubar/` | tray app binary |
+| Area | Purpose |
+|------|---------|
+| `main.go`, `server/`, `auth/`, `logger/`, `models/`, `cmd/menubar/` | CLI/server lifecycle, GitHub auth, structured logging, data-only API structs, tray app |
+| `proxy/chat_handlers.go`, `proxy/translator.go`, `proxy/streaming.go`, `proxy/openai_stream_reader.go` | Anthropic/OpenAI chat translation, forced-stream aggregation, SSE translation and passthrough |
+| `proxy/gemini*.go` | Gemini-native handlers plus Gemini↔OpenAI request/response and streaming translation |
+| `proxy/providers.go`, `proxy/provider_endpoint_policy.go`, `proxy/upstream_http.go`, `proxy/openai_codex_auth.go`, `proxy/azure_identity_auth.go` | Provider config, model ownership, endpoint allowlists, model rewrite, provider auth, upstream request construction |
+| `proxy/responses_handler.go`, `proxy/responses_websocket.go`, `proxy/responses_failure_translate.go`, `proxy/compaction.go` | OpenAI Responses passthrough, compact/memory shims, proxy-owned websocket bridge, compaction/replay behavior, Responses failure translation |
+| `proxy/tool_optimizer*.go`, `proxy/optimizer_*.go`, `proxy/tool_output_context.go`, `proxy/tool_shapes.go`, `proxy/filter_hint.go` | Optional fail-open tool command/output optimizers and tool-shape/context helpers |
+| `proxy/retry.go`, `proxy/upstream_error_detail.go`, shared helpers in `proxy/handler.go` | Retry/backoff, upstream error summaries, request body limits, headers, health/ready/models handlers, caches |
+
+New `proxy/*.go` files should join one of these responsibility clusters. Add a new row only when a genuinely new responsibility appears.
 
 ## Key Design Decisions
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,3 +94,21 @@ To use it:
 This workflow is intentionally separate from the normal CI workflow so pull requests and forked builds remain deterministic and do not depend on live provider credentials.
 
 You can also run the same smoke scripts locally after building `vekil`; the CLI smoke script additionally requires those three CLIs to be installed.
+
+## Extending vekil
+
+### Add a tool optimizer provider
+
+- Add a new `type` case in `newToolOptimizerFromConfig` and a constructor in `proxy/`.
+- Keep optimizers opt-in and disabled by default.
+- Fail open: errors, timeouts, invalid JSON, or invalid replacements must preserve the original payload.
+- Add config validation and tests for the new provider type.
+- See [`tool-optimizers.md`](tool-optimizers.md) for the config protocols (`rtk_cli`, `exec_json`, and `noop`).
+
+### Add or extend a provider type
+
+- Register the provider kind in `proxy/providers.go` and its endpoint policy in `proxy/provider_endpoint_policy.go`.
+- Keep upstream deployment names internal to provider config; public model IDs remain global.
+- Treat `models[].endpoints` as a verified allowlist. Do not advertise routes that have not been tested for that provider/model.
+- Preserve startup failure on public-model-ID collisions.
+- Cross-link config examples in [`provider-routing.md`](provider-routing.md) instead of duplicating YAML here.

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -58,4 +58,8 @@ Use `curl -N` or another SSE-capable client so streamed frames are not buffered 
 
 ## `POST /v1beta/models/{model}:countTokens`, `POST /v1/models/{model}:countTokens`, and `POST /models/{model}:countTokens` (Gemini)
 
-`countTokens` uses the same accepted route prefixes as the other Gemini compatibility routes. It normalizes the Gemini request into the same prompt/tool payload used by `generateContent`, performs a minimal upstream `/chat/completions` probe, and returns `usage.prompt_tokens` as Gemini `totalTokens`. Normalized requests are cached for 60 seconds.
+`countTokens` uses the same accepted route prefixes as the other Gemini compatibility routes. It normalizes the Gemini request into the same prompt/tool payload used by `generateContent`, performs a minimal upstream `/chat/completions` probe, and returns `usage.prompt_tokens` as Gemini `totalTokens`. Normalized successful requests are cached for 60 seconds. If the probe hits a transient transport error, 429, 5xx, or a 200 response with missing usage, the proxy returns a dependency-free local token estimate instead of failing the counting request. It still surfaces permanent client/configuration failures such as 400, 401, and 403 without estimating.
+
+### Function calling `VALIDATED` mode
+
+Gemini `functionCallingConfig.mode: "VALIDATED"` is accepted and translated to OpenAI `tool_choice: "auto"`. OpenAI Chat Completions has no equivalent schema-validation-guarantee tier, so this is a lossy compatibility mapping: the model may decide whether to call a tool, but any Gemini-specific validation guarantee is not preserved by the OpenAI-shaped upstream request.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.18.6
+	golang.org/x/net v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -21,7 +22,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,6 +4,7 @@ package logger
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -40,13 +41,22 @@ func ParseLevel(s string) Level {
 
 // Logger writes structured JSON log entries to stderr.
 type Logger struct {
-	level Level
-	mu    sync.Mutex
+	level  Level
+	writer io.Writer
+	mu     sync.Mutex
 }
 
 // New creates a Logger that emits messages at or above the given level.
 func New(level Level) *Logger {
-	return &Logger{level: level}
+	return NewWithWriter(level, os.Stderr)
+}
+
+// NewWithWriter creates a Logger that writes to w. A nil writer falls back to stderr.
+func NewWithWriter(level Level, w io.Writer) *Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	return &Logger{level: level, writer: w}
 }
 
 func (l *Logger) log(level Level, msg string, fields map[string]interface{}) {
@@ -64,7 +74,7 @@ func (l *Logger) log(level Level, msg string, fields map[string]interface{}) {
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	_ = json.NewEncoder(os.Stderr).Encode(e)
+	_ = json.NewEncoder(l.writer).Encode(e)
 }
 
 // Debug logs a message at debug level.

--- a/models/openai.go
+++ b/models/openai.go
@@ -100,9 +100,21 @@ type OpenAIChoice struct {
 
 // OpenAIUsage contains token usage statistics.
 type OpenAIUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens            int                            `json:"prompt_tokens"`
+	CompletionTokens        int                            `json:"completion_tokens"`
+	TotalTokens             int                            `json:"total_tokens"`
+	PromptTokensDetails     *OpenAIPromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *OpenAICompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+// OpenAIPromptTokensDetails contains prompt-token detail breakdowns.
+type OpenAIPromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens,omitempty"`
+}
+
+// OpenAICompletionTokensDetails contains completion-token detail breakdowns.
+type OpenAICompletionTokensDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 }
 
 // OpenAIStreamChunk is a single SSE chunk in an OpenAI streaming response.

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -73,6 +73,29 @@ func prepareAnthropicChatCompletionsRequest(req *models.AnthropicRequest) ([]byt
 	return body, mode, nil
 }
 
+func mapAnthropicUpstreamStatus(statusCode int) string {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusRequestEntityTooLarge:
+		return "request_too_large"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case http.StatusServiceUnavailable, 529:
+		return "overloaded_error"
+	case http.StatusInternalServerError:
+		return "api_error"
+	default:
+		return "api_error"
+	}
+}
+
 func anthropicExtraHeadersFromRequest(r *http.Request) http.Header {
 	var headers http.Header
 	for _, name := range []string{
@@ -117,11 +140,7 @@ func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *
 			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
 			return
 		}
-		if statusCode == http.StatusInternalServerError {
-			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
-			return
-		}
-		writeAnthropicError(w, statusCode, "api_error", formatUpstreamRequestFailure(err, "upstream request failed"))
+		writeAnthropicError(w, statusCode, mapAnthropicUpstreamStatus(statusCode), formatUpstreamRequestFailure(err, "upstream request failed"))
 		return
 	}
 
@@ -152,11 +171,7 @@ func (h *ProxyHandler) forwardAnthropicCountTokensDirect(w http.ResponseWriter, 
 			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
 			return
 		}
-		if statusCode == http.StatusInternalServerError {
-			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
-			return
-		}
-		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
+		writeAnthropicError(w, statusCode, mapAnthropicUpstreamStatus(statusCode), formatUpstreamRequestFailure(err, "upstream request failed"))
 		return
 	}
 
@@ -217,14 +232,15 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 	body, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
-		writeAnthropicError(w, status, "invalid_request_error", err.Error())
+		writeAnthropicError(w, status, mapAnthropicUpstreamStatus(status), err.Error())
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
 
 	var req models.AnthropicRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON in request body")
+		message, _ := jsonDecodeErrorDetails(err, "invalid JSON in request body")
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", message)
 		return
 	}
 
@@ -235,7 +251,14 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 		logger.F("tools", len(req.Tools)),
 	)
 
-	if h.shouldForwardAnthropicMessagesDirect(req.Model) {
+	directAnthropic := h.shouldForwardAnthropicMessagesDirect(req.Model)
+	providerEndpoint := providerEndpointChatCompletions
+	if directAnthropic {
+		providerEndpoint = providerEndpointMessages
+	}
+	h.observeRequestSummary(r.Context(), "anthropic", req.Model, req.Stream, providerEndpoint)
+
+	if directAnthropic {
 		h.forwardAnthropicMessagesDirect(w, r, body, &req)
 		return
 	}
@@ -259,24 +282,24 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
 			return
 		}
-		if statusCode == http.StatusInternalServerError {
-			writeAnthropicError(w, statusCode, "api_error", "authentication failed")
-			return
-		}
-		writeAnthropicError(w, statusCode, "api_error", formatUpstreamRequestFailure(err, "upstream request failed"))
+		writeAnthropicError(w, statusCode, mapAnthropicUpstreamStatus(statusCode), formatUpstreamRequestFailure(err, "upstream request failed"))
 		return
 	}
+
+	observeUpstreamHeaders(r.Context(), resp.Header)
 
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		detail := formatUpstreamErrorMessage(resp.StatusCode, errBody)
 		h.log.Error("upstream error",
 			logger.F("endpoint", "anthropic"),
 			logger.F("status", resp.StatusCode),
-			logger.F("body", string(errBody)),
+			logger.F("detail", detail),
 			logger.F("request_bytes", len(oaiBody)),
 		)
-		writeAnthropicError(w, resp.StatusCode, "api_error", formatUpstreamErrorMessage(resp.StatusCode, errBody))
+		h.log.Debug("upstream error body", logger.F("endpoint", "anthropic"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
+		writeAnthropicError(w, resp.StatusCode, mapAnthropicUpstreamStatus(resp.StatusCode), detail)
 		return
 	}
 
@@ -291,6 +314,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 			)
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			observeOpenAIUsage(r.Context(), oaiResp.Usage)
 			h.maybeRewriteOrCaptureOpenAIChatToolCommands(r.Context(), oaiResp, h.toolContexts, scope, false)
 			anthropicResp := TranslateOpenAIToAnthropic(oaiResp, req.Model)
 			w.Header().Set("Content-Type", "application/json")
@@ -310,18 +334,26 @@ func (h *ProxyHandler) HandleAnthropicMessagesCountTokens(w http.ResponseWriter,
 	body, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
-		writeAnthropicError(w, status, "invalid_request_error", err.Error())
+		writeAnthropicError(w, status, mapAnthropicUpstreamStatus(status), err.Error())
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
 
 	var req models.AnthropicRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON in request body")
+		message, _ := jsonDecodeErrorDetails(err, "invalid JSON in request body")
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", message)
 		return
 	}
 
-	if h.shouldForwardAnthropicCountTokensDirect(req.Model) {
+	directAnthropic := h.shouldForwardAnthropicCountTokensDirect(req.Model)
+	providerEndpoint := providerEndpointChatCompletions
+	if directAnthropic {
+		providerEndpoint = providerEndpointMessages
+	}
+	h.observeRequestSummary(r.Context(), "anthropic_count_tokens", req.Model, false, providerEndpoint)
+
+	if directAnthropic {
 		h.forwardAnthropicCountTokensDirect(w, r, body)
 		return
 	}
@@ -340,7 +372,7 @@ func (h *ProxyHandler) HandleAnthropicMessagesCountTokens(w http.ResponseWriter,
 			writeAnthropicError(w, statusCode, "invalid_request_error", err.Error())
 			return
 		}
-		writeAnthropicError(w, statusCode, "api_error", "upstream request failed")
+		writeAnthropicError(w, statusCode, mapAnthropicUpstreamStatus(statusCode), formatUpstreamRequestFailure(err, "upstream request failed"))
 		return
 	}
 
@@ -430,8 +462,10 @@ func (h *ProxyHandler) decodeAnthropicCountTokensProbeResponse(resp *http.Respon
 
 	if resp.StatusCode != http.StatusOK {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		h.log.Error("upstream error", logger.F("endpoint", "anthropic_count_tokens"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
-		return nil, &upstreamError{statusCode: resp.StatusCode}
+		detail := formatUpstreamErrorMessage(resp.StatusCode, errBody)
+		h.log.Error("upstream error", logger.F("endpoint", "anthropic_count_tokens"), logger.F("status", resp.StatusCode), logger.F("detail", detail))
+		h.log.Debug("upstream error body", logger.F("endpoint", "anthropic_count_tokens"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
+		return nil, &upstreamError{statusCode: resp.StatusCode, body: errBody}
 	}
 
 	var oaiResp models.OpenAIResponse
@@ -448,13 +482,20 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	bodyBytes, err := readBody(r)
 	if err != nil {
 		status := readBodyStatusCode(err)
-		writeOpenAIError(w, status, err.Error(), "invalid_request_error")
+		writeOpenAIRequestBodyError(w, status, err)
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
 
+	if message, param, ok := validateOpenAIChatRequest(bodyBytes); ok {
+		writeOpenAIErrorWithDetails(w, http.StatusBadRequest, message, "invalid_request_error", param, "")
+		return
+	}
+
+	requestedModel := extractRequestModel(bodyBytes)
 	scope := chatToolExecutionScopeFromHeaders(r.Header)
 	bodyBytes, mode := prepareOpenAIChatCompletionsRequest(bodyBytes)
+	h.observeRequestSummary(r.Context(), "openai_chat", requestedModel, mode.clientRequestedStream, providerEndpointChatCompletions)
 	bodyBytes = h.rewriteOpenAIChatRequestBodyWithToolOptimizers(r.Context(), bodyBytes, h.toolContexts, scope)
 
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(mode.clientRequestedStream || mode.forceUpstreamStream)
@@ -468,20 +509,19 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
 			return
 		}
-		if statusCode == http.StatusInternalServerError {
-			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
-			return
-		}
 		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
 
+	observeUpstreamHeaders(r.Context(), resp.Header)
+
 	err = h.routeChatCompletionsResponse(w, resp, mode, chatCompletionsResponseHandlers{
 		stream: func(resp *http.Response) {
 			copyPassthroughHeaders(w.Header(), resp.Header)
-			StreamOpenAIPassthroughWithFinalResponse(w, resp.Body, h.openAIChatStreamFinalResponseCallback(r.Context(), h.toolContexts, scope))
+			StreamOpenAIPassthroughWithFinalResponse(w, resp.Body, h.openAIChatStreamFinalResponseCallback(r.Context(), h.toolContexts, scope), openAIChatStreamUsageCallback(r.Context()))
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			observeOpenAIUsage(r.Context(), oaiResp.Usage)
 			h.maybeRewriteOrCaptureOpenAIChatToolCommands(r.Context(), oaiResp, h.toolContexts, scope, false)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(oaiResp)
@@ -493,6 +533,65 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	if err != nil {
 		writeOpenAIError(w, http.StatusBadGateway, "failed to aggregate upstream response", "server_error")
 	}
+}
+
+func validateOpenAIChatRequest(body []byte) (string, string, bool) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", "", false
+	}
+	if rawMessages, ok := payload["messages"]; !ok || !rawJSONHasNonEmptyArray(rawMessages) {
+		return "messages must be a non-empty array", "messages", true
+	}
+	if rawToolChoice, ok := payload["tool_choice"]; ok && openAIToolChoiceRequiresTools(rawToolChoice) && !hasNonEmptyTools(payload["tools"]) {
+		return "tool_choice requires non-empty tools", "tool_choice", true
+	}
+	if rawResponseFormat, ok := payload["response_format"]; ok && responseFormatMissingJSONSchema(rawResponseFormat) {
+		return "response_format json_schema requires json_schema.schema", "response_format.json_schema.schema", true
+	}
+	return "", "", false
+}
+
+func rawJSONHasNonEmptyArray(raw json.RawMessage) bool {
+	var values []json.RawMessage
+	return json.Unmarshal(raw, &values) == nil && len(values) > 0
+}
+
+func openAIToolChoiceRequiresTools(raw json.RawMessage) bool {
+	var choice string
+	if err := json.Unmarshal(raw, &choice); err == nil {
+		choice = strings.TrimSpace(choice)
+		return choice == "required"
+	}
+	var object struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return false
+	}
+	switch strings.TrimSpace(object.Type) {
+	case "required", "function":
+		return true
+	default:
+		return false
+	}
+}
+
+func responseFormatMissingJSONSchema(raw json.RawMessage) bool {
+	var format struct {
+		Type       string          `json:"type"`
+		JSONSchema json.RawMessage `json:"json_schema"`
+	}
+	if err := json.Unmarshal(raw, &format); err != nil || strings.TrimSpace(format.Type) != "json_schema" {
+		return false
+	}
+	var schema struct {
+		Schema json.RawMessage `json:"schema"`
+	}
+	if err := json.Unmarshal(format.JSONSchema, &schema); err != nil {
+		return true
+	}
+	return len(bytes.TrimSpace(schema.Schema)) == 0 || string(bytes.TrimSpace(schema.Schema)) == "null"
 }
 
 func hasNonEmptyTools(raw json.RawMessage) bool {
@@ -519,6 +618,9 @@ func injectParallelToolCalls(body []byte) []byte {
 	if !hasTools || !hasNonEmptyTools(tools) {
 		return body
 	}
+	if rawToolChoice, ok := m["tool_choice"]; ok && openAIToolChoiceIsNone(rawToolChoice) {
+		return body
+	}
 	if _, hasPTC := m["parallel_tool_calls"]; hasPTC {
 		return body
 	}
@@ -528,6 +630,20 @@ func injectParallelToolCalls(body []byte) []byte {
 		return body
 	}
 	return result
+}
+
+func openAIToolChoiceIsNone(raw json.RawMessage) bool {
+	var choice string
+	if err := json.Unmarshal(raw, &choice); err == nil {
+		return strings.EqualFold(strings.TrimSpace(choice), "none")
+	}
+	var object struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &object); err == nil {
+		return strings.EqualFold(strings.TrimSpace(object.Type), "none")
+	}
+	return false
 }
 
 // injectForceStream adds stream: true and stream_options to a request body

--- a/proxy/gemini.go
+++ b/proxy/gemini.go
@@ -415,7 +415,7 @@ func TranslateGeminiToOpenAI(req *models.GeminiGenerateContentRequest, pathModel
 		oaiReq.Tools = filterGeminiAllowedTools(oaiReq.Tools, req.ToolConfig.FunctionCallingConfig)
 	}
 
-	if len(oaiReq.Tools) > 0 {
+	if len(oaiReq.Tools) > 0 && !openAIToolChoiceIsNone(oaiReq.ToolChoice) {
 		parallelToolCalls := true
 		oaiReq.ParallelToolCalls = &parallelToolCalls
 	}
@@ -774,7 +774,7 @@ func translateGeminiToolChoice(config *models.GeminiFunctionCallingConfig, decla
 	}
 
 	mode := strings.ToUpper(strings.TrimSpace(config.Mode))
-	if len(config.AllowedFunctionNames) == 1 && mode != "NONE" {
+	if len(config.AllowedFunctionNames) == 1 && mode != "NONE" && mode != "VALIDATED" {
 		return json.Marshal(map[string]interface{}{
 			"type": "function",
 			"function": map[string]string{
@@ -784,7 +784,7 @@ func translateGeminiToolChoice(config *models.GeminiFunctionCallingConfig, decla
 	}
 
 	switch mode {
-	case "", "AUTO":
+	case "", "AUTO", "VALIDATED":
 		return json.Marshal("auto")
 	case "NONE":
 		return json.Marshal("none")

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -67,6 +67,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 		logger.F("contents", len(req.Contents)),
 		logger.F("tools", len(req.Tools)),
 	)
+	h.observeRequestSummary(r.Context(), "gemini", pathModel, stream, providerEndpointChatCompletions)
 
 	scope := chatToolExecutionScopeFromHeaders(r.Header)
 	oaiReq, err := TranslateGeminiToOpenAI(req, pathModel, stream)
@@ -98,15 +99,19 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 		return
 	}
 
+	observeUpstreamHeaders(r.Context(), resp.Header)
+
 	if resp.StatusCode != http.StatusOK {
 		defer func() { _ = resp.Body.Close() }()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		detail := formatUpstreamErrorMessage(resp.StatusCode, errBody)
 		h.log.Error("upstream error",
 			logger.F("endpoint", "gemini"),
 			logger.F("status", resp.StatusCode),
-			logger.F("body", string(errBody)),
+			logger.F("detail", detail),
 			logger.F("request_bytes", len(oaiBody)),
 		)
+		h.log.Debug("upstream error body", logger.F("endpoint", "gemini"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
 		writeGeminiError(w, resp.StatusCode, mapGeminiUpstreamStatus(resp.StatusCode), formatUpstreamErrorMessage(resp.StatusCode, errBody))
 		return
 	}
@@ -120,6 +125,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 			StreamOpenAIToGeminiWithFinalResponse(w, resp.Body, h.openAIChatStreamFinalResponseCallback(r.Context(), h.toolContexts, scope))
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			observeOpenAIUsage(r.Context(), oaiResp.Usage)
 			h.maybeRewriteOrCaptureOpenAIChatToolCommands(r.Context(), oaiResp, h.toolContexts, scope, false)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(TranslateOpenAIToGemini(oaiResp))
@@ -130,6 +136,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 			if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 				return err
 			}
+			observeOpenAIUsage(r.Context(), parsed.Usage)
 			h.maybeRewriteOrCaptureOpenAIChatToolCommands(r.Context(), &parsed, h.toolContexts, scope, false)
 
 			w.Header().Set("Content-Type", "application/json")
@@ -166,6 +173,7 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 		h.writeGeminiProtocolError(w, err)
 		return
 	}
+	h.observeRequestSummary(r.Context(), "gemini_count_tokens", pathModel, false, providerEndpointChatCompletions)
 
 	cacheKey, err := hashOpenAIRequest(oaiReq)
 	if err != nil {
@@ -181,12 +189,24 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 
 	oaiResp, err := h.runGeminiCountTokensProbe(oaiReq)
 	if err != nil {
+		var estimateErr *geminiCountTokensEstimateError
+		if errors.As(err, &estimateErr) {
+			estimated := buildEstimatedGeminiCountTokensResult(req, estimateOpenAIRequestTokens(oaiReq))
+			h.log.Debug("using estimated Gemini token count", logger.F("reason", estimateErr.reason), logger.F("total_tokens", estimated.TotalTokens), logger.Err(estimateErr.Unwrap()))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(estimated)
+			return
+		}
 		h.writeGeminiProtocolError(w, err)
 		return
 	}
 
 	if oaiResp.Usage == nil {
-		writeGeminiError(w, http.StatusInternalServerError, "INTERNAL", "upstream response did not include usage")
+		estimated := buildEstimatedGeminiCountTokensResult(req, estimateOpenAIRequestTokens(oaiReq))
+		h.log.Debug("using estimated Gemini token count", logger.F("reason", "missing_usage"), logger.F("total_tokens", estimated.TotalTokens))
+		h.setGeminiCountTokensCache(cacheKey, estimated)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(estimated)
 		return
 	}
 
@@ -204,6 +224,48 @@ func (h *ProxyHandler) handleGeminiCountTokens(w http.ResponseWriter, r *http.Re
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
+}
+
+func buildEstimatedGeminiCountTokensResult(req *models.GeminiGenerateContentRequest, total int) models.GeminiCountTokensResponse {
+	if total <= 0 {
+		total = 1
+	}
+	result := models.GeminiCountTokensResponse{TotalTokens: total}
+	if !geminiRequestHasInlineMedia(req) {
+		result.PromptTokensDetails = []models.GeminiTokenCountDetails{{
+			Modality:   "TEXT",
+			TokenCount: total,
+		}}
+	}
+	return result
+}
+
+func estimateOpenAIRequestTokens(req *models.OpenAIRequest) int {
+	if req == nil {
+		return 1
+	}
+	bytes := len(req.Model)
+	for _, msg := range req.Messages {
+		bytes += len(msg.Role) + len(msg.Name) + len(msg.Content) + len(msg.ToolCallID)
+		for _, call := range msg.ToolCalls {
+			bytes += len(call.ID) + len(call.Type) + len(call.Function.Name) + len(call.Function.Arguments)
+		}
+	}
+	for _, tool := range req.Tools {
+		encoded, _ := json.Marshal(tool)
+		bytes += len(encoded)
+	}
+	if len(req.ResponseFormat) > 0 {
+		bytes += len(req.ResponseFormat)
+	}
+	estimate := bytes / 4
+	if bytes%4 != 0 {
+		estimate++
+	}
+	if estimate <= 0 {
+		estimate = 1
+	}
+	return estimate
 }
 
 func geminiRequestHasInlineMedia(req *models.GeminiGenerateContentRequest) bool {
@@ -282,7 +344,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequ
 
 	resp, err := h.postChatCompletions(upstreamCtx, body)
 	if err != nil {
-		return nil, false, mapGeminiTransportError(err)
+		return nil, false, mapGeminiCountTokensTransportError(err)
 	}
 
 	if resp.StatusCode == http.StatusBadRequest && probeReq.MaxCompletionTokens != nil {
@@ -308,7 +370,7 @@ func (h *ProxyHandler) executeGeminiCountTokensProbeFinal(probeReq *models.OpenA
 
 	resp, err := h.postChatCompletions(upstreamCtx, body)
 	if err != nil {
-		return nil, mapGeminiTransportError(err)
+		return nil, mapGeminiCountTokensTransportError(err)
 	}
 
 	oaiResp, _, err := h.decodeGeminiProbeResponse(resp)
@@ -320,12 +382,18 @@ func (h *ProxyHandler) decodeGeminiProbeResponse(resp *http.Response) (*models.O
 
 	if resp.StatusCode != http.StatusOK {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		h.log.Error("upstream error", logger.F("endpoint", "gemini_count_tokens"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
-		return nil, false, &geminiProtocolError{
+		detail := formatUpstreamErrorMessage(resp.StatusCode, errBody)
+		h.log.Error("upstream error", logger.F("endpoint", "gemini_count_tokens"), logger.F("status", resp.StatusCode), logger.F("detail", detail))
+		h.log.Debug("upstream error body", logger.F("endpoint", "gemini_count_tokens"), logger.F("status", resp.StatusCode), logger.F("body", string(errBody)))
+		protocolErr := &geminiProtocolError{
 			statusCode: resp.StatusCode,
 			status:     mapGeminiUpstreamStatus(resp.StatusCode),
-			message:    formatUpstreamErrorMessage(resp.StatusCode, errBody),
+			message:    detail,
 		}
+		if geminiCountTokensShouldEstimateStatus(resp.StatusCode) {
+			return nil, false, &geminiCountTokensEstimateError{reason: fmt.Sprintf("upstream_status_%d", resp.StatusCode), err: protocolErr}
+		}
+		return nil, false, protocolErr
 	}
 
 	var oaiResp models.OpenAIResponse
@@ -338,6 +406,44 @@ func (h *ProxyHandler) decodeGeminiProbeResponse(resp *http.Response) (*models.O
 	}
 
 	return &oaiResp, false, nil
+}
+
+type geminiCountTokensEstimateError struct {
+	reason string
+	err    error
+}
+
+func (e *geminiCountTokensEstimateError) Error() string {
+	if e == nil || e.err == nil {
+		return "Gemini countTokens estimate fallback"
+	}
+	return e.err.Error()
+}
+
+func (e *geminiCountTokensEstimateError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func geminiCountTokensShouldEstimateStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+}
+
+func mapGeminiCountTokensTransportError(err error) error {
+	var providerErr *providerRequestError
+	if errors.As(err, &providerErr) {
+		return mapGeminiTransportError(err)
+	}
+	var upstreamErr *upstreamError
+	if errors.As(err, &upstreamErr) && geminiCountTokensShouldEstimateStatus(upstreamErr.statusCode) {
+		return &geminiCountTokensEstimateError{reason: fmt.Sprintf("upstream_status_%d", upstreamErr.statusCode), err: mapGeminiTransportError(err)}
+	}
+	if permanentTransportError(err) {
+		return mapGeminiTransportError(err)
+	}
+	return &geminiCountTokensEstimateError{reason: "transport_error", err: mapGeminiTransportError(err)}
 }
 
 func (h *ProxyHandler) writeGeminiProtocolError(w http.ResponseWriter, err error) {

--- a/proxy/gemini_streaming.go
+++ b/proxy/gemini_streaming.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,6 +56,7 @@ func StreamOpenAIToGeminiWithFinalResponse(
 	w http.ResponseWriter,
 	body io.ReadCloser,
 	onFinalResponse func(*models.OpenAIResponse),
+	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
 	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
@@ -64,14 +66,28 @@ func StreamOpenAIToGeminiWithFinalResponse(
 	if onFinalResponse != nil {
 		aggregator = newOpenAIResponseAggregator()
 	}
+	onUsage := firstOpenAIUsageCallback(onUsageCallbacks)
 
 	sawDone, err := consumeOpenAIStreamChunks(body, func(chunk models.OpenAIStreamChunk) bool {
+		if onUsage != nil && chunk.Usage != nil {
+			onUsage(chunk.Usage)
+		}
 		if aggregator != nil {
 			aggregator.addChunk(chunk)
 		}
 		return state.consumeChunk(chunk)
 	})
-	if err != nil || !sawDone {
+	if err != nil {
+		var streamErr *openAIStreamError
+		if errors.As(err, &streamErr) {
+			state.writeError(streamErr.Error())
+			return
+		}
+		state.writeError(fmt.Sprintf("upstream stream read failed: %v", err))
+		return
+	}
+	if !sawDone {
+		state.writeError("upstream stream ended before [DONE]")
 		return
 	}
 
@@ -296,4 +312,18 @@ func (s *geminiStreamState) writeTail() bool {
 
 func (s *geminiStreamState) writeData(data interface{}) bool {
 	return writeGeminiSSEData(s.w, data) == nil
+}
+
+func (s *geminiStreamState) writeError(message string) bool {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "upstream stream ended unexpectedly"
+	}
+	return s.writeData(models.GeminiErrorResponse{
+		Error: models.GeminiError{
+			Code:    http.StatusBadGateway,
+			Message: message,
+			Status:  "UNAVAILABLE",
+		},
+	})
 }

--- a/proxy/gemini_streaming_test.go
+++ b/proxy/gemini_streaming_test.go
@@ -465,8 +465,8 @@ func TestStreamOpenAIToGemini_NoTailWithoutDone(t *testing.T) {
 	StreamOpenAIToGemini(w, body)
 
 	frames := parseGeminiSSEFrames(w.Body.String())
-	if len(frames) != 1 {
-		t.Fatalf("len(frames) = %d, want 1\nraw:\n%s", len(frames), w.Body.String())
+	if len(frames) != 2 {
+		t.Fatalf("len(frames) = %d, want 2\nraw:\n%s", len(frames), w.Body.String())
 	}
 
 	var first models.GeminiGenerateContentResponse
@@ -478,5 +478,12 @@ func TestStreamOpenAIToGemini_NoTailWithoutDone(t *testing.T) {
 	}
 	if len(first.Candidates) == 0 || first.Candidates[0].FinishReason != "" {
 		t.Fatalf("unexpected finish reason in non-terminal frame: %#v", first.Candidates)
+	}
+	var errFrame models.GeminiErrorResponse
+	if err := json.Unmarshal([]byte(frames[1]), &errFrame); err != nil {
+		t.Fatalf("unmarshal error frame: %v", err)
+	}
+	if errFrame.Error.Message == "" {
+		t.Fatalf("expected truncation error frame, got %#v", errFrame)
 	}
 }

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2493,4 +2494,122 @@ func TestHandleGeminiModelsErrors(t *testing.T) {
 
 func floatPtr(v float64) *float64 {
 	return &v
+}
+
+func TestHandleGeminiModelsCountTokensEstimatesOnTransientFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "rate limit", status: http.StatusTooManyRequests},
+		{name: "server error", status: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(`{"error":{"message":"temporary"}}`))
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{"contents":[{"role":"user","parts":[{"text":"Count this transient fallback request"}]}]}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			handler.HandleGeminiModels(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("StatusCode = %d, want 200 estimate: %s", resp.StatusCode, string(body))
+			}
+			var countResp models.GeminiCountTokensResponse
+			if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if countResp.TotalTokens <= 0 {
+				t.Fatalf("TotalTokens = %d, want positive estimate", countResp.TotalTokens)
+			}
+			if calls.Load() == 0 {
+				t.Fatal("upstream was not called")
+			}
+		})
+	}
+}
+
+func TestHandleGeminiModelsCountTokensEstimatesOnTransportError(t *testing.T) {
+	var calls atomic.Int32
+	handler := newRoundTripTestProxyHandler(t, func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, io.ErrUnexpectedEOF
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{"contents":[{"role":"user","parts":[{"text":"Count this after a transport failure"}]}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200 estimate: %s", resp.StatusCode, string(body))
+	}
+	var countResp models.GeminiCountTokensResponse
+	if err := json.NewDecoder(resp.Body).Decode(&countResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if countResp.TotalTokens <= 0 {
+		t.Fatalf("TotalTokens = %d, want positive estimate", countResp.TotalTokens)
+	}
+	if calls.Load() == 0 {
+		t.Fatal("transport was not called")
+	}
+}
+
+func TestHandleGeminiModelsCountTokensDoesNotEstimatePermanentUpstreamErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "bad request", status: http.StatusBadRequest},
+		{name: "unauthorized", status: http.StatusUnauthorized},
+		{name: "forbidden", status: http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+				call := calls.Add(1)
+				// The first 400 probes max_completion_tokens compatibility and may fall back
+				// to max_tokens. Keep returning 400 to verify the final client/config error
+				// is surfaced rather than converted into an estimate.
+				_ = call
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(`{"error":{"message":"permanent"}}`))
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:countTokens", strings.NewReader(`{"contents":[{"role":"user","parts":[{"text":"Count this permanent failure"}]}]}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			handler.HandleGeminiModels(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != tt.status {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("StatusCode = %d, want %d: %s", resp.StatusCode, tt.status, string(body))
+			}
+			var errResp models.GeminiErrorResponse
+			if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if errResp.Error.Message == "" {
+				t.Fatalf("expected real error response, got %#v", errResp)
+			}
+		})
+	}
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
 	"github.com/sozercan/vekil/models"
+	"golang.org/x/net/http2"
 )
 
 const (
@@ -239,6 +240,9 @@ type ProxyHandler struct {
 	toolOptimizers                  *ToolOptimizerManager
 	toolContexts                    *ToolExecutionContextStore
 	responsesWS                     ResponsesWebSocketConfig
+	responsesWSSessionsMu           sync.Mutex
+	responsesWSSessions             map[*responsesWebSocketSession]struct{}
+	responsesWSDraining             bool
 	streamingUpstreamTimeout        time.Duration
 	compactChunkBodyBytes           int
 	compactChunkConfigured          bool
@@ -413,19 +417,39 @@ func WithCompactUpstreamMaxAttempts(max int) Option {
 	}
 }
 
+func newInferenceTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 100
+	transport.IdleConnTimeout = 55 * time.Second
+	transport.ForceAttemptHTTP2 = true
+
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	tlsConfig.MinVersion = tls.VersionTLS12
+	if tlsConfig.ClientSessionCache == nil {
+		tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(0)
+	}
+	transport.TLSClientConfig = tlsConfig
+
+	if h2Transport, err := http2.ConfigureTransports(transport); err == nil {
+		h2Transport.ReadIdleTimeout = 30 * time.Second
+		h2Transport.PingTimeout = 15 * time.Second
+	}
+
+	return transport
+}
+
 // NewProxyHandler creates a ProxyHandler with connection pooling and HTTP/2.
 func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) (*ProxyHandler, error) {
 	h := &ProxyHandler{
 		auth: a,
 		client: &http.Client{
-			Transport: &http.Transport{
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 100,
-				IdleConnTimeout:     90 * time.Second,
-				TLSHandshakeTimeout: 10 * time.Second,
-				ForceAttemptHTTP2:   true,
-				TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
-			},
+			Transport: newInferenceTransport(),
 		},
 		copilotURL: "https://api.githubcopilot.com",
 		// Keep global Copilot header overrides empty by default. Header application
@@ -815,10 +839,6 @@ func (h *ProxyHandler) HandleModels(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
-		if statusCode == http.StatusInternalServerError {
-			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
-			return
-		}
 		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 		return
 	}
@@ -1175,29 +1195,75 @@ func writeAnthropicError(w http.ResponseWriter, status int, errType, message str
 	})
 }
 
+var upstreamRequestIDHeaderNames = []string{"X-Request-Id", "X-Azure-Request-Id", "Openai-Request-Id"}
+
+// UpstreamRequestID returns the first recognized upstream request id from headers.
+func UpstreamRequestID(headers http.Header) string {
+	for _, name := range upstreamRequestIDHeaderNames {
+		if value := headers.Get(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 func writeOpenAIErrorWithRetryAfter(w http.ResponseWriter, status int, message, errType, retryAfter string, upstreamHeaders http.Header) {
+	writeOpenAIErrorWithRetryAfterDetails(w, status, message, errType, retryAfter, upstreamHeaders, "", "")
+}
+
+func writeOpenAIErrorWithRetryAfterDetails(w http.ResponseWriter, status int, message, errType, retryAfter string, upstreamHeaders http.Header, param, code string) {
 	w.Header().Set("Content-Type", "application/json")
 	if retryAfter != "" {
 		w.Header().Set("Retry-After", retryAfter)
 	}
-	for _, name := range []string{"X-Request-Id", "X-Azure-Request-Id", "Openai-Request-Id"} {
+	for _, name := range upstreamRequestIDHeaderNames {
 		for _, value := range headerValuesCI(upstreamHeaders, name) {
 			w.Header().Add(name, value)
 		}
+	}
+	var paramValue interface{}
+	if strings.TrimSpace(param) != "" {
+		paramValue = strings.TrimSpace(param)
+	}
+	var codeValue interface{}
+	if strings.TrimSpace(code) != "" {
+		codeValue = strings.TrimSpace(code)
 	}
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"error": map[string]interface{}{
 			"message": message,
 			"type":    errType,
-			"param":   nil,
-			"code":    nil,
+			"param":   paramValue,
+			"code":    codeValue,
 		},
 	})
 }
 
 func writeOpenAIError(w http.ResponseWriter, status int, message, errType string) {
 	writeOpenAIErrorWithRetryAfter(w, status, message, errType, "", nil)
+}
+
+func writeOpenAIRequestBodyError(w http.ResponseWriter, status int, err error) {
+	message := err.Error()
+	code := ""
+	if status == http.StatusRequestEntityTooLarge {
+		code = "request_too_large"
+	}
+	writeOpenAIErrorWithDetails(w, status, message, "invalid_request_error", "", code)
+}
+
+func jsonDecodeErrorDetails(err error, fallback string) (string, string) {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) && strings.TrimSpace(typeErr.Field) != "" {
+		field := strings.TrimSpace(typeErr.Field)
+		return fmt.Sprintf("invalid value for field %q: expected %s", field, typeErr.Type), field
+	}
+	return fallback, ""
+}
+
+func writeOpenAIErrorWithDetails(w http.ResponseWriter, status int, message, errType, param, code string) {
+	writeOpenAIErrorWithRetryAfterDetails(w, status, message, errType, "", nil, param, code)
 }
 
 // readBody reads the request body up to maxRequestBodySize. If the body exceeds

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -778,8 +778,8 @@ func TestHandleAnthropicUpstreamError(t *testing.T) {
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		t.Fatalf("failed to parse error response: %v", err)
 	}
-	if errResp.Error.Type != "api_error" {
-		t.Errorf("expected error type api_error, got %q", errResp.Error.Type)
+	if errResp.Error.Type != "invalid_request_error" {
+		t.Errorf("expected error type invalid_request_error, got %q", errResp.Error.Type)
 	}
 	for _, want := range []string{"upstream error (400)", "tool schema is invalid", "type=invalid_request_error", "param=tools.0", "code=invalid_tool_schema"} {
 		if !strings.Contains(errResp.Error.Message, want) {
@@ -6749,11 +6749,12 @@ func TestHandleOpenAIChatCompletions_RejectsConfiguredAzureModelWithoutChatSuppo
 		logger.New(logger.LevelInfo),
 		WithProvidersConfig(ProvidersConfig{
 			Providers: []ProviderConfig{{
-				ID:        "azure",
-				Type:      "azure-openai",
-				Default:   true,
-				BaseURL:   "https://example.openai.azure.com/openai",
-				APIKeyEnv: "TEST_AZURE_API_KEY",
+				ID:         "azure",
+				Type:       "azure-openai",
+				Default:    true,
+				BaseURL:    "https://example.openai.azure.com/openai",
+				APIVersion: "2025-04-01-preview",
+				APIKeyEnv:  "TEST_AZURE_API_KEY",
 				Models: []ProviderModelConfig{{
 					PublicID:   "gpt-5.4-pro",
 					Deployment: "gpt-5.4-pro",
@@ -6803,11 +6804,12 @@ func TestHandleResponses_RejectsConfiguredAzureModelWithoutResponsesSupport(t *t
 		logger.New(logger.LevelInfo),
 		WithProvidersConfig(ProvidersConfig{
 			Providers: []ProviderConfig{{
-				ID:        "azure",
-				Type:      "azure-openai",
-				Default:   true,
-				BaseURL:   "https://example.openai.azure.com/openai",
-				APIKeyEnv: "TEST_AZURE_API_KEY",
+				ID:         "azure",
+				Type:       "azure-openai",
+				Default:    true,
+				BaseURL:    "https://example.openai.azure.com/openai",
+				APIVersion: "2025-04-01-preview",
+				APIKeyEnv:  "TEST_AZURE_API_KEY",
 				Models: []ProviderModelConfig{{
 					PublicID:   "gpt-5.4-pro",
 					Deployment: "gpt-5.4-pro",
@@ -7008,10 +7010,11 @@ func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
 					Default: true,
 				},
 				{
-					ID:        "azure",
-					Type:      "azure-openai",
-					BaseURL:   "https://example.openai.azure.com/openai/v1",
-					APIKeyEnv: "TEST_AZURE_API_KEY",
+					ID:         "azure",
+					Type:       "azure-openai",
+					BaseURL:    "https://example.openai.azure.com/openai/v1",
+					APIVersion: "2025-04-01-preview",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
 					Models: []ProviderModelConfig{{
 						PublicID:   "gpt-5.4",
 						Deployment: "gpt-5-4-prod",
@@ -7060,11 +7063,12 @@ func TestNewProxyHandler_FailsWhenOpenAICodexModelCollidesWithAzure(t *testing.T
 					BaseURL: codexServer.URL,
 				},
 				{
-					ID:        "azure",
-					Type:      "azure-openai",
-					Default:   true,
-					BaseURL:   "https://example.openai.azure.com/openai/v1",
-					APIKeyEnv: "TEST_AZURE_API_KEY",
+					ID:         "azure",
+					Type:       "azure-openai",
+					Default:    true,
+					BaseURL:    "https://example.openai.azure.com/openai/v1",
+					APIVersion: "2025-04-01-preview",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
 					Models: []ProviderModelConfig{{
 						PublicID:   "gpt-5.4",
 						Deployment: "gpt-5-4-prod",
@@ -7355,10 +7359,11 @@ func TestNewProxyHandler_AllowsDuplicateModelIDsWithinSameProvider(t *testing.T)
 					Default: true,
 				},
 				{
-					ID:        "azure",
-					Type:      "azure-openai",
-					BaseURL:   "https://example.openai.azure.com/openai/v1",
-					APIKeyEnv: "TEST_AZURE_API_KEY",
+					ID:         "azure",
+					Type:       "azure-openai",
+					BaseURL:    "https://example.openai.azure.com/openai/v1",
+					APIVersion: "2025-04-01-preview",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
 					Models: []ProviderModelConfig{{
 						PublicID:   "gpt-5.4-pro",
 						Deployment: "gpt-5-4-pro",
@@ -7441,10 +7446,11 @@ func TestHandleResponses_AllowsMergedDuplicateDynamicProviderEndpoints(t *testin
 					Default: true,
 				},
 				{
-					ID:        "azure",
-					Type:      "azure-openai",
-					BaseURL:   "https://example.openai.azure.com/openai/v1",
-					APIKeyEnv: "TEST_AZURE_API_KEY",
+					ID:         "azure",
+					Type:       "azure-openai",
+					BaseURL:    "https://example.openai.azure.com/openai/v1",
+					APIVersion: "2025-04-01-preview",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
 					Models: []ProviderModelConfig{{
 						PublicID:   "gpt-5.4-pro",
 						Deployment: "gpt-5-4-pro",
@@ -10108,5 +10114,127 @@ func TestHandleOpenAIChatCompletions_RoutesConfiguredAzureIdentityProvider(t *te
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestProviderResolutionFailuresSurfaceRealCauseAcrossPublicSurfaces(t *testing.T) {
+	handler := &ProxyHandler{
+		auth:       auth.NewTestAuthenticator("test-token"),
+		log:        logger.New(logger.LevelError),
+		copilotURL: "http://upstream.test",
+		providersState: &providerSetup{
+			providers:         map[string]*providerRuntime{},
+			providerOrder:     nil,
+			defaultProviderID: "missing",
+			models:            map[string]providerModel{},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		body        string
+		handle      func(http.ResponseWriter, *http.Request)
+		wantMessage string
+		anthropic   bool
+	}{
+		{
+			name:        "openai chat",
+			path:        "/v1/chat/completions",
+			body:        `{"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}`,
+			handle:      handler.HandleOpenAIChatCompletions,
+			wantMessage: "no provider available for endpoint /chat/completions",
+		},
+		{
+			name:        "anthropic messages",
+			path:        "/v1/messages",
+			body:        `{"model":"claude-sonnet-4","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`,
+			handle:      handler.HandleAnthropicMessages,
+			wantMessage: "no provider available for endpoint /chat/completions",
+			anthropic:   true,
+		},
+		{
+			name:        "responses",
+			path:        "/v1/responses",
+			body:        `{"model":"gpt-5","input":"hi"}`,
+			handle:      handler.HandleResponses,
+			wantMessage: "no provider available for endpoint /responses",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			tt.handle(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusInternalServerError {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("StatusCode = %d, want 500: %s", resp.StatusCode, string(body))
+			}
+			body, _ := io.ReadAll(resp.Body)
+			if !strings.Contains(string(body), tt.wantMessage) {
+				t.Fatalf("response body = %s, want real provider error %q", string(body), tt.wantMessage)
+			}
+			for _, forbidden := range []string{"authentication failed", "upstream request failed"} {
+				if strings.Contains(string(body), forbidden) {
+					t.Fatalf("response body = %s, should not contain generic message %q", string(body), forbidden)
+				}
+			}
+		})
+	}
+}
+
+func TestStripUnsupportedResponsesRequestFields_RemovesSamplingForCodexOnly(t *testing.T) {
+	body := []byte(`{"model":"gpt-5-codex","input":"hi","top_p":0.9,"temperature":0.2}`)
+
+	codex := &providerRuntime{kind: providerTypeOpenAICodex}
+	rewritten, fields := stripUnsupportedResponsesRequestFields(body, codex)
+	if !reflect.DeepEqual(fields, []string{"top_p", "temperature"}) {
+		t.Fatalf("stripped fields = %#v, want top_p and temperature", fields)
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("unmarshal rewritten body: %v", err)
+	}
+	if _, ok := payload["top_p"]; ok {
+		t.Fatalf("top_p was not stripped: %s", rewritten)
+	}
+	if _, ok := payload["temperature"]; ok {
+		t.Fatalf("temperature was not stripped: %s", rewritten)
+	}
+
+	copilot := &providerRuntime{kind: providerTypeCopilot}
+	rewritten, fields = stripUnsupportedResponsesRequestFields(body, copilot)
+	if len(fields) != 0 {
+		t.Fatalf("copilot stripped fields = %#v, want none", fields)
+	}
+	if string(rewritten) != string(body) {
+		t.Fatalf("copilot body changed: got %s want %s", rewritten, body)
+	}
+}
+
+func TestSyntheticResponsesStoreFalseOnlyForProxyBuiltRequests(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://api.githubcopilot.com"}
+	fields := map[string]json.RawMessage{
+		"model": json.RawMessage(`"gpt-5"`),
+		"input": json.RawMessage(`"hi"`),
+	}
+
+	handler.setSyntheticResponsesStoreFalse(fields)
+	if got := strings.TrimSpace(string(fields["store"])); got != "false" {
+		t.Fatalf("synthetic store = %q, want false", got)
+	}
+
+	passthrough := handler.rewriteResponsesRequestBody([]byte(`{"model":"gpt-5","input":"hi"}`), "responses", true)
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(passthrough, &payload); err != nil {
+		t.Fatalf("unmarshal passthrough body: %v", err)
+	}
+	if _, ok := payload["store"]; ok {
+		t.Fatalf("passthrough rewrite unexpectedly added store: %s", passthrough)
 	}
 }

--- a/proxy/openai_stream_reader.go
+++ b/proxy/openai_stream_reader.go
@@ -12,52 +12,145 @@ import (
 
 const (
 	openAIStreamScannerInitialBuffer = 64 * 1024
-	openAIStreamScannerMaxBuffer     = 1024 * 1024
+	openAIStreamScannerMaxBuffer     = 8 * 1024 * 1024
 )
 
 type sseDataAccumulator struct {
+	eventType string
 	dataLines []string
 }
 
-func (a *sseDataAccumulator) consumeLine(line string, onData func(string) bool) bool {
+func (a *sseDataAccumulator) consumeLine(line string, onData func(string, string) bool) bool {
 	line = strings.TrimRight(line, "\r\n")
 	if line == "" {
 		return a.dispatch(onData)
 	}
-
-	data, ok := parseSSELine(line)
-	if !ok {
+	if data, ok := parseSSELine(line); ok {
+		a.dataLines = append(a.dataLines, data)
 		return true
 	}
-	a.dataLines = append(a.dataLines, data)
+	if eventType, ok := parseSSEEventLine(line); ok {
+		a.eventType = eventType
+	}
 	return true
 }
 
-func (a *sseDataAccumulator) dispatch(onData func(string) bool) bool {
+func (a *sseDataAccumulator) dispatch(onData func(string, string) bool) bool {
 	if len(a.dataLines) == 0 {
+		a.eventType = ""
 		return true
 	}
 	data := strings.Join(a.dataLines, "\n")
+	eventType := a.eventType
 	a.dataLines = a.dataLines[:0]
+	a.eventType = ""
 	if onData == nil {
 		return true
 	}
-	return onData(data)
+	return onData(eventType, data)
+}
+
+func parseSSEEventLine(line string) (string, bool) {
+	if !strings.HasPrefix(line, "event:") {
+		return "", false
+	}
+	eventType := strings.TrimPrefix(line, "event:")
+	eventType = strings.TrimPrefix(eventType, " ")
+	return strings.TrimSpace(eventType), true
+}
+
+func readOpenAISSELine(reader *bufio.Reader) (string, error) {
+	var line strings.Builder
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			if line.Len()+len(fragment) > openAIStreamScannerMaxBuffer {
+				return "", fmt.Errorf("SSE line exceeds %d bytes", openAIStreamScannerMaxBuffer)
+			}
+			line.Write(fragment)
+		}
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		if line.Len() > 0 {
+			return line.String(), err
+		}
+		return "", err
+	}
+}
+
+type openAIStreamError struct {
+	Type    string
+	Code    string
+	Message string
+}
+
+func (e *openAIStreamError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Code != "" {
+		return e.Code
+	}
+	if e.Type != "" {
+		return e.Type
+	}
+	return "upstream stream error"
+}
+
+func parseOpenAIStreamError(eventType, data string) (*openAIStreamError, bool) {
+	var envelope struct {
+		Error *struct {
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(data), &envelope); err == nil {
+		if envelope.Error != nil {
+			return &openAIStreamError{
+				Type:    strings.TrimSpace(envelope.Error.Type),
+				Code:    strings.TrimSpace(envelope.Error.Code),
+				Message: strings.TrimSpace(envelope.Error.Message),
+			}, true
+		}
+		if strings.EqualFold(strings.TrimSpace(eventType), "error") {
+			return &openAIStreamError{
+				Type:    strings.TrimSpace(envelope.Type),
+				Code:    strings.TrimSpace(envelope.Code),
+				Message: strings.TrimSpace(envelope.Message),
+			}, true
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(eventType), "error") {
+		return &openAIStreamError{Message: sanitizeUpstreamErrorText(data)}, true
+	}
+	return nil, false
 }
 
 // consumeOpenAIStreamChunks scans an upstream OpenAI SSE stream, ignores
-// non-data events and malformed JSON chunks, and reports whether the stream
-// terminated with the expected [DONE] sentinel. Multi-line SSE data fields are
-// joined according to the SSE event model before JSON decoding.
+// malformed JSON chunks, and reports whether the stream terminated with the
+// expected [DONE] sentinel. Multi-line SSE data fields are joined according to
+// the SSE event model before JSON decoding.
 func consumeOpenAIStreamChunks(r io.Reader, onChunk func(models.OpenAIStreamChunk) bool) (bool, error) {
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, openAIStreamScannerInitialBuffer), openAIStreamScannerMaxBuffer)
+	reader := bufio.NewReaderSize(r, openAIStreamScannerInitialBuffer)
 
 	sawDone := false
+	var streamReadErr error
 	var accumulator sseDataAccumulator
-	processData := func(data string) bool {
+	processData := func(eventType, data string) bool {
 		if data == "[DONE]" {
 			sawDone = true
+			return false
+		}
+		if streamErr, ok := parseOpenAIStreamError(eventType, data); ok {
+			streamReadErr = streamErr
 			return false
 		}
 
@@ -69,18 +162,24 @@ func consumeOpenAIStreamChunks(r io.Reader, onChunk func(models.OpenAIStreamChun
 		return onChunk == nil || onChunk(chunk)
 	}
 
-	for scanner.Scan() {
-		if !accumulator.consumeLine(scanner.Text(), processData) {
-			return sawDone, nil
+	for {
+		line, err := readOpenAISSELine(reader)
+		if len(line) > 0 {
+			if !accumulator.consumeLine(line, processData) {
+				return sawDone, streamReadErr
+			}
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
 		return false, fmt.Errorf("reading SSE stream: %w", err)
 	}
 
 	if !accumulator.dispatch(processData) {
-		return sawDone, nil
+		return sawDone, streamReadErr
 	}
 
 	return sawDone, nil

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -102,6 +102,7 @@ type ProviderModelConfig struct {
 	ReasoningEffort     []string `json:"reasoning_effort,omitempty" yaml:"reasoning_effort,omitempty"`
 	Vision              *bool    `json:"vision,omitempty" yaml:"vision,omitempty"`
 	ParallelToolCalls   *bool    `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
+	DropSamplingParams  *bool    `json:"drop_sampling_params,omitempty" yaml:"drop_sampling_params,omitempty"`
 	ContextWindow       *int64   `json:"context_window,omitempty" yaml:"context_window,omitempty"`
 }
 
@@ -142,6 +143,8 @@ type providerModel struct {
 	upstreamModel      string
 	providerID         string
 	supportedEndpoints []string
+	parallelToolCalls  *bool
+	dropSamplingParams bool
 	disabled           bool
 	raw                json.RawMessage
 }
@@ -197,6 +200,7 @@ type azureBaseURLKind int
 
 const (
 	azureBaseURLKindInvalid azureBaseURLKind = iota
+	azureBaseURLKindResourceRoot
 	azureBaseURLKindLegacyOpenAI
 	azureBaseURLKindOpenAIV1
 	azureBaseURLKindModels
@@ -564,15 +568,19 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		if baseURL == "" {
 			return nil, fmt.Errorf("provider %q must set base_url", id)
 		}
-		switch classifyAzureBaseURL(baseURL) {
-		case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI:
+		baseKind := classifyAzureBaseURL(baseURL)
+		switch baseKind {
+		case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI, azureBaseURLKindResourceRoot:
 		case azureBaseURLKindModels:
 			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: Microsoft Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", id, baseURL)
 		default:
-			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected an absolute URL whose path ends in /openai/v1 or /openai, with no query string or fragment", id, baseURL)
+			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected an absolute URL whose path ends in /openai/v1 or /openai, or is the Azure OpenAI resource root, with no query string or fragment", id, baseURL)
 		}
 		runtime.baseURL = baseURL
 		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
+		if runtime.apiVersion == "" && baseKind != azureBaseURLKindOpenAIV1 {
+			return nil, fmt.Errorf("provider %q api_version is required for Azure base_url %q unless the path ends in /openai/v1", id, baseURL)
+		}
 
 		authMode := providerAuthMode(strings.TrimSpace(cfg.AuthMode))
 		if authMode == "" {
@@ -942,7 +950,10 @@ func buildStaticProviderModel(providerID string, cfg ProviderModelConfig, defaul
 		name = publicID
 	}
 
-	endpoints := normalizeProviderEndpoints(cfg.Endpoints, defaultEndpoints)
+	endpoints, err := normalizeProviderEndpoints(cfg.Endpoints, defaultEndpoints)
+	if err != nil {
+		return providerModel{}, fmt.Errorf("provider %q model %q: %w", providerID, publicID, err)
+	}
 	raw, err := synthesizeProviderModelRaw(providerID, publicID, name, endpoints, cfg)
 	if err != nil {
 		return providerModel{}, err
@@ -953,6 +964,8 @@ func buildStaticProviderModel(providerID string, cfg ProviderModelConfig, defaul
 		upstreamModel:      upstreamModel,
 		providerID:         providerID,
 		supportedEndpoints: endpoints,
+		parallelToolCalls:  cloneBoolPtr(cfg.ParallelToolCalls),
+		dropSamplingParams: cfg.DropSamplingParams != nil && *cfg.DropSamplingParams,
 		raw:                raw,
 	}, nil
 }
@@ -971,9 +984,9 @@ func normalizeProviderModelConfig(cfg ProviderModelConfig) ProviderModelConfig {
 	return cfg
 }
 
-func normalizeProviderEndpoints(endpoints []string, defaultEndpoints []string) []string {
+func normalizeProviderEndpoints(endpoints []string, defaultEndpoints []string) ([]string, error) {
 	if len(endpoints) == 0 {
-		return append([]string(nil), defaultEndpoints...)
+		return append([]string(nil), defaultEndpoints...), nil
 	}
 
 	normalized := make([]string, 0, len(endpoints))
@@ -983,6 +996,9 @@ func normalizeProviderEndpoints(endpoints []string, defaultEndpoints []string) [
 		if endpoint == "" {
 			continue
 		}
+		if !knownProviderEndpoint(endpoint) {
+			return nil, fmt.Errorf("unsupported endpoint %q", endpoint)
+		}
 		if _, ok := seen[endpoint]; ok {
 			continue
 		}
@@ -990,9 +1006,26 @@ func normalizeProviderEndpoints(endpoints []string, defaultEndpoints []string) [
 		normalized = append(normalized, endpoint)
 	}
 	if len(normalized) == 0 {
-		return append([]string(nil), defaultEndpoints...)
+		return append([]string(nil), defaultEndpoints...), nil
 	}
-	return normalized
+	return normalized, nil
+}
+
+func knownProviderEndpoint(endpoint string) bool {
+	switch endpoint {
+	case providerEndpointChatCompletions, providerEndpointResponses, providerEndpointMessages:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func synthesizeProviderModelRaw(providerID, publicID, name string, endpoints []string, cfg ProviderModelConfig) (json.RawMessage, error) {
@@ -1116,7 +1149,7 @@ func rewriteRequestModelForProvider(body []byte, upstreamModel string) ([]byte, 
 	return rewriteResponsesRequestModel(body, upstreamModel)
 }
 
-func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string, extraQuery string) (string, error) {
+func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string, extraQuery string, owners ...providerModel) (string, error) {
 	if provider == nil {
 		return "", fmt.Errorf("provider is required")
 	}
@@ -1126,11 +1159,50 @@ func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string
 	if upstreamPath == "" {
 		return "", fmt.Errorf("provider %q has no upstream path configured for %s", provider.id, path)
 	}
+
+	baseKind := classifyAzureBaseURL(baseURL)
+	if provider.kind == providerTypeAzureOpenAI && provider.apiVersion != "" && baseKind != azureBaseURLKindOpenAIV1 {
+		if path == providerEndpointChatCompletions && !strings.HasPrefix(strings.TrimPrefix(upstreamPath, "/"), "deployments/") {
+			owner := providerModel{}
+			if len(owners) > 0 {
+				owner = owners[0]
+			}
+			deployment := strings.TrimSpace(owner.upstreamModel)
+			if deployment == "" {
+				deployment = strings.TrimSpace(owner.publicID)
+			}
+			if deployment == "" {
+				return "", fmt.Errorf("provider %q has no Azure deployment configured for %s", provider.id, path)
+			}
+			operation := strings.TrimPrefix(upstreamPath, "/")
+			fullURL := azureClassicOpenAIBaseURL(baseURL, baseKind) + "/deployments/" + url.PathEscape(deployment) + "/" + operation
+			return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+		}
+		fullURL := azureClassicOpenAIBaseURL(baseURL, baseKind) + upstreamPath
+		return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+	}
+
 	fullURL := baseURL + upstreamPath
-	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" || classifyAzureBaseURL(baseURL) == azureBaseURLKindOpenAIV1 {
+	if provider.kind != providerTypeAzureOpenAI || provider.apiVersion == "" || baseKind == azureBaseURLKindOpenAIV1 {
 		return appendRawQuery(fullURL, extraQuery), nil
 	}
 	return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+}
+
+func azureClassicOpenAIBaseURL(baseURL string, baseKind azureBaseURLKind) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseKind == azureBaseURLKindResourceRoot {
+		return baseURL + "/openai"
+	}
+	return baseURL
+}
+
+func providerUsesAzureClassicDeploymentPath(provider *providerRuntime, endpoint string) bool {
+	if provider == nil || provider.kind != providerTypeAzureOpenAI || endpoint != providerEndpointChatCompletions {
+		return false
+	}
+	baseKind := classifyAzureBaseURL(provider.baseURL)
+	return baseKind == azureBaseURLKindLegacyOpenAI || baseKind == azureBaseURLKindResourceRoot
 }
 
 func (p *providerRuntime) upstreamPath(endpoint string) string {
@@ -1178,6 +1250,8 @@ func classifyAzureBaseURL(baseURL string) azureBaseURLKind {
 
 	path := strings.TrimRight(parsed.Path, "/")
 	switch {
+	case path == "":
+		return azureBaseURLKindResourceRoot
 	case strings.HasSuffix(path, "/openai/v1"):
 		return azureBaseURLKindOpenAIV1
 	case strings.HasSuffix(path, "/openai"):
@@ -1243,6 +1317,7 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 		h.setCopilotHeadersForProvider(req, token, provider, endpoint)
 	case providerTypeAzureOpenAI:
 		clearCopilotHeaders(req.Header)
+		mergeHeaderValues(req.Header, provider.extraHeaders)
 		req.Header.Del("api-key")
 		switch provider.azureAuthMode() {
 		case providerAuthModeAPIKey:
@@ -1315,8 +1390,8 @@ func applyGenericProviderAuth(req *http.Request, provider *providerRuntime) erro
 	}
 }
 
-func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string) (*http.Request, error) {
-	fullURL, err := h.providerRequestURL(provider, path, extraQuery)
+func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, owners ...providerModel) (*http.Request, error) {
+	fullURL, err := h.providerRequestURL(provider, path, extraQuery, owners...)
 	if err != nil {
 		return nil, err
 	}
@@ -1774,12 +1849,27 @@ func decodeProviderModelsFromBody(provider *providerRuntime, body []byte) ([]pro
 			upstreamModel:      publicID,
 			providerID:         provider.id,
 			supportedEndpoints: supportedEndpoints,
+			parallelToolCalls:  providerModelParallelToolCallsFromRaw(raw),
 			disabled:           disabled,
 			raw:                mergeProviderModelRaw(raw, supportedEndpoints),
 		})
 	}
 
 	return models, nil
+}
+
+func providerModelParallelToolCallsFromRaw(raw json.RawMessage) *bool {
+	var parsed struct {
+		Capabilities struct {
+			Supports struct {
+				ParallelToolCalls *bool `json:"parallel_tool_calls"`
+			} `json:"supports"`
+		} `json:"capabilities"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil
+	}
+	return cloneBoolPtr(parsed.Capabilities.Supports.ParallelToolCalls)
 }
 
 func openRouterModelSupportsTools(supportedParams []string) bool {
@@ -1945,6 +2035,7 @@ func decodeOpenAICodexModelsFromBody(provider *providerRuntime, body []byte) ([]
 			upstreamModel:      publicID,
 			providerID:         provider.id,
 			supportedEndpoints: append([]string(nil), openAICodexProviderEndpoints...),
+			parallelToolCalls:  cloneBoolPtr(&parsed.SupportsParallelToolCalls),
 			raw:                modelRaw,
 		})
 	}

--- a/proxy/request_summary.go
+++ b/proxy/request_summary.go
@@ -1,0 +1,178 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/sozercan/vekil/logger"
+	"github.com/sozercan/vekil/models"
+)
+
+type requestSummaryContextKey struct{}
+
+// RequestSummary is a mutable per-request summary populated by handlers and
+// emitted by the server-level request logging middleware.
+type RequestSummary struct {
+	mu sync.Mutex
+
+	endpoint          string
+	model             string
+	provider          string
+	providerKind      string
+	streamSet         bool
+	stream            bool
+	upstreamRequestID string
+	promptTokens      *int
+	completionTokens  *int
+	totalTokens       *int
+}
+
+// WithRequestSummary attaches a mutable request summary to ctx and returns both
+// the derived context and the summary pointer. Handlers mutate the pointer in
+// place so middleware can observe the final values after the handler returns.
+func WithRequestSummary(ctx context.Context) (context.Context, *RequestSummary) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if existing := RequestSummaryFromContext(ctx); existing != nil {
+		return ctx, existing
+	}
+	summary := &RequestSummary{}
+	return context.WithValue(ctx, requestSummaryContextKey{}, summary), summary
+}
+
+// RequestSummaryFromContext returns the mutable request summary attached to ctx,
+// if any.
+func RequestSummaryFromContext(ctx context.Context) *RequestSummary {
+	if ctx == nil {
+		return nil
+	}
+	summary, _ := ctx.Value(requestSummaryContextKey{}).(*RequestSummary)
+	return summary
+}
+
+func (s *RequestSummary) setRoute(endpoint, model string, stream bool) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if endpoint = strings.TrimSpace(endpoint); endpoint != "" {
+		s.endpoint = endpoint
+	}
+	if model = strings.TrimSpace(model); model != "" {
+		s.model = model
+	}
+	s.stream = stream
+	s.streamSet = true
+}
+
+func (s *RequestSummary) setProvider(provider, kind string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if provider = strings.TrimSpace(provider); provider != "" {
+		s.provider = provider
+	}
+	if kind = strings.TrimSpace(kind); kind != "" {
+		s.providerKind = kind
+	}
+}
+
+func (s *RequestSummary) setUpstreamRequestID(requestID string) {
+	if s == nil {
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upstreamRequestID = requestID
+}
+
+func (s *RequestSummary) setOpenAIUsage(usage *models.OpenAIUsage) {
+	if s == nil || usage == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.promptTokens = summaryIntPtr(usage.PromptTokens)
+	s.completionTokens = summaryIntPtr(usage.CompletionTokens)
+	s.totalTokens = summaryIntPtr(usage.TotalTokens)
+}
+
+func summaryIntPtr(v int) *int { return &v }
+
+// LoggerFields returns the structured fields populated for this request.
+func (s *RequestSummary) LoggerFields() []logger.Field {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fields := make([]logger.Field, 0, 8)
+	if s.endpoint != "" {
+		fields = append(fields, logger.F("endpoint", s.endpoint))
+	}
+	if s.model != "" {
+		fields = append(fields, logger.F("model", s.model))
+	}
+	if s.provider != "" {
+		fields = append(fields, logger.F("provider", s.provider))
+	}
+	if s.providerKind != "" {
+		fields = append(fields, logger.F("provider_kind", s.providerKind))
+	}
+	if s.streamSet {
+		fields = append(fields, logger.F("stream", s.stream))
+	}
+	if s.upstreamRequestID != "" {
+		fields = append(fields, logger.F("upstream_request_id", s.upstreamRequestID))
+	}
+	if s.promptTokens != nil {
+		fields = append(fields, logger.F("prompt_tokens", *s.promptTokens))
+	}
+	if s.completionTokens != nil {
+		fields = append(fields, logger.F("completion_tokens", *s.completionTokens))
+	}
+	if s.totalTokens != nil {
+		fields = append(fields, logger.F("total_tokens", *s.totalTokens))
+	}
+	return fields
+}
+
+func (h *ProxyHandler) observeRequestSummary(ctx context.Context, endpoint, model string, stream bool, providerEndpoint string) {
+	summary := RequestSummaryFromContext(ctx)
+	if summary == nil {
+		return
+	}
+	summary.setRoute(endpoint, model, stream)
+	lookupModel := strings.TrimSpace(model)
+	if providerEndpoint == providerEndpointMessages {
+		lookupModel = NormalizeModelName(lookupModel)
+	}
+	provider, _, _ := h.resolveProviderModel(lookupModel, providerEndpoint)
+	if provider == nil {
+		return
+	}
+	summary.setProvider(provider.id, string(provider.kind))
+}
+
+func observeOpenAIUsage(ctx context.Context, usage *models.OpenAIUsage) {
+	if summary := RequestSummaryFromContext(ctx); summary != nil {
+		summary.setOpenAIUsage(usage)
+	}
+}
+
+func observeUpstreamHeaders(ctx context.Context, headers http.Header) {
+	if summary := RequestSummaryFromContext(ctx); summary != nil {
+		summary.setUpstreamRequestID(UpstreamRequestID(headers))
+	}
+}

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -116,10 +116,6 @@ func (h *ProxyHandler) writeResponsesUpstreamRequestFailure(w http.ResponseWrite
 		writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
 		return
 	}
-	if statusCode == http.StatusInternalServerError {
-		writeOpenAIError(w, statusCode, "authentication failed", "server_error")
-		return
-	}
 	writeOpenAIUpstreamRequestFailure(w, statusCode, err)
 }
 
@@ -129,12 +125,13 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
-		writeOpenAIError(w, status, err.Error(), "invalid_request_error")
+		writeOpenAIRequestBodyError(w, status, err)
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
 
 	prepared := h.prepareResponsesRequest(r.Context(), r, bodyBytes)
+	h.observeRequestSummary(r.Context(), "responses", extractRequestModel(prepared.body), prepared.streaming, providerEndpointResponses)
 
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(prepared.streaming)
 	defer upstreamCancel()
@@ -159,6 +156,8 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 		h.writeResponsesUpstreamRequestFailure(w, "responses", err)
 		return
 	}
+
+	observeUpstreamHeaders(r.Context(), resp.Header)
 
 	if prepared.streaming && resp.StatusCode == http.StatusOK {
 		model := extractRequestModel(prepared.body)
@@ -236,6 +235,60 @@ type compactBudget struct {
 	max           int
 	learnedTarget int
 	resolvedModel string
+	usage         responsesUsageTotals
+}
+
+type responsesUsageTotals struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+func (b *compactBudget) addResponsesUsage(body []byte) {
+	if b == nil {
+		return
+	}
+	usage := extractResponsesUsageTotals(body)
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 && usage.TotalTokens == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.usage.InputTokens += usage.InputTokens
+	b.usage.OutputTokens += usage.OutputTokens
+	b.usage.TotalTokens += usage.TotalTokens
+}
+
+func (b *compactBudget) responsesUsage() map[string]interface{} {
+	if b == nil {
+		return zeroResponsesUsage()
+	}
+	b.mu.Lock()
+	usage := b.usage
+	b.mu.Unlock()
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 && usage.TotalTokens == 0 {
+		return zeroResponsesUsage()
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+	}
+	return map[string]interface{}{
+		"input_tokens":          usage.InputTokens,
+		"input_tokens_details":  nil,
+		"output_tokens":         usage.OutputTokens,
+		"output_tokens_details": nil,
+		"total_tokens":          usage.TotalTokens,
+	}
+}
+
+func extractResponsesUsageTotals(body []byte) responsesUsageTotals {
+	var envelope struct {
+		Usage responsesUsageTotals `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		return envelope.Usage
+	}
+	return responsesUsageTotals{}
 }
 
 func newCompactBudget(max int) *compactBudget {
@@ -362,7 +415,7 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
-		writeOpenAIError(w, status, err.Error(), "invalid_request_error")
+		writeOpenAIRequestBodyError(w, status, err)
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
@@ -385,10 +438,6 @@ func (h *ProxyHandler) HandleCompact(w http.ResponseWriter, r *http.Request) {
 		h.log.Error("upstream request failed", logger.F("endpoint", "compact"), logger.Err(err))
 		if statusCode == http.StatusBadRequest {
 			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
-			return
-		}
-		if statusCode == http.StatusInternalServerError {
-			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
 		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
@@ -425,7 +474,7 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 	bodyBytes, err := readBodyWithLimit(r, maxLargeRequestBodySize)
 	if err != nil {
 		status := readBodyStatusCode(err)
-		writeOpenAIError(w, status, err.Error(), "invalid_request_error")
+		writeOpenAIRequestBodyError(w, status, err)
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
@@ -436,9 +485,12 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 		Reasoning json.RawMessage   `json:"reasoning,omitempty"`
 	}
 	if err := json.Unmarshal(bodyBytes, &memReq); err != nil {
-		writeOpenAIError(w, http.StatusBadRequest, "invalid JSON in request body", "invalid_request_error")
+		message, param := jsonDecodeErrorDetails(err, "invalid JSON in request body")
+		writeOpenAIErrorWithDetails(w, http.StatusBadRequest, message, "invalid_request_error", param, "")
 		return
 	}
+
+	h.observeRequestSummary(r.Context(), "memory_summarize", memReq.Model, false, providerEndpointResponses)
 
 	tracesJSON, _ := json.Marshal(memReq.Traces)
 	userContent := "Summarize the following session traces:\n\n" + string(tracesJSON)
@@ -456,6 +508,9 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 			},
 		},
 	}
+	if h.shouldSetSyntheticResponsesStoreFalse(memReq.Model) {
+		responsesReq["store"] = false
+	}
 	if len(memReq.Reasoning) > 0 && string(memReq.Reasoning) != "null" {
 		responsesReq["reasoning"] = json.RawMessage(memReq.Reasoning)
 	}
@@ -470,10 +525,6 @@ func (h *ProxyHandler) HandleMemorySummarize(w http.ResponseWriter, r *http.Requ
 		h.log.Error("upstream request failed", logger.F("endpoint", "memory_summarize"), logger.Err(err))
 		if statusCode == http.StatusBadRequest {
 			writeOpenAIError(w, statusCode, err.Error(), "invalid_request_error")
-			return
-		}
-		if statusCode == http.StatusInternalServerError {
-			writeOpenAIError(w, statusCode, "authentication failed", "server_error")
 			return
 		}
 		writeOpenAIUpstreamRequestFailure(w, statusCode, err)
@@ -622,6 +673,26 @@ func writeCompactResponse(w http.ResponseWriter, summaryText string, retainedOut
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(compactResp)
+}
+
+func (h *ProxyHandler) setSyntheticResponsesStoreFalse(requestFields map[string]json.RawMessage) {
+	if requestFields == nil || !h.shouldSetSyntheticResponsesStoreFalse(rawJSONString(requestFields["model"])) {
+		return
+	}
+	requestFields["store"] = json.RawMessage("false")
+}
+
+func (h *ProxyHandler) shouldSetSyntheticResponsesStoreFalse(model string) bool {
+	provider, _, _ := h.resolveProviderModel(strings.TrimSpace(model), providerEndpointResponses)
+	if provider == nil {
+		return false
+	}
+	switch provider.kind {
+	case providerTypeCopilot, providerTypeOpenAICodex, providerTypeOpenAICompatible, providerTypeAzureOpenAI:
+		return true
+	default:
+		return false
+	}
 }
 
 type compactInflightCall struct {
@@ -817,6 +888,7 @@ func (h *ProxyHandler) compactResponsesRequestWithBudget(ctx context.Context, re
 		)
 	}
 
+	h.setSyntheticResponsesStoreFalse(requestFields)
 	targetBodySize := h.effectiveCompactChunkBodyBytes()
 	learnedTarget, learned := h.learnedCompactTargetForRequest(requestFields, targetBodySize)
 	if learned {
@@ -873,6 +945,7 @@ func (h *ProxyHandler) compactResponsesRequestDepth(ctx context.Context, request
 		if err != nil {
 			return "", nil, err
 		}
+		budget.addResponsesUsage(respBody)
 		summary, err := extractResponsesOutputText(respBody)
 		if err != nil {
 			return "", nil, err
@@ -1858,7 +1931,8 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *provider
 	}
 
 	unsupportedToolTypes := unsupportedResponsesToolTypes(provider)
-	if len(unsupportedToolTypes) == 0 {
+	unsupportedSamplingFields := unsupportedResponsesSamplingFields(provider)
+	if len(unsupportedToolTypes) == 0 && len(unsupportedSamplingFields) == 0 {
 		return bodyBytes, nil
 	}
 
@@ -1867,44 +1941,51 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *provider
 		return bodyBytes, nil
 	}
 
-	rawTools, ok := payload["tools"]
-	if !ok {
-		return bodyBytes, nil
-	}
-
-	var tools []json.RawMessage
-	if err := json.Unmarshal(rawTools, &tools); err != nil {
-		return bodyBytes, nil
-	}
-
-	filteredTools := make([]json.RawMessage, 0, len(tools))
-	strippedFields := make([]string, 0, len(tools)+1)
-	strippedToolTypes := make(map[string]struct{})
-	for i, rawTool := range tools {
-		toolType := responsesToolType(rawTool)
-		if _, unsupported := unsupportedToolTypes[toolType]; unsupported {
-			strippedFields = append(strippedFields, fmt.Sprintf("tools[%d]", i))
-			strippedToolTypes[toolType] = struct{}{}
-			continue
+	strippedFields := make([]string, 0, len(unsupportedSamplingFields)+1)
+	for _, field := range unsupportedSamplingFields {
+		if _, ok := payload[field]; ok {
+			delete(payload, field)
+			strippedFields = append(strippedFields, field)
 		}
-		filteredTools = append(filteredTools, rawTool)
+	}
+
+	if len(unsupportedToolTypes) > 0 {
+		rawTools, ok := payload["tools"]
+		if ok {
+			var tools []json.RawMessage
+			if err := json.Unmarshal(rawTools, &tools); err == nil {
+				filteredTools := make([]json.RawMessage, 0, len(tools))
+				strippedToolTypes := make(map[string]struct{})
+				for i, rawTool := range tools {
+					toolType := responsesToolType(rawTool)
+					if _, unsupported := unsupportedToolTypes[toolType]; unsupported {
+						strippedFields = append(strippedFields, fmt.Sprintf("tools[%d]", i))
+						strippedToolTypes[toolType] = struct{}{}
+						continue
+					}
+					filteredTools = append(filteredTools, rawTool)
+				}
+
+				if len(strippedToolTypes) > 0 {
+					rewrittenTools, err := json.Marshal(filteredTools)
+					if err != nil {
+						return bodyBytes, nil
+					}
+					payload["tools"] = rewrittenTools
+
+					if rawToolChoice, ok := payload["tool_choice"]; ok {
+						if _, stripped := stripUnsupportedResponsesToolChoice(rawToolChoice, len(filteredTools) == 0, strippedToolTypes); stripped {
+							delete(payload, "tool_choice")
+							strippedFields = append(strippedFields, "tool_choice")
+						}
+					}
+				}
+			}
+		}
 	}
 
 	if len(strippedFields) == 0 {
 		return bodyBytes, nil
-	}
-
-	rewrittenTools, err := json.Marshal(filteredTools)
-	if err != nil {
-		return bodyBytes, nil
-	}
-	payload["tools"] = rewrittenTools
-
-	if rawToolChoice, ok := payload["tool_choice"]; ok {
-		if _, stripped := stripUnsupportedResponsesToolChoice(rawToolChoice, len(filteredTools) == 0, strippedToolTypes); stripped {
-			delete(payload, "tool_choice")
-			strippedFields = append(strippedFields, "tool_choice")
-		}
 	}
 
 	rewrittenBody, err := json.Marshal(payload)
@@ -1913,6 +1994,16 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *provider
 	}
 
 	return rewrittenBody, strippedFields
+}
+
+func unsupportedResponsesSamplingFields(provider *providerRuntime) []string {
+	if provider == nil {
+		return nil
+	}
+	if provider.kind == providerTypeOpenAICodex {
+		return []string{"top_p", "temperature"}
+	}
+	return nil
 }
 
 func unsupportedResponsesToolTypes(provider *providerRuntime) map[string]struct{} {
@@ -2008,6 +2099,7 @@ func (h *ProxyHandler) postResponsesWithFallbackHeadersTracked(ctx context.Conte
 	if !changed {
 		return resp, "", nil
 	}
+	fallbackBody = sanitizeResponsesModelFallbackBody(fallbackBody)
 
 	h.log.Info("retrying responses request with fallback model",
 		logger.F("requested_model", requestedModel),
@@ -2041,20 +2133,66 @@ func (h *ProxyHandler) postResponsesCompactWithFallback(ctx context.Context, bod
 // applyResolvedCompactModel rewrites bodyBytes' "model" field to the budget's
 // resolved fallback model when one has been recorded. Failures fall back to
 // the original body so a malformed request still gets the prior fallback path.
+func sanitizeResponsesModelFallbackBody(body []byte) []byte {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+	delete(payload, "previous_response_id")
+
+	var input []json.RawMessage
+	if err := json.Unmarshal(payload["input"], &input); err == nil {
+		sanitized := make([]json.RawMessage, 0, len(input))
+		for _, raw := range input {
+			var item map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &item); err != nil {
+				sanitized = append(sanitized, raw)
+				continue
+			}
+			if rawJSONString(item["type"]) == "reasoning" {
+				continue
+			}
+			var asInterface interface{}
+			_ = json.Unmarshal(raw, &asInterface)
+			if !isProxyCompactionContextMessage(asInterface) {
+				delete(item, "encrypted_content")
+			}
+			rewritten, err := json.Marshal(item)
+			if err != nil {
+				sanitized = append(sanitized, raw)
+				continue
+			}
+			sanitized = append(sanitized, rewritten)
+		}
+		if rewrittenInput, err := json.Marshal(sanitized); err == nil {
+			payload["input"] = rewrittenInput
+		}
+	}
+
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return rewritten
+}
+
 func applyResolvedCompactModel(bodyBytes []byte, budget *compactBudget) []byte {
 	resolvedModel := budget.resolvedModelValue()
 	if resolvedModel == "" {
 		return bodyBytes
 	}
 	current := extractResponsesRequestModel(bodyBytes)
-	if current == "" || current == resolvedModel {
+	if current == "" {
 		return bodyBytes
+	}
+	if current == resolvedModel {
+		return sanitizeResponsesModelFallbackBody(bodyBytes)
 	}
 	rewritten, changed, err := rewriteResponsesRequestModel(bodyBytes, resolvedModel)
 	if err != nil || !changed {
 		return bodyBytes
 	}
-	return rewritten
+	return sanitizeResponsesModelFallbackBody(rewritten)
 }
 
 func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx context.Context, bodyBytes []byte, extraHeaders, upstreamHeaders http.Header, resp *http.Response) (*http.Response, error) {
@@ -2650,7 +2788,7 @@ func (h *ProxyHandler) maybeBuildResponsesCompactionTriggerResponse(ctx context.
 		return resp, true, nil
 	}
 
-	return syntheticCompactionTriggerResponse(summary, stream), true, nil
+	return syntheticCompactionTriggerResponse(summary, stream, budget.responsesUsage()), true, nil
 }
 
 func compactTriggerRequestFields(bodyBytes []byte) (map[string]json.RawMessage, bool, error) {
@@ -2697,7 +2835,10 @@ func responsesInputItemType(raw json.RawMessage) string {
 	return rawJSONString(item["type"])
 }
 
-func syntheticCompactionTriggerResponse(summary string, stream bool) *http.Response {
+func syntheticCompactionTriggerResponse(summary string, stream bool, usage map[string]interface{}) *http.Response {
+	if usage == nil {
+		usage = zeroResponsesUsage()
+	}
 	responseID := "resp-vekil-compact-" + uuid.NewString()
 	compactionItem := map[string]string{
 		"type":              "compaction",
@@ -2722,7 +2863,7 @@ func syntheticCompactionTriggerResponse(summary string, stream bool) *http.Respo
 			"type": "response.completed",
 			"response": map[string]interface{}{
 				"id":    responseID,
-				"usage": zeroResponsesUsage(),
+				"usage": usage,
 			},
 		})
 		return &http.Response{
@@ -2738,7 +2879,7 @@ func syntheticCompactionTriggerResponse(summary string, stream bool) *http.Respo
 		"object": "response",
 		"status": "completed",
 		"output": []interface{}{compactionItem},
-		"usage":  zeroResponsesUsage(),
+		"usage":  usage,
 	})
 	return &http.Response{
 		StatusCode: http.StatusOK,

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -93,6 +93,7 @@ type responsesWebSocketSession struct {
 	doneOnce       sync.Once
 	inflightMu     sync.Mutex
 	inflightCancel context.CancelFunc
+	inflightGen    uint64
 }
 
 type responsesWebSocketRequestPlan struct {
@@ -326,22 +327,33 @@ func (s *responsesWebSocketSession) sendGoingAwayWithDeadline(deadline time.Time
 	s.closeDone()
 }
 
-func (s *responsesWebSocketSession) setInflightCancel(cancel context.CancelFunc) {
+// setInflightCancel records the cancel func for the current in-flight upstream
+// call and returns a generation token. The token must be passed to
+// clearInflightCancel so that only the matching cancel is cleared: nested or
+// subsequent in-flight calls (e.g. auto-compaction inside a create request)
+// bump the generation, and a stale clear is then a no-op rather than nilling
+// out a newer cancel. (context.CancelFunc values are not comparable, so the
+// generation token stands in for identity.)
+func (s *responsesWebSocketSession) setInflightCancel(cancel context.CancelFunc) uint64 {
 	if s == nil || cancel == nil {
-		return
+		return 0
 	}
 	s.inflightMu.Lock()
 	defer s.inflightMu.Unlock()
+	s.inflightGen++
 	s.inflightCancel = cancel
+	return s.inflightGen
 }
 
-func (s *responsesWebSocketSession) clearInflightCancel(context.CancelFunc) {
-	if s == nil {
+func (s *responsesWebSocketSession) clearInflightCancel(gen uint64) {
+	if s == nil || gen == 0 {
 		return
 	}
 	s.inflightMu.Lock()
 	defer s.inflightMu.Unlock()
-	s.inflightCancel = nil
+	if s.inflightGen == gen {
+		s.inflightCancel = nil
+	}
 }
 
 func (s *responsesWebSocketSession) cancelInflight() {
@@ -528,9 +540,9 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 	}
 
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(true)
-	s.setInflightCancel(upstreamCancel)
+	inflightGen := s.setInflightCancel(upstreamCancel)
 	defer func() {
-		s.clearInflightCancel(upstreamCancel)
+		s.clearInflightCancel(inflightGen)
 		upstreamCancel()
 	}()
 
@@ -779,9 +791,9 @@ func (s *responsesWebSocketSession) rememberPlannedResponse(plan responsesWebSoc
 
 func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
 	ctx, cancel := h.newInferenceUpstreamContext(true)
-	s.setInflightCancel(cancel)
+	inflightGen := s.setInflightCancel(cancel)
 	defer func() {
-		s.clearInflightCancel(cancel)
+		s.clearInflightCancel(inflightGen)
 		cancel()
 	}()
 

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -19,6 +21,11 @@ import (
 )
 
 const responsesWebSocketRequestHeaderPrefix = "ws_request_header_"
+
+var (
+	responsesWebSocketWriteWait  = 10 * time.Second
+	responsesWebSocketPingPeriod = 30 * time.Second
+)
 
 // errStreamFailedUpstream is a sentinel error indicating the upstream stream
 // ended with response.failed or response.incomplete after forwarding the
@@ -82,6 +89,10 @@ type responsesWebSocketSession struct {
 	historyItems   []json.RawMessage
 	toolContexts   *ToolExecutionContextStore
 	toolScope      string
+	done           chan struct{}
+	doneOnce       sync.Once
+	inflightMu     sync.Mutex
+	inflightCancel context.CancelFunc
 }
 
 type responsesWebSocketRequestPlan struct {
@@ -154,6 +165,10 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 		http.Error(w, http.StatusText(http.StatusUpgradeRequired), http.StatusUpgradeRequired)
 		return
 	}
+	if h.responsesWebSocketIsDraining() {
+		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+		return
+	}
 
 	conn, err := responsesWebSocketUpgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -163,6 +178,13 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 
 	conn.SetReadLimit(maxRequestBodySize)
 	session := newResponsesWebSocketSession(conn, r)
+	session.startPingLoop()
+	if !h.registerResponsesWebSocketSession(session) {
+		session.sendGoingAwayWithDeadline(time.Now().Add(responsesWebSocketWriteWait))
+		return
+	}
+	defer h.unregisterResponsesWebSocketSession(session)
+	defer session.closeDone()
 
 	for {
 		messageType, payload, err := conn.ReadMessage()
@@ -171,13 +193,13 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 		}
 		if messageType != websocket.TextMessage {
 			session.sendWrappedError(http.StatusBadRequest, "responses websocket only accepts text frames", "invalid_request_error", nil)
-			return
+			continue
 		}
 
 		frameType, err := parseResponsesWebSocketFrameType(payload)
 		if err != nil {
 			session.sendWrappedError(http.StatusBadRequest, err.Error(), "invalid_request_error", nil)
-			return
+			continue
 		}
 		if frameType == "response.processed" {
 			continue
@@ -186,13 +208,151 @@ func (h *ProxyHandler) HandleResponsesWebSocket(w http.ResponseWriter, r *http.R
 		request, err := parseResponsesWebSocketCreateRequest(payload)
 		if err != nil {
 			session.sendWrappedError(http.StatusBadRequest, err.Error(), "invalid_request_error", nil)
-			return
+			continue
 		}
 
 		if err := session.handleCreateRequest(h, request); err != nil {
 			h.log.Debug("responses websocket request failed", logger.Err(err))
-			return
+			continue
 		}
+	}
+}
+
+func (h *ProxyHandler) registerResponsesWebSocketSession(session *responsesWebSocketSession) bool {
+	if h == nil || session == nil {
+		return false
+	}
+	h.responsesWSSessionsMu.Lock()
+	defer h.responsesWSSessionsMu.Unlock()
+	if h.responsesWSDraining {
+		return false
+	}
+	if h.responsesWSSessions == nil {
+		h.responsesWSSessions = make(map[*responsesWebSocketSession]struct{})
+	}
+	h.responsesWSSessions[session] = struct{}{}
+	return true
+}
+
+func (h *ProxyHandler) unregisterResponsesWebSocketSession(session *responsesWebSocketSession) {
+	if h == nil || session == nil {
+		return
+	}
+	h.responsesWSSessionsMu.Lock()
+	defer h.responsesWSSessionsMu.Unlock()
+	delete(h.responsesWSSessions, session)
+}
+
+func (h *ProxyHandler) responsesWebSocketIsDraining() bool {
+	if h == nil {
+		return true
+	}
+	h.responsesWSSessionsMu.Lock()
+	defer h.responsesWSSessionsMu.Unlock()
+	return h.responsesWSDraining
+}
+
+func (h *ProxyHandler) ShutdownWebSocketSessions(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	h.responsesWSSessionsMu.Lock()
+	h.responsesWSDraining = true
+	sessions := make([]*responsesWebSocketSession, 0, len(h.responsesWSSessions))
+	for session := range h.responsesWSSessions {
+		sessions = append(sessions, session)
+	}
+	h.responsesWSSessionsMu.Unlock()
+
+	for _, session := range sessions {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		session.sendGoingAwayWithDeadline(responsesWebSocketShutdownCloseDeadline(ctx))
+	}
+}
+
+func (s *responsesWebSocketSession) closeDone() {
+	if s == nil || s.done == nil {
+		return
+	}
+	s.doneOnce.Do(func() { close(s.done) })
+}
+
+func (s *responsesWebSocketSession) startPingLoop() {
+	if s == nil || s.conn == nil || responsesWebSocketPingPeriod <= 0 {
+		return
+	}
+	ticker := time.NewTicker(responsesWebSocketPingPeriod)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				deadline := time.Now().Add(responsesWebSocketWriteWait)
+				if err := s.conn.WriteControl(websocket.PingMessage, nil, deadline); err != nil {
+					s.cancelInflight()
+					_ = s.conn.Close()
+					s.closeDone()
+					return
+				}
+			case <-s.done:
+				return
+			}
+		}
+	}()
+}
+
+func responsesWebSocketShutdownCloseDeadline(ctx context.Context) time.Time {
+	deadline := time.Now().Add(responsesWebSocketWriteWait)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		return ctxDeadline
+	}
+	return deadline
+}
+
+func (s *responsesWebSocketSession) sendGoingAwayWithDeadline(deadline time.Time) {
+	if s == nil || s.conn == nil {
+		return
+	}
+	s.cancelInflight()
+	if deadline.IsZero() {
+		deadline = time.Now().Add(responsesWebSocketWriteWait)
+	}
+	_ = s.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down"), deadline)
+	_ = s.conn.Close()
+	s.closeDone()
+}
+
+func (s *responsesWebSocketSession) setInflightCancel(cancel context.CancelFunc) {
+	if s == nil || cancel == nil {
+		return
+	}
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	s.inflightCancel = cancel
+}
+
+func (s *responsesWebSocketSession) clearInflightCancel(context.CancelFunc) {
+	if s == nil {
+		return
+	}
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	s.inflightCancel = nil
+}
+
+func (s *responsesWebSocketSession) cancelInflight() {
+	if s == nil {
+		return
+	}
+	s.inflightMu.Lock()
+	cancel := s.inflightCancel
+	s.inflightMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 }
 
@@ -240,6 +400,7 @@ func newResponsesWebSocketSession(conn *websocket.Conn, r *http.Request) *respon
 		// upstream during this proxy-owned websocket session.
 		toolContexts: NewToolExecutionContextStore(),
 		toolScope:    "responses-ws:" + uuid.NewString(),
+		done:         make(chan struct{}),
 	}
 }
 
@@ -367,7 +528,11 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 	}
 
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContext(true)
-	defer upstreamCancel()
+	s.setInflightCancel(upstreamCancel)
+	defer func() {
+		s.clearInflightCancel(upstreamCancel)
+		upstreamCancel()
+	}()
 
 	resp, translated, translatedHeaders, err := h.prepareResponsesStream(s.ctx, upstreamCtx, request.Model, func() (*http.Response, error) {
 		attemptPlan, err := s.planRequest(h, request)
@@ -614,7 +779,11 @@ func (s *responsesWebSocketSession) rememberPlannedResponse(plan responsesWebSoc
 
 func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, request *responsesWebSocketCreateRequest, metrics responsesWebSocketRequestMetrics) responsesWebSocketRequestMetrics {
 	ctx, cancel := h.newInferenceUpstreamContext(true)
-	defer cancel()
+	s.setInflightCancel(cancel)
+	defer func() {
+		s.clearInflightCancel(cancel)
+		cancel()
+	}()
 
 	compaction, compacted, err := s.compactHistory(h, ctx, request, false)
 	if err != nil {
@@ -889,6 +1058,7 @@ func (s *responsesWebSocketSession) streamUpstreamResponse(h *ProxyHandler, body
 			}
 		}
 
+		_ = s.conn.SetWriteDeadline(time.Now().Add(responsesWebSocketWriteWait))
 		if err := s.conn.WriteMessage(websocket.TextMessage, []byte(data)); err != nil {
 			return err
 		}
@@ -944,6 +1114,7 @@ func (s *responsesWebSocketSession) writeJSON(payload interface{}) error {
 	if err != nil {
 		return err
 	}
+	_ = s.conn.SetWriteDeadline(time.Now().Add(responsesWebSocketWriteWait))
 	return s.conn.WriteMessage(websocket.TextMessage, encoded)
 }
 

--- a/proxy/responses_websocket_test.go
+++ b/proxy/responses_websocket_test.go
@@ -3273,3 +3273,52 @@ func TestResponsesWebSocketRememberPlannedResponseResetsCompactionTrigger(t *tes
 		t.Fatalf("historyItems = %s, want reset empty history", session.historyItems)
 	}
 }
+
+func TestHandleResponsesWebSocket_SendsPingAndAcceptsPong(t *testing.T) {
+	oldWriteWait := responsesWebSocketWriteWait
+	oldPingPeriod := responsesWebSocketPingPeriod
+	responsesWebSocketWriteWait = 50 * time.Millisecond
+	responsesWebSocketPingPeriod = 10 * time.Millisecond
+	t.Cleanup(func() {
+		responsesWebSocketWriteWait = oldWriteWait
+		responsesWebSocketPingPeriod = oldPingPeriod
+	})
+
+	handler := &ProxyHandler{log: logger.New(logger.LevelError), responsesWS: ResponsesWebSocketConfig{Enabled: true}}
+	server := startResponsesWebSocketProxyServer(t, handler)
+	conn := mustDialResponsesWebSocket(t, server, nil)
+	defer func() { _ = conn.Close() }()
+
+	pinged := make(chan struct{})
+	var once sync.Once
+	conn.SetPingHandler(func(appData string) error {
+		once.Do(func() { close(pinged) })
+		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+	})
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+				return
+			}
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-pinged:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket ping")
+	}
+
+	_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "done"), time.Now().Add(time.Second))
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket reader to finish")
+	}
+}

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -2,23 +2,42 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"io"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/sozercan/vekil/logger"
 )
 
-const upstreamErrorDetailDrainTimeout = 250 * time.Millisecond
+const (
+	upstreamErrorDetailDrainTimeout = 250 * time.Millisecond
+	maxRetryBackoff                 = 30 * time.Second
+	maxRetryAfter                   = 5 * time.Minute
+)
 
 // retryable returns true for status codes that warrant a retry.
 func retryable(statusCode int) bool {
 	switch statusCode {
-	case http.StatusTooManyRequests,
+	case http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
 		http.StatusBadGateway,
 		http.StatusServiceUnavailable,
-		http.StatusGatewayTimeout:
+		http.StatusGatewayTimeout,
+		529, // Anthropic overloaded_error
+		520, // Cloudflare: web server returned an unknown error
+		521, // Cloudflare: web server is down
+		522, // Cloudflare: connection timed out
+		523, // Cloudflare: origin is unreachable
+		524, // Cloudflare: a timeout occurred
+		530: // Cloudflare: origin DNS / origin error
 		return true
 	}
 	return false
@@ -26,23 +45,62 @@ func retryable(statusCode int) bool {
 
 // backoff returns the delay for the given attempt (0-indexed) with jitter.
 func backoff(base time.Duration, attempt int) time.Duration {
-	delay := base << uint(attempt)
-	jitter := time.Duration(rand.Int64N(int64(delay / 4)))
-	return delay + jitter
+	if base <= 0 {
+		base = time.Nanosecond
+	}
+	if attempt < 0 {
+		attempt = 0
+	}
+
+	delay := base
+	for range attempt {
+		if delay >= maxRetryBackoff || delay > maxRetryBackoff/2 {
+			delay = maxRetryBackoff
+			break
+		}
+		delay *= 2
+	}
+	if delay > maxRetryBackoff {
+		delay = maxRetryBackoff
+	}
+
+	jitterBound := delay / 4
+	if jitterBound <= 0 {
+		return delay
+	}
+	return delay + time.Duration(rand.Int64N(int64(jitterBound)))
 }
 
 // parseRetryAfter extracts a delay from a Retry-After header value.
-// It supports both delay-seconds ("120") and is intentionally simple —
-// HTTP-date values are ignored and fall back to the caller's default.
+// It supports both delay-seconds ("120") and HTTP-date values.
 func parseRetryAfter(value string) (time.Duration, bool) {
 	if value == "" {
 		return 0, false
 	}
 	seconds, err := strconv.Atoi(value)
-	if err != nil || seconds <= 0 {
+	if err == nil {
+		if seconds <= 0 {
+			return 0, false
+		}
+		return clampRetryAfter(time.Duration(seconds) * time.Second), true
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
 		return 0, false
 	}
-	return time.Duration(seconds) * time.Second, true
+	delay := time.Until(retryAt)
+	if delay <= 0 {
+		return 0, false
+	}
+	return clampRetryAfter(delay), true
+}
+
+func clampRetryAfter(delay time.Duration) time.Duration {
+	if delay > maxRetryAfter {
+		return maxRetryAfter
+	}
+	return delay
 }
 
 // drainAndClose discards up to 4 KB from the body before closing it so that
@@ -75,8 +133,13 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		resp, err := h.client.Do(req)
 		if err != nil {
 			lastErr = err
+			if permanentTransportError(err) {
+				return nil, err
+			}
 			if attempt < maxRetries-1 {
-				if ctxErr := sleepWithContext(req.Context(), backoff(retryDelay, attempt)); ctxErr != nil {
+				delay := backoff(retryDelay, attempt)
+				h.logRetryAttempt(attempt, 0, "", delay, err)
+				if ctxErr := sleepWithContext(req.Context(), delay); ctxErr != nil {
 					return nil, ctxErr
 				}
 			}
@@ -102,6 +165,7 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			if ra, ok := parseRetryAfter(retryAfterHeader); ok && ra > delay {
 				delay = ra
 			}
+			h.logRetryAttempt(attempt, resp.StatusCode, retryAfterHeader, delay, nil)
 			if ctxErr := sleepWithContext(req.Context(), delay); ctxErr != nil {
 				return nil, ctxErr
 			}
@@ -110,6 +174,56 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		}
 	}
 	return nil, lastErr
+}
+
+func (h *ProxyHandler) logRetryAttempt(attempt int, status int, retryAfter string, delay time.Duration, err error) {
+	if h == nil || h.log == nil {
+		return
+	}
+	fields := []logger.Field{
+		logger.F("attempt", attempt),
+		logger.F("delay", delay.String()),
+	}
+	if status != 0 {
+		fields = append(fields, logger.F("status", status))
+	}
+	if retryAfter != "" {
+		fields = append(fields, logger.F("retry_after", retryAfter))
+	}
+	if err != nil {
+		fields = append(fields, logger.Err(err))
+	}
+	h.log.Debug("retrying upstream request", fields...)
+}
+
+func permanentTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var certVerifyErr *tls.CertificateVerificationError
+	if errors.As(err, &certVerifyErr) {
+		return true
+	}
+	var unknownAuthorityErr x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthorityErr) {
+		return true
+	}
+	var hostnameErr x509.HostnameError
+	if errors.As(err, &hostnameErr) {
+		return true
+	}
+	var certInvalidErr x509.CertificateInvalidError
+	if errors.As(err, &certInvalidErr) {
+		return true
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		return true
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "unsupported protocol scheme")
 }
 
 // sleepWithContext blocks for the given duration or until the context is done,

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -86,6 +86,42 @@ func TestDoWithRetry_RetriesOnServerError(t *testing.T) {
 	}
 }
 
+func TestDoWithRetry_RetriesAnthropicOverloaded529(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.WriteHeader(529)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	h := &ProxyHandler{
+		auth:           auth.NewTestAuthenticator("tok"),
+		client:         server.Client(),
+		copilotURL:     server.URL,
+		log:            logger.New(logger.LevelError),
+		retryBaseDelay: 1 * time.Millisecond,
+	}
+
+	resp, err := h.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequest(http.MethodPost, server.URL+"/test", nil)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2", calls.Load())
+	}
+}
+
 func TestDoWithRetry_ExhaustsRetries(t *testing.T) {
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -153,10 +189,19 @@ func TestRetryable(t *testing.T) {
 		{http.StatusOK, false},
 		{http.StatusBadRequest, false},
 		{http.StatusUnauthorized, false},
+		{http.StatusRequestTimeout, true},
 		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, false},
 		{http.StatusBadGateway, true},
 		{http.StatusServiceUnavailable, true},
 		{http.StatusGatewayTimeout, true},
+		{520, true},
+		{521, true},
+		{522, true},
+		{523, true},
+		{524, true},
+		{529, true},
+		{530, true},
 	}
 
 	for _, tt := range tests {
@@ -368,7 +413,7 @@ func TestParseRetryAfter(t *testing.T) {
 		{"abc", 0, false},
 		{"5", 5 * time.Second, true},
 		{"120", 120 * time.Second, true},
-		// HTTP-date is intentionally not supported.
+		{"999999", maxRetryAfter, true},
 		{"Wed, 21 Oct 2015 07:28:00 GMT", 0, false},
 	}
 
@@ -379,5 +424,31 @@ func TestParseRetryAfter(t *testing.T) {
 				t.Errorf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", tt.value, dur, ok, tt.wantDur, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestParseRetryAfter_HTTPDateAndClamp(t *testing.T) {
+	future := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+	dur, ok := parseRetryAfter(future)
+	if !ok {
+		t.Fatalf("parseRetryAfter(future HTTP-date) ok = false, want true")
+	}
+	if dur <= 0 || dur > 3*time.Second {
+		t.Fatalf("future HTTP-date duration = %v, want a small positive duration", dur)
+	}
+
+	farFuture := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
+	dur, ok = parseRetryAfter(farFuture)
+	if !ok || dur != maxRetryAfter {
+		t.Fatalf("far future duration = (%v, %v), want (%v, true)", dur, ok, maxRetryAfter)
+	}
+}
+
+func TestBackoffGuardsZeroBaseAndLargeAttempt(t *testing.T) {
+	if got := backoff(0, -10); got <= 0 {
+		t.Fatalf("backoff(0, -10) = %v, want positive duration", got)
+	}
+	if got := backoff(time.Second, 1000); got < maxRetryBackoff || got >= maxRetryBackoff+maxRetryBackoff/4 {
+		t.Fatalf("backoff(time.Second, 1000) = %v, want capped delay plus bounded jitter", got)
 	}
 }

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -119,7 +119,12 @@ func StreamOpenAIPassthroughWithFinalResponse(
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			return true
 		}
-		aggregator.addChunk(chunk)
+		if onUsage != nil && chunk.Usage != nil {
+			onUsage(chunk.Usage)
+		}
+		if aggregator != nil {
+			aggregator.addChunk(chunk)
+		}
 		return true
 	}
 
@@ -262,12 +267,7 @@ func StreamOpenAIToAnthropicWithFinalResponse(
 			onUsage(chunk.Usage)
 		}
 		if aggregator != nil {
-			if aggregator != nil {
-				aggregator.addChunk(chunk)
-			}
-			if onUsage != nil && chunk.Usage != nil {
-				onUsage(chunk.Usage)
-			}
+			aggregator.addChunk(chunk)
 		}
 		return state.consumeChunk(chunk)
 	})

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,6 +85,7 @@ func StreamOpenAIPassthroughWithFinalResponse(
 	w http.ResponseWriter,
 	body io.ReadCloser,
 	onFinalResponse func(*models.OpenAIResponse),
+	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
 	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
@@ -93,17 +95,21 @@ func StreamOpenAIPassthroughWithFinalResponse(
 		flusher = f
 	}
 
-	if onFinalResponse == nil {
+	onUsage := firstOpenAIUsageCallback(onUsageCallbacks)
+	if onFinalResponse == nil && onUsage == nil {
 		_, _ = io.Copy(&flushWriter{w: w, flusher: flusher}, body)
 		return
 	}
 
-	aggregator := newOpenAIResponseAggregator()
+	var aggregator *openAIResponseAggregator
+	if onFinalResponse != nil {
+		aggregator = newOpenAIResponseAggregator()
+	}
 	reader := bufio.NewReaderSize(body, openAIStreamScannerInitialBuffer)
 
 	sawDone := false
 	var accumulator sseDataAccumulator
-	processData := func(data string) bool {
+	processData := func(_ string, data string) bool {
 		if data == "[DONE]" {
 			sawDone = true
 			return true
@@ -118,7 +124,7 @@ func StreamOpenAIPassthroughWithFinalResponse(
 	}
 
 	for {
-		line, err := reader.ReadString('\n')
+		line, err := readOpenAISSELine(reader)
 		if len(line) > 0 {
 			if _, writeErr := io.WriteString(w, line); writeErr != nil {
 				return
@@ -137,10 +143,19 @@ func StreamOpenAIPassthroughWithFinalResponse(
 	}
 
 	accumulator.dispatch(processData)
-	if !sawDone {
+	if !sawDone || onFinalResponse == nil || aggregator == nil {
 		return
 	}
 	onFinalResponse(aggregator.buildResponse())
+}
+
+func firstOpenAIUsageCallback(callbacks []func(*models.OpenAIUsage)) func(*models.OpenAIUsage) {
+	for _, callback := range callbacks {
+		if callback != nil {
+			return callback
+		}
+	}
+	return nil
 }
 
 func streamAnthropicPassthroughBody(w http.ResponseWriter, body io.Reader, publicModel, upstreamModel string) {
@@ -160,7 +175,7 @@ func streamAnthropicPassthroughBody(w http.ResponseWriter, body io.Reader, publi
 	reader := bufio.NewReaderSize(body, openAIStreamScannerInitialBuffer)
 	frame := make([]string, 0, 4)
 	for {
-		line, err := reader.ReadString('\n')
+		line, err := readOpenAISSELine(reader)
 		if len(line) > 0 {
 			frame = append(frame, line)
 			if strings.TrimRight(line, "\r\n") == "" {
@@ -226,6 +241,7 @@ func StreamOpenAIToAnthropicWithFinalResponse(
 	model string,
 	requestID string,
 	onFinalResponse func(*models.OpenAIResponse),
+	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
 	defer func() { _ = body.Close() }()
 	setSSEHeaders(w)
@@ -239,14 +255,33 @@ func StreamOpenAIToAnthropicWithFinalResponse(
 	if onFinalResponse != nil {
 		aggregator = newOpenAIResponseAggregator()
 	}
+	onUsage := firstOpenAIUsageCallback(onUsageCallbacks)
 
 	sawDone, err := consumeOpenAIStreamChunks(body, func(chunk models.OpenAIStreamChunk) bool {
+		if onUsage != nil && chunk.Usage != nil {
+			onUsage(chunk.Usage)
+		}
 		if aggregator != nil {
-			aggregator.addChunk(chunk)
+			if aggregator != nil {
+				aggregator.addChunk(chunk)
+			}
+			if onUsage != nil && chunk.Usage != nil {
+				onUsage(chunk.Usage)
+			}
 		}
 		return state.consumeChunk(chunk)
 	})
-	if err != nil || !sawDone {
+	if err != nil {
+		var streamErr *openAIStreamError
+		if errors.As(err, &streamErr) {
+			state.emitError(streamErr.Error())
+			return
+		}
+		state.emitError(fmt.Sprintf("upstream stream read failed: %v", err))
+		return
+	}
+	if !sawDone {
+		state.emitError("upstream stream ended before [DONE]")
 		return
 	}
 
@@ -320,6 +355,20 @@ func (s *anthropicStreamState) start() bool {
 
 func (s *anthropicStreamState) emit(eventType string, data interface{}) bool {
 	return writeSSEEvent(s.w, eventType, data) == nil
+}
+
+func (s *anthropicStreamState) emitError(message string) bool {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "upstream stream ended unexpectedly"
+	}
+	return s.emit("error", map[string]interface{}{
+		"type": "error",
+		"error": map[string]string{
+			"type":    "api_error",
+			"message": message,
+		},
+	})
 }
 
 func (s *anthropicStreamState) consumeChunk(chunk models.OpenAIStreamChunk) bool {
@@ -515,10 +564,8 @@ func (s *anthropicStreamState) finish() bool {
 		Delta: delta,
 	}
 	if s.storedUsage != nil {
-		event.Usage = &models.AnthropicUsage{
-			InputTokens:  s.storedUsage.PromptTokens,
-			OutputTokens: s.storedUsage.CompletionTokens,
-		}
+		usage := openAIUsageToAnthropicUsage(s.storedUsage)
+		event.Usage = &usage
 	}
 
 	if !s.emit("message_delta", event) {
@@ -673,16 +720,5 @@ func (a *openAIResponseAggregator) buildMessage(choice *aggregatedOpenAIChoice) 
 }
 
 func convertFinishReason(reason string) string {
-	switch reason {
-	case "stop":
-		return "end_turn"
-	case "tool_calls":
-		return "tool_use"
-	case "length":
-		return "max_tokens"
-	case "content_filter":
-		return "end_turn"
-	default:
-		return reason
-	}
+	return MapStopReason(&reason)
 }

--- a/proxy/streaming_test.go
+++ b/proxy/streaming_test.go
@@ -19,7 +19,7 @@ func buildSSEStream(chunks ...string) io.ReadCloser {
 }
 
 func oversizedSSEPayload() string {
-	return strings.Repeat("x", openAIStreamScannerMaxBuffer+32)
+	return strings.Repeat("x", 1024*1024+32)
 }
 
 type sseEvent struct {
@@ -944,7 +944,8 @@ func TestConvertFinishReason(t *testing.T) {
 		{"length", "length", "max_tokens"},
 		{"tool_calls", "tool_calls", "tool_use"},
 		{"content_filter", "content_filter", "end_turn"},
-		{"unknown", "unknown_reason", "unknown_reason"},
+		{"function_call", "function_call", "tool_use"},
+		{"unknown", "unknown_reason", "end_turn"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1656,12 +1657,12 @@ func TestAggregateStreamToResponse_ErrorsOnScannerFailure(t *testing.T) {
 		"[DONE]",
 	)
 
-	if _, err := aggregateStreamToResponse(body); err == nil {
-		t.Fatal("expected error on scanner failure")
+	if _, err := aggregateStreamToResponse(body); err != nil {
+		t.Fatalf("unexpected error after oversized non-JSON SSE data: %v", err)
 	}
 }
 
-func TestStreamOpenAIToAnthropic_NoSuccessTailOnScannerFailure(t *testing.T) {
+func TestStreamOpenAIToAnthropic_ContinuesAfterOversizedNonJSONData(t *testing.T) {
 	body := buildSSEStream(
 		`{"id":"c1","created":1000,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hello"}}]}`,
 		oversizedSSEPayload(),
@@ -1672,9 +1673,53 @@ func TestStreamOpenAIToAnthropic_NoSuccessTailOnScannerFailure(t *testing.T) {
 	StreamOpenAIToAnthropic(w, body, "claude-sonnet-4", "req-scan-fail")
 
 	events := parseSSEEvents(w.Body.String())
+	foundStop := false
 	for _, evt := range events {
-		if evt.Event == "message_delta" || evt.Event == "message_stop" {
-			t.Fatalf("unexpected terminal success event %q after scanner failure\nraw:\n%s", evt.Event, w.Body.String())
+		if evt.Event == "message_stop" {
+			foundStop = true
 		}
+	}
+	if !foundStop {
+		t.Fatalf("expected stream to continue to message_stop after oversized non-JSON data\nraw:\n%s", w.Body.String())
+	}
+}
+
+func TestStreamOpenAIToAnthropic_TruncatedStreamEmitsErrorWithoutMessageStop(t *testing.T) {
+	body := buildSSEStream(`{"id":"c1","created":1000,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"partial"}}]}`)
+	w := httptest.NewRecorder()
+
+	StreamOpenAIToAnthropic(w, body, "claude-sonnet-4", "req-truncated")
+
+	events := parseSSEEvents(w.Body.String())
+	foundError := false
+	for _, evt := range events {
+		if evt.Event == "message_stop" {
+			t.Fatalf("unexpected message_stop for truncated stream\nraw:\n%s", w.Body.String())
+		}
+		if evt.Event == "error" {
+			foundError = true
+			if !strings.Contains(evt.Data, "upstream stream ended before [DONE]") {
+				t.Fatalf("error event data = %s, want truncation message", evt.Data)
+			}
+		}
+	}
+	if !foundError {
+		t.Fatalf("missing error event for truncated stream\nraw:\n%s", w.Body.String())
+	}
+}
+
+func TestConsumeOpenAIStreamChunks_ErrorsOnOverLimitSSELine(t *testing.T) {
+	largeMalformed := strings.Repeat("x", openAIStreamScannerMaxBuffer+32)
+	body := buildSSEStream(
+		`{"id":"c1","created":1000,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"ok"}}]}`,
+		largeMalformed,
+		"[DONE]",
+	)
+	_, err := aggregateStreamToResponse(body)
+	if err == nil {
+		t.Fatal("expected error for over-limit SSE line")
+	}
+	if !strings.Contains(err.Error(), "SSE line exceeds") {
+		t.Fatalf("error = %v, want SSE line limit", err)
 	}
 }

--- a/proxy/tool_optimizer_chat.go
+++ b/proxy/tool_optimizer_chat.go
@@ -196,11 +196,24 @@ func (h *ProxyHandler) captureOpenAIChatToolCallContext(call models.OpenAIToolCa
 }
 
 func (h *ProxyHandler) openAIChatStreamFinalResponseCallback(ctx context.Context, store *ToolExecutionContextStore, scope string) func(*models.OpenAIResponse) {
-	if h == nil || h.toolOptimizers == nil || !h.toolOptimizers.OutputReduceEnabled() || store == nil || strings.TrimSpace(scope) == "" {
+	shouldCaptureTools := h != nil && h.toolOptimizers != nil && h.toolOptimizers.OutputReduceEnabled() && store != nil && strings.TrimSpace(scope) != ""
+	if !shouldCaptureTools {
 		return nil
 	}
 	return func(oaiResp *models.OpenAIResponse) {
+		if oaiResp != nil {
+			observeOpenAIUsage(ctx, oaiResp.Usage)
+		}
 		h.maybeRewriteOrCaptureOpenAIChatToolCommands(ctx, oaiResp, store, scope, false)
+	}
+}
+
+func openAIChatStreamUsageCallback(ctx context.Context) func(*models.OpenAIUsage) {
+	if RequestSummaryFromContext(ctx) == nil {
+		return nil
+	}
+	return func(usage *models.OpenAIUsage) {
+		observeOpenAIUsage(ctx, usage)
 	}
 }
 

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -85,7 +85,7 @@ func TranslateAnthropicToOpenAI(req *models.AnthropicRequest) (*models.OpenAIReq
 	}
 
 	// Parallel tool calls
-	if len(oaiReq.Tools) > 0 {
+	if len(oaiReq.Tools) > 0 && (req.ToolChoice == nil || !strings.EqualFold(strings.TrimSpace(req.ToolChoice.Type), "none")) {
 		parallelToolCalls := true
 		if req.ToolChoice != nil && req.ToolChoice.DisableParallelToolUse != nil && *req.ToolChoice.DisableParallelToolUse {
 			parallelToolCalls = false
@@ -188,12 +188,16 @@ func translateMessage(msg models.AnthropicMessage) ([]models.OpenAIMessage, erro
 			multimodalParts = append(multimodalParts, *part)
 
 		case "tool_use":
+			arguments := block.Input
+			if !json.Valid(arguments) {
+				arguments = json.RawMessage(`{}`)
+			}
 			toolCalls = append(toolCalls, models.OpenAIToolCall{
 				ID:   block.ID,
 				Type: "function",
 				Function: models.OpenAIFunctionCall{
 					Name:      block.Name,
-					Arguments: string(block.Input),
+					Arguments: string(arguments),
 				},
 			})
 
@@ -357,12 +361,31 @@ func MapStopReason(finishReason *string) string {
 		return "end_turn"
 	case "length":
 		return "max_tokens"
-	case "tool_calls":
+	case "tool_calls", "function_call":
 		return "tool_use"
 	case "content_filter":
 		return "end_turn"
 	default:
 		return "end_turn"
+	}
+}
+
+func openAIUsageToAnthropicUsage(usage *models.OpenAIUsage) models.AnthropicUsage {
+	if usage == nil {
+		return models.AnthropicUsage{}
+	}
+	cachedTokens := 0
+	if usage.PromptTokensDetails != nil && usage.PromptTokensDetails.CachedTokens > 0 {
+		cachedTokens = usage.PromptTokensDetails.CachedTokens
+	}
+	inputTokens := usage.PromptTokens - cachedTokens
+	if inputTokens < 0 {
+		inputTokens = 0
+	}
+	return models.AnthropicUsage{
+		InputTokens:          inputTokens,
+		CacheReadInputTokens: cachedTokens,
+		OutputTokens:         usage.CompletionTokens,
 	}
 }
 
@@ -425,10 +448,7 @@ func TranslateOpenAIToAnthropic(resp *models.OpenAIResponse, model string) *mode
 	}
 
 	if resp.Usage != nil {
-		result.Usage = models.AnthropicUsage{
-			InputTokens:  resp.Usage.PromptTokens,
-			OutputTokens: resp.Usage.CompletionTokens,
-		}
+		result.Usage = openAIUsageToAnthropicUsage(resp.Usage)
 	}
 
 	return result

--- a/proxy/upstream_error_detail.go
+++ b/proxy/upstream_error_detail.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"unicode/utf8"
 )
@@ -28,6 +29,12 @@ func formatUpstreamRequestFailure(err error, fallback string) string {
 	var upstreamErr *upstreamError
 	if errors.As(err, &upstreamErr) {
 		return upstreamErr.Error()
+	}
+	var providerErr *providerRequestError
+	if errors.As(err, &providerErr) {
+		if detail := sanitizeUpstreamErrorText(providerErr.Error()); detail != "" {
+			return detail
+		}
 	}
 	return fallback
 }
@@ -97,12 +104,13 @@ func summarizeJSONErrorValue(raw json.RawMessage) string {
 		}
 	}
 
-	attrs := make([]string, 0, 4)
+	attrs := make([]string, 0, 6)
 	for _, key := range []string{"type", "code", "param", "status"} {
 		if value := rawJSONErrorString(obj[key]); value != "" {
 			attrs = append(attrs, key+"="+value)
 		}
 	}
+	attrs = append(attrs, summarizeJSONInnerError(obj["innererror"])...)
 
 	if message == "" {
 		return strings.Join(attrs, ", ")
@@ -111,6 +119,55 @@ func summarizeJSONErrorValue(raw json.RawMessage) string {
 		return message
 	}
 	return message + " (" + strings.Join(attrs, ", ") + ")"
+}
+
+func summarizeJSONInnerError(raw json.RawMessage) []string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil
+	}
+	var inner map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &inner); err != nil {
+		return nil
+	}
+	attrs := make([]string, 0, 2)
+	if code := rawJSONErrorString(inner["code"]); code != "" {
+		attrs = append(attrs, "innererror.code="+code)
+	}
+	if filtered := summarizeContentFilterResult(inner["content_filter_result"]); filtered != "" {
+		attrs = append(attrs, "content_filter="+filtered)
+	}
+	return attrs
+}
+
+func summarizeContentFilterResult(raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	var categories map[string]struct {
+		Filtered bool   `json:"filtered"`
+		Severity string `json:"severity"`
+	}
+	if err := json.Unmarshal(raw, &categories); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, len(categories))
+	for category, result := range categories {
+		if !result.Filtered {
+			continue
+		}
+		category = sanitizeUpstreamErrorText(category)
+		severity := sanitizeUpstreamErrorText(result.Severity)
+		if category == "" {
+			continue
+		}
+		if severity != "" {
+			parts = append(parts, category+"="+severity)
+		} else {
+			parts = append(parts, category)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ";")
 }
 
 func rawJSONErrorString(raw json.RawMessage) string {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -117,7 +117,7 @@ func mergeHeaderValues(dst, src http.Header) {
 	}
 }
 
-func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, []byte, error) {
+func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, providerModel, []byte, error) {
 	model := extractRequestModel(body)
 	lookupModel := model
 	if endpoint == providerEndpointMessages {
@@ -125,32 +125,70 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 	}
 	provider, owner, known := h.resolveProviderModel(lookupModel, endpoint)
 	if provider == nil {
-		return nil, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
+		return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no provider available for endpoint %s", endpoint)}
 	}
 	if !provider.supportsEndpoint(endpoint) {
-		return nil, nil, &providerRequestError{
+		return nil, providerModel{}, nil, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("provider %q does not support %s", provider.id, endpoint),
 		}
 	}
 	if known && !providerModelSupportsEndpoint(owner, endpoint) {
-		return nil, nil, &providerRequestError{
+		return nil, providerModel{}, nil, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
 		}
 	}
 	if !known && !provider.allowsUnknownModelEndpoint(endpoint) {
-		return nil, nil, &providerRequestError{
+		return nil, providerModel{}, nil, &providerRequestError{
 			statusCode: http.StatusBadRequest,
 			err:        fmt.Errorf("model %q does not support %s", model, endpoint),
 		}
 	}
 
-	rewrittenBody, _, err := rewriteRequestModelForProvider(body, owner.upstreamModel)
-	if err != nil {
-		return nil, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+	rewrittenBody := body
+	if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
+		var err error
+		rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)
+		if err != nil {
+			return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+		}
 	}
-	return provider, rewrittenBody, nil
+	rewrittenBody = applyProviderModelRequestPolicy(rewrittenBody, owner)
+	return provider, owner, rewrittenBody, nil
+}
+
+func applyProviderModelRequestPolicy(body []byte, owner providerModel) []byte {
+	if !owner.dropSamplingParams && (owner.parallelToolCalls == nil || *owner.parallelToolCalls) {
+		return body
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+	changed := false
+	if owner.dropSamplingParams {
+		for _, field := range []string{"temperature", "top_p"} {
+			if _, ok := payload[field]; ok {
+				delete(payload, field)
+				changed = true
+			}
+		}
+	}
+	if owner.parallelToolCalls != nil && !*owner.parallelToolCalls {
+		if _, ok := payload["parallel_tool_calls"]; ok {
+			delete(payload, "parallel_tool_calls")
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return rewritten
 }
 
 func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body []byte) (*http.Response, error) {
@@ -158,13 +196,13 @@ func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body [
 }
 
 func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	provider, rewrittenBody, err := h.resolveProviderRequest(body, path)
+	provider, owner, rewrittenBody, err := h.resolveProviderRequest(body, path)
 	if err != nil {
 		return nil, err
 	}
 
 	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "")
+		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "", owner)
 		if err != nil {
 			return nil, err
 		}
@@ -185,7 +223,7 @@ func (h *ProxyHandler) postAnthropicMessages(ctx context.Context, body []byte, e
 }
 
 func (h *ProxyHandler) postAnthropicMessagesCountTokens(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	provider, rewrittenBody, err := h.resolveProviderRequest(body, providerEndpointMessages)
+	provider, owner, rewrittenBody, err := h.resolveProviderRequest(body, providerEndpointMessages)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +235,7 @@ func (h *ProxyHandler) postAnthropicMessagesCountTokens(ctx context.Context, bod
 	}
 
 	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "")
+		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "", owner)
 		if err != nil {
 			return nil, err
 		}

--- a/proxy/upstream_http_test.go
+++ b/proxy/upstream_http_test.go
@@ -1,9 +1,12 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -84,7 +87,7 @@ func TestExtractRequestModel(t *testing.T) {
 func TestResolveProviderRequest_RewritesConfiguredResponsesModelToProviderDeployment(t *testing.T) {
 	handler := newProviderRoutingTestHandler(t, []string{"/responses"})
 
-	provider, rewrittenBody, err := handler.resolveProviderRequest([]byte(`{"model":"gpt-5-public","input":"hello"}`), "/responses")
+	provider, _, rewrittenBody, err := handler.resolveProviderRequest([]byte(`{"model":"gpt-5-public","input":"hello"}`), "/responses")
 	if err != nil {
 		t.Fatalf("resolveProviderRequest() error = %v", err)
 	}
@@ -112,7 +115,7 @@ func TestResolveProviderRequest_RewritesConfiguredResponsesModelToProviderDeploy
 func TestResolveProviderRequest_RejectsKnownModelWithoutEndpointSupport(t *testing.T) {
 	handler := newProviderRoutingTestHandler(t, []string{"/responses"})
 
-	provider, rewrittenBody, err := handler.resolveProviderRequest([]byte(`{"model":"gpt-5-public","messages":[{"role":"user","content":"hello"}]}`), "/chat/completions")
+	provider, _, rewrittenBody, err := handler.resolveProviderRequest([]byte(`{"model":"gpt-5-public","messages":[{"role":"user","content":"hello"}]}`), "/chat/completions")
 	if err == nil {
 		t.Fatal("resolveProviderRequest() error = nil, want unsupported endpoint error")
 	}
@@ -140,7 +143,7 @@ func TestResponsesRequestRewriting_StripsUnsupportedImageGenerationToolForAzure(
 	originalBody := []byte(`{"model":"gpt-5-public","input":"hello","tools":[{"type":"function","name":"lookup_weather","description":"Lookup the weather","parameters":{"type":"object","properties":{}}},{"type":"image_generation"}],"tool_choice":"auto"}`)
 
 	rewrittenForResponses := handler.rewriteResponsesRequestBody(originalBody, "responses", true)
-	provider, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
+	provider, _, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
 	if err != nil {
 		t.Fatalf("resolveProviderRequest() error = %v", err)
 	}
@@ -184,7 +187,7 @@ func TestResponsesRequestRewriting_StripsUnsupportedImageGenerationToolForDefaul
 	originalBody := []byte(`{"model":"gpt-5.4","input":"hello","tools":[{"type":"image_generation"}],"tool_choice":"required"}`)
 
 	rewrittenForResponses := handler.rewriteResponsesRequestBody(originalBody, "responses", true)
-	provider, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
+	provider, _, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
 	if err != nil {
 		t.Fatalf("resolveProviderRequest() error = %v", err)
 	}
@@ -216,7 +219,7 @@ func TestResponsesRequestRewriting_StripsUnsupportedImageGenerationToolChoiceFor
 	originalBody := []byte(`{"model":"gpt-5-public","input":"hello","tools":[{"type":"function","name":"lookup_weather","description":"Lookup the weather","parameters":{"type":"object","properties":{}}},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
 
 	rewrittenForResponses := handler.rewriteResponsesRequestBody(originalBody, "responses", true)
-	provider, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
+	provider, _, rewrittenBody, err := handler.resolveProviderRequest(rewrittenForResponses, "/responses")
 	if err != nil {
 		t.Fatalf("resolveProviderRequest() error = %v", err)
 	}
@@ -306,5 +309,67 @@ func TestRewriteRequestModelForProvider_RewritesGenericJSONModelAndNoopsWhenUnch
 	}
 	if string(unchangedBody) != string(rewrittenBody) {
 		t.Fatalf("rewriteRequestModelForProvider(already mapped) body changed: got %s want %s", unchangedBody, rewrittenBody)
+	}
+}
+
+func TestPostChatCompletions_UsesAzureClassicDeploymentURLAndKeepsPublicBodyModel(t *testing.T) {
+	var sawRequest bool
+	azureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if got, want := r.URL.Path, "/openai/deployments/gpt-5-4-prod/chat/completions"; got != want {
+			t.Fatalf("upstream path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("api-version"), "2025-04-01-preview"; got != want {
+			t.Fatalf("api-version = %q, want %q", got, want)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read upstream body: %v", err)
+		}
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal upstream body: %v", err)
+		}
+		if got := rawJSONString(payload["model"]); got != "gpt-5-public" {
+			t.Fatalf("upstream body model = %q, want public model to remain unchanged", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-test","choices":[]}`))
+	}))
+	defer azureServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:         "azure",
+				Type:       "azure-openai",
+				Default:    true,
+				BaseURL:    azureServer.URL + "/openai",
+				APIVersion: "2025-04-01-preview",
+				APIKey:     "azure-test-key",
+				Models: []ProviderModelConfig{{
+					PublicID:   "gpt-5-public",
+					Deployment: "gpt-5-4-prod",
+					Endpoints:  []string{providerEndpointChatCompletions},
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+
+	resp, err := handler.postChatCompletions(context.Background(), []byte(`{"model":"gpt-5-public","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("postChatCompletions() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if !sawRequest {
+		t.Fatal("upstream server was not called")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net"
@@ -15,9 +16,10 @@ import (
 
 // Server encapsulates the HTTP server lifecycle.
 type Server struct {
-	httpServer *http.Server
-	log        *logger.Logger
-	running    atomic.Bool
+	httpServer   *http.Server
+	proxyHandler *proxy.ProxyHandler
+	log          *logger.Logger
+	running      atomic.Bool
 }
 
 type options struct {
@@ -72,6 +74,91 @@ func WithCompactUpstreamMaxAttempts(max int) Option {
 	return WithProxyOptions(proxy.WithCompactUpstreamMaxAttempts(max))
 }
 
+type responseRecorder struct {
+	http.ResponseWriter
+	status int
+	bytes  int64
+}
+
+func (r *responseRecorder) WriteHeader(status int) {
+	if r.status != 0 {
+		return
+	}
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *responseRecorder) Write(p []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	n, err := r.ResponseWriter.Write(p)
+	r.bytes += int64(n)
+	return n, err
+}
+
+func (r *responseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (r *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := r.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	conn, rw, err := h.Hijack()
+	if err != nil {
+		return nil, nil, err
+	}
+	if r.status == 0 {
+		r.status = http.StatusSwitchingProtocols
+	}
+	return conn, rw, nil
+}
+
+func (r *responseRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+func withRequestLog(next http.Handler, log *logger.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		recorder := &responseRecorder{ResponseWriter: w}
+		ctx, summary := proxy.WithRequestSummary(r.Context())
+		next.ServeHTTP(recorder, r.WithContext(ctx))
+		status := recorder.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		if log != nil {
+			fields := []logger.Field{
+				logger.F("method", r.Method),
+				logger.F("path", r.URL.Path),
+				logger.F("status", status),
+				logger.F("bytes", recorder.bytes),
+				logger.F("duration_ms", time.Since(start).Milliseconds()),
+			}
+			if requestID := proxy.UpstreamRequestID(recorder.Header()); requestID != "" {
+				summaryFields := summary.LoggerFields()
+				alreadyCaptured := false
+				for _, field := range summaryFields {
+					if field.Key == "upstream_request_id" {
+						alreadyCaptured = true
+						break
+					}
+				}
+				if !alreadyCaptured {
+					fields = append(fields, logger.F("upstream_request_id", requestID))
+				}
+			}
+			fields = append(fields, summary.LoggerFields()...)
+			log.Info("request completed", fields...)
+		}
+	})
+}
+
 // New creates a Server with routes and timeouts configured.
 func New(authenticator *auth.Authenticator, log *logger.Logger, host, port string, opts ...Option) (*Server, error) {
 	cfg := options{}
@@ -105,12 +192,13 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      withRequestLog(mux, log),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,
 		},
-		log: log,
+		proxyHandler: handler,
+		log:          log,
 	}, nil
 }
 
@@ -137,6 +225,9 @@ func (s *Server) Start() error {
 
 // Stop performs a graceful shutdown of the server.
 func (s *Server) Stop(ctx context.Context) error {
+	if s.proxyHandler != nil {
+		s.proxyHandler.ShutdownWebSocketSessions(ctx)
+	}
 	err := s.httpServer.Shutdown(ctx)
 	s.running.Store(false)
 	return err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -170,3 +170,93 @@ func TestRequestLogIncludesSummaryUsageAndUpstreamRequestID(t *testing.T) {
 		}
 	}
 }
+
+// TestStreamingChatCompletionsPassthroughThroughServer drives a streaming
+// POST /v1/chat/completions request through the full server stack (so
+// withRequestLog attaches a RequestSummary and the usage callback is non-nil)
+// with tool optimizers disabled. This exercises StreamOpenAIPassthroughWithFinalResponse
+// on its default-config path, where onFinalResponse is nil but onUsage is not.
+// Before the nil-aggregator guard this panicked on the first SSE chunk; this
+// test also asserts the streamed body is forwarded verbatim with a [DONE]
+// sentinel and that streaming usage is recorded in the request log.
+func TestStreamingChatCompletionsPassthroughThroughServer(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("upstream path = %q, want /chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("X-Request-Id", "req-stream-456")
+		flusher, _ := w.(http.Flusher)
+		writeChunk := func(s string) {
+			_, _ = io.WriteString(w, s)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		writeChunk("data: {\"id\":\"chatcmpl-2\",\"created\":1,\"model\":\"gpt-5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hel\"}}]}\n\n")
+		writeChunk("data: {\"id\":\"chatcmpl-2\",\"created\":1,\"model\":\"gpt-5\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"}}]}\n\n")
+		writeChunk("data: {\"id\":\"chatcmpl-2\",\"created\":1,\"model\":\"gpt-5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2,\"total_tokens\":9}}\n\n")
+		writeChunk("data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	var logs bytes.Buffer
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.NewWithWriter(logger.LevelInfo, &logs),
+		"127.0.0.1",
+		"0",
+		WithProxyOptions(proxy.WithCopilotBaseURL(upstream.URL)),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	body := `{"model":"gpt-5","stream":true,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		got, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(got))
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	streamed, _ := io.ReadAll(resp.Body)
+	got := string(streamed)
+	// The passthrough must forward every upstream chunk verbatim, including
+	// the terminal [DONE] sentinel, without truncation or panic.
+	for _, want := range []string{"\"content\":\"Hel\"", "\"content\":\"lo\"", "\"finish_reason\":\"stop\"", "data: [DONE]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("streamed body missing %q; got:\n%s", want, got)
+		}
+	}
+
+	lines := strings.Split(strings.TrimSpace(logs.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("log lines = %d, want 1: %q", len(lines), logs.String())
+	}
+	var entry map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("unmarshal log entry: %v", err)
+	}
+	if got, ok := entry["stream"].(bool); !ok || !got {
+		t.Fatalf("log[stream] = %#v, want true", entry["stream"])
+	}
+	// Usage must be observed via the streaming onUsage callback (regression:
+	// the callback was previously wired but never invoked, so these were absent).
+	for key, expected := range map[string]float64{"status": 200, "prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9} {
+		if got, ok := entry[key].(float64); !ok || got != expected {
+			t.Fatalf("log[%s] = %#v, want %v in %#v", key, entry[key], expected, entry)
+		}
+	}
+	if got := entry["upstream_request_id"]; got != "req-stream-456" {
+		t.Fatalf("log[upstream_request_id] = %#v, want req-stream-456", got)
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,7 +1,12 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +99,74 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestRequestLogIncludesSummaryUsageAndUpstreamRequestID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("upstream path = %q, want /chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("X-Request-Id", "req-upstream-123")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"created\":1,\"model\":\"gpt-5\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"created\":1,\"model\":\"gpt-5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":3,\"total_tokens\":15}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	var logs bytes.Buffer
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.NewWithWriter(logger.LevelInfo, &logs),
+		"127.0.0.1",
+		"0",
+		WithProxyOptions(proxy.WithCopilotBaseURL(upstream.URL)),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	body := `{"model":"gpt-5","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{}}}}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(body))
+	}
+
+	lines := strings.Split(strings.TrimSpace(logs.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("log lines = %d, want 1: %q", len(lines), logs.String())
+	}
+	var entry map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("unmarshal log entry: %v", err)
+	}
+	want := map[string]interface{}{
+		"msg":                 "request completed",
+		"method":              "POST",
+		"path":                "/v1/chat/completions",
+		"endpoint":            "openai_chat",
+		"model":               "gpt-5",
+		"provider":            "copilot",
+		"provider_kind":       "copilot",
+		"stream":              false,
+		"upstream_request_id": "req-upstream-123",
+	}
+	for key, expected := range want {
+		if got := entry[key]; got != expected {
+			t.Fatalf("log[%s] = %#v, want %#v in %#v", key, got, expected, entry)
+		}
+	}
+	for key, expected := range map[string]float64{"status": 200, "prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15} {
+		if got, ok := entry[key].(float64); !ok || got != expected {
+			t.Fatalf("log[%s] = %#v, want %v in %#v", key, entry[key], expected, entry)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Harden proxy compatibility and reliability.
- Add regression coverage for important edge cases.
- Refresh supporting documentation.

## Validation
- `make test`
- `make build`
- `make vet`
- `make lint`
- `golangci-lint run --new-from-rev=de0bb7a4bcce7e66e33d23efc024dc22a39dfd97`
- `go test ./proxy -race -count=1`
