### PR TITLE
feat(cli): add --quiet flag to suppress non-error output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ Vekil supports two runtime patterns:
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
+| `--quiet` | `QUIET` | `false` | Suppress non-error output (only error and fatal messages are logged). |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	tokenDir                        *string
 	providersConfigPath             *string
 	logLevel                        *string
+	quiet                           *bool
 	streamingUpstreamTimeout        *time.Duration
 	copilotEditorVersion            *string
 	copilotPluginVersion            *string
@@ -241,6 +242,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
+		quiet:                           fs.Bool("quiet", getEnvBool("QUIET", false), "Suppress non-error output (only error and fatal messages are logged)"),
 		streamingUpstreamTimeout:        fs.Duration("streaming-upstream-timeout", getEnvDuration("STREAMING_UPSTREAM_TIMEOUT", proxy.DefaultStreamingUpstreamTimeout()), "Timeout for streaming upstream inference requests"),
 		copilotEditorVersion:            fs.String("copilot-editor-version", getEnv("COPILOT_EDITOR_VERSION", ""), "Upstream Copilot editor-version header"),
 		copilotPluginVersion:            fs.String("copilot-plugin-version", getEnv("COPILOT_PLUGIN_VERSION", ""), "Upstream Copilot editor-plugin-version header"),
@@ -282,11 +284,19 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+// resolveLogLevel returns the effective serve-mode log level.
+func resolveLogLevel(quiet bool, logLevel string) logger.Level {
+	if quiet {
+		return logger.LevelError
+	}
+	return logger.ParseLevel(logLevel)
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
-	log := logger.New(logger.ParseLevel(*serve.logLevel))
+	log := logger.New(resolveLogLevel(*serve.quiet, *serve.logLevel))
 
 	authenticator, err := auth.NewAuthenticator(*serve.tokenDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -185,6 +186,78 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	cliServe := parseServeFlagsForTest(t, "--responses-ws-enabled=false")
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
+	}
+}
+
+func TestQuietFlag(t *testing.T) {
+	flagTests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "default false",
+			want: false,
+		},
+		{
+			name: "flag sets true",
+			args: []string{"-quiet"},
+			want: true,
+		},
+	}
+
+	for _, tc := range flagTests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			serve := registerServeFlags(fs)
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatalf("parse serve flags: %v", err)
+			}
+			if got := *serve.quiet; got != tc.want {
+				t.Fatalf("quiet = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	levelTests := []struct {
+		name     string
+		quiet    bool
+		logLevel string
+		want     logger.Level
+	}{
+		{
+			name:     "quiet wins over info",
+			quiet:    true,
+			logLevel: "info",
+			want:     logger.LevelError,
+		},
+		{
+			name:     "quiet wins over debug",
+			quiet:    true,
+			logLevel: "debug",
+			want:     logger.LevelError,
+		},
+		{
+			name:     "info without quiet",
+			quiet:    false,
+			logLevel: "info",
+			want:     logger.LevelInfo,
+		},
+		{
+			name:     "debug without quiet",
+			quiet:    false,
+			logLevel: "debug",
+			want:     logger.LevelDebug,
+		},
+	}
+
+	for _, tc := range levelTests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveLogLevel(tc.quiet, tc.logLevel); got != tc.want {
+				t.Fatalf("resolveLogLevel(%v, %q) = %v, want %v", tc.quiet, tc.logLevel, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `--quiet` flag (env var `QUIET`) to vekil's serve (default) mode. When set, it suppresses all non-error output by building the logger at `LevelError`, so only `error` and `fatal` messages are emitted while `info`/`debug` output is hidden. Login/logout subcommands are unaffected.

## Changes

- **`main.go`**
  - Added a `quiet *bool` field to the `serveFlags` struct (next to `logLevel`).
  - Registered the `--quiet` flag following the existing bool-flag pattern, with a `QUIET` env-var fallback via `getEnvBool`.
  - Added a small pure helper `resolveLogLevel(quiet bool, logLevel string) logger.Level` that returns `logger.LevelError` when quiet, otherwise `logger.ParseLevel(logLevel)`.
  - Wired `runServe()` to build the logger via `resolveLogLevel(*serve.quiet, *serve.logLevel)`.
- **`main_test.go`**
  - Added `TestQuietFlag`, a table-driven test matching existing style. It exercises the flag end-to-end: parsing `-quiet` through a `flag.FlagSet` built by `registerServeFlags`, and asserting log-level resolution (quiet wins over both `info` and `debug`; default-false falls back to the configured level).
- **`docs/configuration.md`**
  - Documented the new `--quiet` / `QUIET` flag in the Generic Flags table, adjacent to `--log-level`.

## Behavior

- `--quiet` (or `QUIET=true`) → only `error` and `fatal` log entries are emitted; `info`/`debug` suppressed.
- Default (`false`) → unchanged behavior, honoring `--log-level`/`LOG_LEVEL`.
- Errors and fatals are **never** suppressed, preserving operability.

## Validation

Run in `golang:1.25` (matches `go 1.25` in `go.mod`) against the head commit:

- `gofmt -l main.go main_test.go` → no output
- `go build ./...` → pass
- `go vet ./...` → pass
- `go test ./...` → all packages pass, including `TestQuietFlag` (6 subtests)

## Review

- Security review: LGTM (confirmed error/fatal output is not suppressed; no auth/token/network changes).
- Quality review: LGTM (after adding the docs row it initially flagged).