### PR TITLE
Add basic metrics endpoint

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+type metrics struct {
+	requestsTotal uint64
+	inFlight      int64
+}
+
+func (m *metrics) instrument(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddUint64(&m.requestsTotal, 1)
+		atomic.AddInt64(&m.inFlight, 1)
+		defer atomic.AddInt64(&m.inFlight, -1)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (m *metrics) handle(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = fmt.Fprintf(w, "# HELP vekil_http_requests_total Total HTTP requests served by Vekil.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", atomic.LoadUint64(&m.requestsTotal))
+	_, _ = fmt.Fprintf(w, "# HELP vekil_http_in_flight_requests Current in-flight HTTP requests served by Vekil.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_in_flight_requests gauge\n")
+	_, _ = fmt.Fprintf(w, "vekil_http_in_flight_requests %d\n", atomic.LoadInt64(&m.inFlight))
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -23,10 +24,10 @@ func (m *metrics) instrument(next http.Handler) http.Handler {
 
 func (m *metrics) handle(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-	_, _ = fmt.Fprintf(w, "# HELP vekil_http_requests_total Total HTTP requests served by Vekil.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_requests_total counter\n")
-	_, _ = fmt.Fprintf(w, "vekil_http_requests_total %d\n", atomic.LoadUint64(&m.requestsTotal))
-	_, _ = fmt.Fprintf(w, "# HELP vekil_http_in_flight_requests Current in-flight HTTP requests served by Vekil.\n")
-	_, _ = fmt.Fprintf(w, "# TYPE vekil_http_in_flight_requests gauge\n")
-	_, _ = fmt.Fprintf(w, "vekil_http_in_flight_requests %d\n", atomic.LoadInt64(&m.inFlight))
+	_, _ = io.WriteString(w, "# HELP vekil_http_requests_total Total HTTP requests served by Vekil.\n")
+	_, _ = io.WriteString(w, "# TYPE vekil_http_requests_total counter\n")
+	_, _ = io.WriteString(w, "vekil_http_requests_total " + strconv.FormatUint(atomic.LoadUint64(&m.requestsTotal), 10) + "\n")
+	_, _ = io.WriteString(w, "# HELP vekil_http_in_flight_requests Current in-flight HTTP requests served by Vekil.\n")
+	_, _ = io.WriteString(w, "# TYPE vekil_http_in_flight_requests gauge\n")
+	_, _ = io.WriteString(w, "vekil_http_in_flight_requests " + strconv.FormatInt(atomic.LoadInt64(&m.inFlight), 10) + "\n")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -101,11 +101,14 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	mux.HandleFunc("GET /readyz", handler.HandleReadyz)
 	mux.HandleFunc("GET /v1/models", handler.HandleModels)
 
+	serverMetrics := &metrics{}
+	mux.HandleFunc("GET /metrics", serverMetrics.handle)
+
 	addr := fmt.Sprintf("%s:%s", host, port)
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      mux,
+			Handler:      serverMetrics.instrument(mux),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -94,5 +97,43 @@ func TestNew_DerivesWriteTimeoutFromConfiguredProxyHandler(t *testing.T) {
 				t.Fatalf("WriteTimeout = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestMetricsEndpointReportsRequestsAndInFlight(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", got)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	text := string(body)
+	for _, want := range []string{
+		"# TYPE vekil_http_requests_total counter\n",
+		"vekil_http_requests_total 1\n",
+		"# TYPE vekil_http_in_flight_requests gauge\n",
+		"vekil_http_in_flight_requests 1\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected metrics body to contain %q, got:\n%s", want, text)
+		}
 	}
 }


### PR DESCRIPTION
## Summary\n- add a Prometheus-style /metrics endpoint to the existing HTTP server\n- instrument requests with a total counter and in-flight gauge\n- add focused server test coverage for emitted metrics\n\n## Validation\n- git diff --cached --check\n- go test ./server (not run: go binary is unavailable in this sandbox)