### PR TITLE
Add --quiet flag to suppress non-error output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,9 +24,12 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | none | `false` | Suppress non-error CLI output |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.
+
+When `--quiet` is set, startup uses non-interactive Copilot auth so device-code prompts are not printed; run `vekil login` first if an interactive sign-in is required.
 
 ## Copilot Header Overrides
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -28,12 +29,13 @@ const (
 
 func main() {
 	// Dispatch subcommands before falling through to the default server mode.
-	switch commandFromArgs(os.Args) {
+	command, commandArgs := commandAndArgsFromArgs(os.Args)
+	switch command {
 	case cliCommandLogin:
-		runLogin(os.Args[2:])
+		runLogin(commandArgs)
 		return
 	case cliCommandLogout:
-		runLogout(os.Args[2:])
+		runLogout(commandArgs)
 		return
 	}
 
@@ -41,24 +43,47 @@ func main() {
 }
 
 func commandFromArgs(args []string) cliCommand {
+	command, _ := commandAndArgsFromArgs(args)
+	return command
+}
+
+func commandAndArgsFromArgs(args []string) (cliCommand, []string) {
 	if len(args) < 2 {
-		return cliCommandServe
+		return cliCommandServe, nil
 	}
 
-	switch args[1] {
-	case "login":
-		return cliCommandLogin
-	case "logout":
-		return cliCommandLogout
-	default:
-		return cliCommandServe
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "login":
+			return cliCommandLogin, subcommandArgs(args, i)
+		case "logout":
+			return cliCommandLogout, subcommandArgs(args, i)
+		}
+
+		if !isGlobalFlagArg(args[i]) {
+			return cliCommandServe, args[1:]
+		}
 	}
+
+	return cliCommandServe, args[1:]
+}
+
+func subcommandArgs(args []string, commandIndex int) []string {
+	commandArgs := make([]string, 0, len(args)-2)
+	commandArgs = append(commandArgs, args[1:commandIndex]...)
+	commandArgs = append(commandArgs, args[commandIndex+1:]...)
+	return commandArgs
+}
+
+func isGlobalFlagArg(arg string) bool {
+	return arg == "--quiet" || strings.HasPrefix(arg, "--quiet=")
 }
 
 type loginOptions struct {
 	tokenDir     string
 	useGitHubCLI bool
 	force        bool
+	quiet        bool
 }
 
 var errConflictingLoginFlags = fmt.Errorf("--github-cli/--gh cannot be used with --force")
@@ -118,13 +143,13 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 			_, _ = fmt.Fprintf(deps.stderr, "error signing in with GitHub CLI: %v\n", err)
 			return 1
 		}
-		_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+		writeStatus(opts.quiet, deps.stderr, "Login successful.\n")
 		return 0
 	}
 
 	if !opts.force {
 		if _, err := authenticator.RefreshTokenNonInteractive(ctx); err == nil {
-			_, _ = fmt.Fprintln(deps.stderr, "Already logged in.")
+			writeStatus(opts.quiet, deps.stderr, "Already logged in.\n")
 			return 0
 		} else if !auth.IsInteractiveLoginRequired(err) {
 			_, _ = fmt.Fprintf(deps.stderr, "error refreshing existing login: %v\n", err)
@@ -138,11 +163,11 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
-	_, _ = fmt.Fprintf(deps.stderr, "Enter code: %s\n", dcResp.UserCode)
+	writeStatus(opts.quiet, deps.stderr, "Opening browser to %s\n", dcResp.VerificationURI)
+	writeStatus(opts.quiet, deps.stderr, "Enter code: %s\n", dcResp.UserCode)
 
 	if err := deps.openURL(dcResp.VerificationURI); err != nil {
-		_, _ = fmt.Fprintf(deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
+		writeStatus(opts.quiet, deps.stderr, "Could not open browser automatically, please visit the URL above.\n")
 	}
 
 	if err := authenticator.PollForAuthorization(ctx, dcResp); err != nil {
@@ -150,7 +175,7 @@ func runLoginWithDeps(args []string, deps loginDeps) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintln(deps.stderr, "Login successful.")
+	writeStatus(opts.quiet, deps.stderr, "Login successful.\n")
 	return 0
 }
 
@@ -178,6 +203,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	githubCLI := fs.Bool("github-cli", false, "Sign in using the currently authenticated GitHub CLI account")
 	gh := fs.Bool("gh", false, "Alias for --github-cli")
 	force := fs.Bool("force", false, "Force the interactive GitHub device-code flow")
+	quiet := registerQuietFlag(fs)
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
@@ -185,6 +211,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 	opts.tokenDir = *tokenDir
 	opts.useGitHubCLI = *githubCLI || *gh
 	opts.force = *force
+	opts.quiet = *quiet
 	if opts.useGitHubCLI && opts.force {
 		return opts, errConflictingLoginFlags
 	}
@@ -194,6 +221,7 @@ func parseLoginOptions(args []string, stderr io.Writer) (loginOptions, error) {
 func runLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	tokenDir := fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)")
+	quiet := registerQuietFlag(fs)
 	fs.Parse(args) //nolint:errcheck
 
 	authenticator, err := auth.NewAuthenticator(*tokenDir)
@@ -207,7 +235,18 @@ func runLogout(args []string) {
 		os.Exit(1)
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.")
+	writeStatus(*quiet, os.Stderr, "Logged out. Vekil will not use GitHub CLI automatically until you run vekil login --github-cli.\n")
+}
+
+func registerQuietFlag(fs *flag.FlagSet) *bool {
+	return fs.Bool("quiet", false, "Suppress non-error output")
+}
+
+func writeStatus(quiet bool, w io.Writer, format string, args ...interface{}) {
+	if quiet {
+		return
+	}
+	_, _ = fmt.Fprintf(w, format, args...)
 }
 
 type serveFlags struct {
@@ -232,6 +271,7 @@ type serveFlags struct {
 	compactUpstreamChunkBytes       *int
 	compactUpstreamChunkConcurrency *int
 	compactUpstreamMaxAttempts      *int
+	quiet                           *bool
 }
 
 func registerServeFlags(fs *flag.FlagSet) serveFlags {
@@ -257,6 +297,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		compactUpstreamChunkBytes:       fs.Int("compact-upstream-chunk-bytes", getEnvInt("COMPACT_UPSTREAM_CHUNK_BYTES", proxy.DefaultCompactUpstreamChunkBytes()), "Target body size (bytes) for chunked /v1/responses/compact retries after an upstream 413; halved on each recursive 413 down to a 64 KiB floor"),
 		compactUpstreamChunkConcurrency: fs.Int("compact-upstream-chunk-concurrency", getEnvInt("COMPACT_UPSTREAM_CHUNK_CONCURRENCY", proxy.DefaultCompactUpstreamChunkConcurrency()), "Maximum sibling chunk compaction calls to run concurrently after the first chunk succeeds"),
 		compactUpstreamMaxAttempts:      fs.Int("compact-upstream-max-attempts", getEnvInt("COMPACT_UPSTREAM_MAX_ATTEMPTS", proxy.DefaultCompactUpstreamMaxAttempts()), "Maximum logical compaction calls the /v1/responses/compact 413 fallback may issue per inbound request. Each call may add one extra HTTP POST for model-fallback and is subject to the shared transport-retry policy"),
+		quiet:                           registerQuietFlag(fs),
 	}
 }
 
@@ -286,7 +327,11 @@ func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	logLevel := logger.ParseLevel(*serve.logLevel)
+	if *serve.quiet && logLevel < logger.LevelError {
+		logLevel = logger.LevelError
+	}
+	log := logger.New(logLevel)
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {
@@ -301,7 +346,13 @@ func runServe() {
 	if providersCfg.UsesCopilot() {
 		log.Info("authenticating with GitHub Copilot...")
 		ctx := context.Background()
-		if _, err := authenticator.GetToken(ctx); err != nil {
+		var err error
+		if *serve.quiet {
+			_, err = authenticator.GetTokenNonInteractive(ctx)
+		} else {
+			_, err = authenticator.GetToken(ctx)
+		}
+		if err != nil {
 			log.Fatal("authentication failed", logger.Err(err))
 		}
 		log.Info("authenticated successfully")

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -188,6 +189,13 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestServeFlagsQuietCanBeEnabled(t *testing.T) {
+	serve := parseServeFlagsForTest(t, "--quiet")
+	if !*serve.quiet {
+		t.Fatal("--quiet should enable quiet mode")
+	}
+}
+
 func TestCommandFromArgs(t *testing.T) {
 	tests := []struct {
 		name string
@@ -214,6 +222,11 @@ func TestCommandFromArgs(t *testing.T) {
 			args: []string{"vekil", "serve"},
 			want: cliCommandServe,
 		},
+		{
+			name: "global quiet before login still dispatches",
+			args: []string{"vekil", "--quiet", "login"},
+			want: cliCommandLogin,
+		},
 	}
 
 	for _, tc := range tests {
@@ -222,6 +235,76 @@ func TestCommandFromArgs(t *testing.T) {
 				t.Fatalf("commandFromArgs(%v) = %v, want %v", tc.args, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCommandAndArgsFromArgsPassesGlobalQuietToSubcommand(t *testing.T) {
+	command, args := commandAndArgsFromArgs([]string{"vekil", "--quiet", "login", "--gh"})
+	if command != cliCommandLogin {
+		t.Fatalf("command = %v, want %v", command, cliCommandLogin)
+	}
+	want := []string{"--quiet", "--gh"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+}
+
+func TestRunLoginQuietSuppressesSuccessOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantOutput bool
+	}{
+		{
+			name:       "default emits success output",
+			args:       []string{"--gh"},
+			wantOutput: true,
+		},
+		{
+			name:       "quiet suppresses success output",
+			args:       []string{"--quiet", "--gh"},
+			wantOutput: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+
+			code := runLoginWithDeps(tc.args, loginDeps{
+				stderr: &stderr,
+				newAuthenticator: func(string) (loginAuthenticator, error) {
+					return &fakeLoginAuthenticator{}, nil
+				},
+			})
+
+			if code != 0 {
+				t.Fatalf("runLoginWithDeps() code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+
+			gotOutput := strings.Contains(stderr.String(), "Login successful.")
+			if gotOutput != tc.wantOutput {
+				t.Fatalf("success output present = %v, want %v; stderr=%q", gotOutput, tc.wantOutput, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunLoginQuietDoesNotSuppressErrors(t *testing.T) {
+	var stderr bytes.Buffer
+
+	code := runLoginWithDeps([]string{"--quiet", "--gh"}, loginDeps{
+		stderr: &stderr,
+		newAuthenticator: func(string) (loginAuthenticator, error) {
+			return &fakeLoginAuthenticator{signInWithGitHubCLIErr: errors.New("boom")}, nil
+		},
+	})
+
+	if code == 0 {
+		t.Fatalf("runLoginWithDeps() code = 0, want non-zero")
+	}
+	if got := stderr.String(); !strings.Contains(got, "error signing in with GitHub CLI: boom") {
+		t.Fatalf("stderr missing error, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds a `--quiet` flag to the vekil CLI that suppresses non-error (informational/status) output while preserving error output so failures remain visible.

## Changes
- Added a global-style `--quiet` flag supported across `serve`, `login`, and `logout` (also works before subcommands, e.g. `vekil --quiet login --gh`).
- Suppresses normal status output via the existing `writeStatus` helper; explicit error paths continue to print.
- In quiet `serve` mode, the logging threshold is raised to error/fatal and non-interactive Copilot auth is used to avoid printing device-code prompts.
- Added tests covering flag parsing, quiet dispatch before subcommand, success-output suppression, and error-output preservation.
- Documented the flag in `docs/configuration.md`.

## Acceptance Criteria
- ✅ `--quiet` flag exists and is wired into the CLI.
- ✅ Non-error output is suppressed when set; errors remain visible.
- ✅ A test exercises the flag and asserts suppression behavior.

## Validation
- `golang:1.25` at head SHA: `go build ./...` OK, `go vet ./...` clean, `go test ./... -count=1` all packages pass.

## Review
- Security review: APPROVED (no credential leak; security-relevant errors still surfaced).
- Quality review: APPROVED (idiomatic, reuses output abstraction, meaningful test coverage).

Files changed: `main.go`, `main_test.go`, `docs/configuration.md`.