### PR TITLE
fix: serve health during Copilot login

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,33 @@ jobs:
       - name: Vet
         run: make vet
 
+  k8s-smoke:
+    runs-on: ubuntu-latest
+    needs: [lint, build, test]
+    env:
+      KIND_VERSION: v0.32.0
+      KUBECTL_VERSION: v1.36.1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install kind and kubectl
+        run: |
+          curl -fsSL -o /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          curl -fsSL -o /tmp/kind.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64.sha256sum"
+          (cd /tmp && sha256sum -c kind.sha256sum)
+          sudo install -m 0755 /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+          curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -fsSL -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
+          echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum -c -
+          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+          kind version
+          kubectl version --client=true
+
+      - name: Kubernetes liveness smoke
+        run: scripts/k8s-kind-smoke.sh
+
   e2e:
     runs-on: ubuntu-latest
     needs: [lint, build, test]

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -57,11 +57,16 @@ var (
 // It handles the device code flow, token caching to disk, and automatic
 // refresh using a read-write mutex for concurrent access.
 type Authenticator struct {
-	tokenDir       string
-	accessToken    string
-	copilotToken   string
-	tokenExpiry    time.Time
-	mu             sync.RWMutex
+	tokenDir     string
+	accessToken  string
+	copilotToken string
+	tokenExpiry  time.Time
+	mu           sync.RWMutex
+
+	// deviceFlowMu serializes interactive logins without blocking readers that
+	// only want to know whether non-interactive credentials are already usable.
+	deviceFlowMu sync.Mutex
+
 	client         *http.Client
 	directClient   *http.Client
 	copilotBaseURL string // overridable for tests; defaults to https://api.github.com
@@ -290,6 +295,18 @@ func (a *Authenticator) getToken(ctx context.Context, allowDeviceFlow bool) (str
 		return a.getTokenFromEnv(ctx, envToken)
 	}
 
+	token, err := a.getTokenWithoutDeviceFlow(ctx)
+	if err == nil {
+		return token, nil
+	}
+	if !allowDeviceFlow || !IsInteractiveLoginRequired(err) {
+		return "", err
+	}
+
+	return a.getTokenWithDeviceFlow(ctx)
+}
+
+func (a *Authenticator) getTokenWithoutDeviceFlow(ctx context.Context) (string, error) {
 	a.mu.RLock()
 	if a.copilotToken != "" && time.Now().Before(a.tokenExpiry) {
 		token := a.copilotToken
@@ -309,10 +326,30 @@ func (a *Authenticator) getToken(ctx context.Context, allowDeviceFlow bool) (str
 		return a.copilotToken, nil
 	}
 
-	if err := a.refreshToken(ctx, allowDeviceFlow); err != nil {
+	if err := a.refreshToken(ctx, false); err != nil {
 		return "", err
 	}
 	return a.copilotToken, nil
+}
+
+func (a *Authenticator) getTokenWithDeviceFlow(ctx context.Context) (string, error) {
+	a.deviceFlowMu.Lock()
+	defer a.deviceFlowMu.Unlock()
+
+	// Another goroutine may have completed sign-in while this caller waited for
+	// the interactive-login slot.
+	token, err := a.getToken(ctx, false)
+	if err == nil {
+		return token, nil
+	}
+	if !IsInteractiveLoginRequired(err) {
+		return "", err
+	}
+
+	if err := a.deviceCodeFlow(ctx); err != nil {
+		return "", err
+	}
+	return a.getToken(ctx, false)
 }
 
 func (a *Authenticator) getTokenFromEnv(ctx context.Context, envToken string) (string, error) {
@@ -433,15 +470,12 @@ func (a *Authenticator) RequestDeviceCode(ctx context.Context) (*DeviceCodeRespo
 
 // PollForAuthorization polls GitHub until the user authorizes the device code,
 // then saves the access token and exchanges it for a Copilot API token.
-// It acquires the write lock internally.
 func (a *Authenticator) PollForAuthorization(ctx context.Context, dcResp *DeviceCodeResponse) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.deviceFlowMu.Lock()
+	defer a.deviceFlowMu.Unlock()
 	return a.pollForAuthorization(ctx, dcResp)
 }
 
-// pollForAuthorization is the internal implementation that must be called with
-// the write lock already held (or from PollForAuthorization which acquires it).
 func (a *Authenticator) pollForAuthorization(ctx context.Context, dcResp *DeviceCodeResponse) error {
 	interval := time.Duration(dcResp.Interval) * time.Second
 	if interval == 0 {
@@ -482,20 +516,7 @@ func (a *Authenticator) pollForAuthorization(ctx context.Context, dcResp *Device
 
 		switch atResp.Error {
 		case "":
-			a.accessToken = atResp.AccessToken
-			if err := a.saveAccessToken(); err != nil {
-				return fmt.Errorf("saving access token: %w", err)
-			}
-			if err := a.exchangeForCopilotToken(ctx); err != nil {
-				return err
-			}
-			if err := a.clearSignedOutMarker(); err != nil {
-				return fmt.Errorf("clearing signed-out marker: %w", err)
-			}
-			if err := a.setGitHubCLIAutoSignIn(false); err != nil {
-				return fmt.Errorf("saving auth preferences: %w", err)
-			}
-			return nil
+			return a.completeDeviceAuthorization(ctx, atResp.AccessToken)
 		case "authorization_pending":
 			continue
 		case "slow_down":
@@ -507,6 +528,26 @@ func (a *Authenticator) pollForAuthorization(ctx context.Context, dcResp *Device
 	}
 
 	return fmt.Errorf("device code flow timed out")
+}
+
+func (a *Authenticator) completeDeviceAuthorization(ctx context.Context, accessToken string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.accessToken = accessToken
+	if err := a.saveAccessToken(); err != nil {
+		return fmt.Errorf("saving access token: %w", err)
+	}
+	if err := a.exchangeForCopilotToken(ctx); err != nil {
+		return err
+	}
+	if err := a.clearSignedOutMarker(); err != nil {
+		return fmt.Errorf("clearing signed-out marker: %w", err)
+	}
+	if err := a.setGitHubCLIAutoSignIn(false); err != nil {
+		return fmt.Errorf("saving auth preferences: %w", err)
+	}
+	return nil
 }
 
 func (a *Authenticator) deviceCodeFlow(ctx context.Context) error {
@@ -523,6 +564,9 @@ func (a *Authenticator) deviceCodeFlow(ctx context.Context) error {
 // SignOut clears all authentication state from memory and removes persisted
 // token files from disk. It is safe for concurrent use.
 func (a *Authenticator) SignOut() error {
+	a.deviceFlowMu.Lock()
+	defer a.deviceFlowMu.Unlock()
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -552,6 +596,9 @@ func (a *Authenticator) SignOut() error {
 // GitHub CLI account. The GitHub CLI token is kept only in memory as a
 // short-lived Copilot bearer token and is never persisted by Vekil.
 func (a *Authenticator) SignInWithGitHubCLI(ctx context.Context) error {
+	a.deviceFlowMu.Lock()
+	defer a.deviceFlowMu.Unlock()
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -186,6 +186,84 @@ func TestGetToken_ConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestGetTokenNonInteractiveReturnsWhileDeviceFlowPending(t *testing.T) {
+	deviceCodeRequested := make(chan struct{})
+	var closeDeviceCodeRequested sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/device/code":
+			closeDeviceCodeRequested.Do(func() { close(deviceCodeRequested) })
+			_ = json.NewEncoder(w).Encode(DeviceCodeResponse{
+				DeviceCode:      "dc_pending",
+				UserCode:        "PEND-1234",
+				VerificationURI: "https://github.com/login/device",
+				ExpiresIn:       60,
+				Interval:        1,
+			})
+		case "/login/oauth/access_token":
+			_ = json.NewEncoder(w).Encode(AccessTokenResponse{Error: "authorization_pending"})
+		case "/copilot_internal/v2/token":
+			t.Fatalf("unexpected Copilot token exchange before authorization")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	a := &Authenticator{
+		client:         server.Client(),
+		copilotBaseURL: server.URL,
+		tokenDir:       t.TempDir(),
+		githubCLIPath:  missingGitHubCLIPath(t),
+	}
+	a.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten, _ := url.Parse(server.URL + req.URL.Path)
+		rewritten.RawQuery = req.URL.RawQuery
+		req.URL = rewritten
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	interactiveCtx, cancelInteractive := context.WithCancel(context.Background())
+	defer cancelInteractive()
+	interactiveDone := make(chan error, 1)
+	go func() {
+		_, err := a.GetToken(interactiveCtx)
+		interactiveDone <- err
+	}()
+
+	select {
+	case <-deviceCodeRequested:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for device-code flow to start")
+	}
+
+	nonInteractiveDone := make(chan error, 1)
+	go func() {
+		_, err := a.GetTokenNonInteractive(context.Background())
+		nonInteractiveDone <- err
+	}()
+
+	select {
+	case err := <-nonInteractiveDone:
+		if !errors.Is(err, ErrNotAuthenticated) {
+			t.Fatalf("GetTokenNonInteractive error = %v, want ErrNotAuthenticated", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("GetTokenNonInteractive blocked behind the pending device-code login")
+	}
+
+	cancelInteractive()
+	select {
+	case err := <-interactiveDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("interactive GetToken error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for interactive GetToken to exit")
+	}
+}
+
 func TestExchangeForCopilotToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "token test-access" {
@@ -786,6 +864,33 @@ func TestStatus_ReportsAuthSources(t *testing.T) {
 			t.Fatalf("expected signed-out status, got %+v", status)
 		}
 	})
+}
+
+func TestSignOutWaitsForPendingDeviceAuthorization(t *testing.T) {
+	a := &Authenticator{tokenDir: t.TempDir()}
+	a.deviceFlowMu.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.SignOut()
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("SignOut returned while device flow was still active: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	a.deviceFlowMu.Unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SignOut returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for SignOut after device flow released")
+	}
 }
 
 func TestPollForAuthorization_Success(t *testing.T) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,7 +61,7 @@ See [OpenAI Responses Compatibility](responses.md) for compaction, oversized rep
 
 ## `GET /healthz`
 
-Returns `{"status":"ok"}`.
+Returns `{"status":"ok"}` as soon as the HTTP listener is serving. This endpoint reports process liveness and does not wait for provider authentication.
 
 ## `GET /readyz`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ make lint
 
 ## CI
 
-GitHub Actions in [`.github/workflows/ci.yaml`](../.github/workflows/ci.yaml) runs lint, tests, build, vet, and e2e validation before merge.
+GitHub Actions in [`.github/workflows/ci.yaml`](../.github/workflows/ci.yaml) runs lint, tests, build, vet, a Kubernetes/kind liveness smoke, and e2e validation before merge. The kind smoke builds the PR image, deploys it into a temporary kind cluster without Copilot credentials, and verifies that `/healthz` stays live with zero liveness-probe restarts while `/readyz` remains gated during device-code login.
 
 Safe Dependabot updates are handled by [`.github/workflows/dependabot-auto-merge.yaml`](../.github/workflows/dependabot-auto-merge.yaml). It listens for Dependabot pull request lifecycle events, skips drafts, skips pull requests with requested changes, skips major updates, and only auto-approves plus enables auto-merge for semver patch/minor updates from eligible package ecosystems. Grouped Dependabot pull requests are eligible only when `dependabot/fetch-metadata` reports the highest update type as patch or minor.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ Zero-config startup and explicit `type: "copilot"` providers need GitHub Copilot
 2. Vekil-managed cached credentials in `~/.config/vekil/`
 3. GitHub CLI auth, but only after `vekil login --github-cli` or `vekil login --gh`
 
-If none are available, first startup starts GitHub's device-code flow. You can also run `vekil login` ahead of time, `vekil login --force` for a fresh device-code sign-in, or `vekil logout` to clear Vekil-managed auth and disable silent GitHub CLI reuse.
+If none are available, first startup starts GitHub's device-code flow after binding the HTTP listener. During that one-time login window, `/healthz` is available for liveness probes and `/readyz` remains `not_ready` until authentication and upstream probing succeed. You can also run `vekil login` ahead of time, `vekil login --force` for a fresh device-code sign-in, or `vekil logout` to clear Vekil-managed auth and disable silent GitHub CLI reuse.
 
 ### Azure OpenAI and Microsoft Foundry
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -282,6 +283,100 @@ func (f serveFlags) responsesWebSocketConfig() proxy.ResponsesWebSocketConfig {
 	}
 }
 
+type serveLifecycleServer interface {
+	Start() error
+	Stop(context.Context) error
+}
+
+type serveStartupAuthenticator interface {
+	GetToken(context.Context) (string, error)
+}
+
+type dynamicProviderModelValidator interface {
+	ValidateDynamicProviderModels(context.Context) error
+}
+
+type startupAuthenticationGate interface {
+	SetStartupAuthenticationPending(bool)
+}
+
+func serveUntilContextDone(ctx context.Context, srv serveLifecycleServer, authenticator serveStartupAuthenticator, usesCopilot bool, log *logger.Logger) error {
+	if gate, ok := srv.(startupAuthenticationGate); ok {
+		gate.SetStartupAuthenticationPending(usesCopilot)
+	}
+	if err := srv.Start(); err != nil {
+		return fmt.Errorf("server start error: %w", err)
+	}
+
+	if usesCopilot {
+		authDone := make(chan error, 1)
+		go func() {
+			if log != nil {
+				log.Info("authenticating with GitHub Copilot...")
+			}
+			_, err := authenticator.GetToken(ctx)
+			if err == nil && log != nil {
+				log.Info("authenticated successfully")
+			}
+			authDone <- err
+		}()
+
+		select {
+		case <-ctx.Done():
+			return stopServeServer(srv, log)
+		case err := <-authDone:
+			if err != nil {
+				if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+					return stopServeServer(srv, log)
+				}
+				authErr := fmt.Errorf("authentication failed: %w", err)
+				if stopErr := stopServeServer(srv, log); stopErr != nil {
+					return errors.Join(authErr, stopErr)
+				}
+				return authErr
+			}
+			if gate, ok := srv.(startupAuthenticationGate); ok {
+				gate.SetStartupAuthenticationPending(false)
+			}
+			if validator, ok := srv.(dynamicProviderModelValidator); ok {
+				if err := validator.ValidateDynamicProviderModels(ctx); err != nil {
+					if ctx.Err() != nil {
+						return stopServeServer(srv, log)
+					}
+					validationErr := fmt.Errorf("provider model validation failed: %w", err)
+					if stopErr := stopServeServer(srv, log); stopErr != nil {
+						return errors.Join(validationErr, stopErr)
+					}
+					return validationErr
+				}
+			}
+		}
+	}
+
+	<-ctx.Done()
+	return stopServeServer(srv, log)
+}
+
+func stopServeServer(srv serveLifecycleServer, log *logger.Logger) error {
+	if gate, ok := srv.(startupAuthenticationGate); ok {
+		gate.SetStartupAuthenticationPending(false)
+	}
+	if log != nil {
+		log.Info("shutting down...")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Stop(ctx); err != nil {
+		return fmt.Errorf("shutdown error: %w", err)
+	}
+	if log != nil {
+		log.Info("server stopped")
+	}
+	return nil
+}
+
 func runServe() {
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
@@ -298,15 +393,6 @@ func runServe() {
 		log.Fatal("failed to load providers config", logger.Err(err))
 	}
 
-	if providersCfg.UsesCopilot() {
-		log.Info("authenticating with GitHub Copilot...")
-		ctx := context.Background()
-		if _, err := authenticator.GetToken(ctx); err != nil {
-			log.Fatal("authentication failed", logger.Err(err))
-		}
-		log.Info("authenticated successfully")
-	}
-
 	srv, err := server.New(
 		authenticator,
 		log,
@@ -318,28 +404,21 @@ func runServe() {
 		server.WithCompactUpstreamChunkBytes(*serve.compactUpstreamChunkBytes),
 		server.WithCompactUpstreamChunkConcurrency(*serve.compactUpstreamChunkConcurrency),
 		server.WithCompactUpstreamMaxAttempts(*serve.compactUpstreamMaxAttempts),
-		server.WithProxyOptions(proxy.WithProvidersConfig(providersCfg)),
+		server.WithProxyOptions(
+			proxy.WithProvidersConfig(providersCfg),
+			proxy.WithDeferredDynamicProviderModelValidation(providersCfg.UsesCopilot()),
+		),
 	)
 	if err != nil {
 		log.Fatal("failed to initialize server", logger.Err(err))
 	}
 
-	if err := srv.Start(); err != nil {
-		log.Fatal("server start error", logger.Err(err))
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := serveUntilContextDone(ctx, srv, authenticator, providersCfg.UsesCopilot(), log); err != nil {
+		log.Fatal("serve error", logger.Err(err))
 	}
-
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
-	<-stop
-	log.Info("shutting down...")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if err := srv.Stop(ctx); err != nil {
-		log.Fatal("shutdown error", logger.Err(err))
-	}
-	log.Info("server stopped")
 }
 
 func getEnv(key, fallback string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
 )
 
 func TestGetEnvDuration(t *testing.T) {
@@ -186,6 +187,153 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 	if cliServe.responsesWebSocketConfig().Enabled {
 		t.Fatal("--responses-ws-enabled=false should override RESPONSES_WS_ENABLED=true")
 	}
+}
+
+func TestServeUntilContextDoneStartsServerBeforeCopilotAuthCompletes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := make(chan string, 4)
+	server := &fakeServeLifecycleServer{
+		startFn: func() error {
+			events <- "start"
+			return nil
+		},
+		stopFn: func(context.Context) error {
+			events <- "stop"
+			return nil
+		},
+	}
+	authenticator := &fakeServeStartupAuthenticator{
+		getTokenFn: func(ctx context.Context) (string, error) {
+			events <- "auth"
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- serveUntilContextDone(ctx, server, authenticator, true, logger.NewWithWriter(logger.LevelError, io.Discard))
+	}()
+
+	assertNextServeEvent(t, events, "start")
+	assertNextServeEvent(t, events, "auth")
+
+	select {
+	case err := <-done:
+		t.Fatalf("serveUntilContextDone returned while Copilot auth was still pending: %v", err)
+	default:
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("serveUntilContextDone after cancellation returned error: %v", err)
+	}
+	assertNextServeEvent(t, events, "stop")
+}
+
+func TestServeUntilContextDoneTreatsValidationCancellationAsShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	server := &fakeServeLifecycleServer{
+		validateFn: func(ctx context.Context) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	authenticator := &fakeServeStartupAuthenticator{}
+
+	if err := serveUntilContextDone(ctx, server, authenticator, true, logger.NewWithWriter(logger.LevelError, io.Discard)); err != nil {
+		t.Fatalf("serveUntilContextDone returned error for shutdown during validation: %v", err)
+	}
+	if !server.stopped {
+		t.Fatal("expected server to be stopped after shutdown during validation")
+	}
+}
+
+func TestServeUntilContextDoneStopsServerOnCopilotAuthFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := &fakeServeLifecycleServer{}
+	authenticator := &fakeServeStartupAuthenticator{
+		getTokenFn: func(context.Context) (string, error) {
+			return "", fmt.Errorf("device code flow timed out")
+		},
+	}
+
+	err := serveUntilContextDone(ctx, server, authenticator, true, logger.NewWithWriter(logger.LevelError, io.Discard))
+	if err == nil {
+		t.Fatal("expected authentication failure")
+	}
+	if !strings.Contains(err.Error(), "authentication failed") {
+		t.Fatalf("expected authentication failure error, got %v", err)
+	}
+	if !server.stopped {
+		t.Fatal("expected server to be stopped after authentication failure")
+	}
+}
+
+func assertNextServeEvent(t *testing.T, events <-chan string, want string) {
+	t.Helper()
+	select {
+	case got := <-events:
+		if got != want {
+			t.Fatalf("next serve event = %q, want %q", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for serve event %q", want)
+	}
+}
+
+type fakeServeLifecycleServer struct {
+	startFn            func() error
+	stopFn             func(context.Context) error
+	validateFn         func(context.Context) error
+	authPending        bool
+	authPendingUpdates []bool
+	started            bool
+	stopped            bool
+}
+
+func (f *fakeServeLifecycleServer) Start() error {
+	f.started = true
+	if f.startFn != nil {
+		return f.startFn()
+	}
+	return nil
+}
+
+func (f *fakeServeLifecycleServer) Stop(ctx context.Context) error {
+	f.stopped = true
+	if f.stopFn != nil {
+		return f.stopFn(ctx)
+	}
+	return nil
+}
+
+func (f *fakeServeLifecycleServer) ValidateDynamicProviderModels(ctx context.Context) error {
+	if f.validateFn != nil {
+		return f.validateFn(ctx)
+	}
+	return nil
+}
+
+func (f *fakeServeLifecycleServer) SetStartupAuthenticationPending(pending bool) {
+	f.authPending = pending
+	f.authPendingUpdates = append(f.authPendingUpdates, pending)
+}
+
+type fakeServeStartupAuthenticator struct {
+	getTokenFn func(context.Context) (string, error)
+}
+
+func (f *fakeServeStartupAuthenticator) GetToken(ctx context.Context) (string, error) {
+	if f.getTokenFn != nil {
+		return f.getTokenFn(ctx)
+	}
+	return "test-token", nil
 }
 
 func TestCommandFromArgs(t *testing.T) {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -230,33 +231,36 @@ func (c ResponsesWebSocketConfig) autoCompactEnabled() bool {
 
 // ProxyHandler holds dependencies for all HTTP handlers.
 type ProxyHandler struct {
-	auth                            *auth.Authenticator
-	client                          *http.Client
-	copilotURL                      string
-	copilotHeaders                  CopilotHeaderConfig
-	providersConfig                 ProvidersConfig
-	providersState                  *providerSetup
-	azureIdentityTokenSourceFactory azureIdentityTokenSourceFactory
-	toolOptimizers                  *ToolOptimizerManager
-	toolContexts                    *ToolExecutionContextStore
-	responsesWS                     ResponsesWebSocketConfig
-	responsesWSSessionsMu           sync.Mutex
-	responsesWSSessions             map[*responsesWebSocketSession]struct{}
-	responsesWSDraining             bool
-	streamingUpstreamTimeout        time.Duration
-	compactChunkBodyBytes           int
-	compactChunkConfigured          bool
-	compactChunkConcurrency         int
-	compactMaxAttempts              int
-	compactLearnedTargetsMu         sync.Mutex
-	compactInflightMu               sync.Mutex
-	compactInflight                 map[string]*compactInflightCall
-	compactLearnedTargets           map[compactLearnedTargetKey]compactLearnedTarget
-	log                             *logger.Logger
-	maxRetries                      int
-	retryBaseDelay                  time.Duration
-	models                          modelsCache
-	geminiCounts                    geminiCountTokensCache
+	auth                             *auth.Authenticator
+	client                           *http.Client
+	copilotURL                       string
+	copilotHeaders                   CopilotHeaderConfig
+	providersConfig                  ProvidersConfig
+	providersState                   *providerSetup
+	deferDynamicProviderModelRefresh bool
+	startupAuthenticationPending     atomic.Bool
+	dynamicProviderValidationPending atomic.Bool
+	azureIdentityTokenSourceFactory  azureIdentityTokenSourceFactory
+	toolOptimizers                   *ToolOptimizerManager
+	toolContexts                     *ToolExecutionContextStore
+	responsesWS                      ResponsesWebSocketConfig
+	responsesWSSessionsMu            sync.Mutex
+	responsesWSSessions              map[*responsesWebSocketSession]struct{}
+	responsesWSDraining              bool
+	streamingUpstreamTimeout         time.Duration
+	compactChunkBodyBytes            int
+	compactChunkConfigured           bool
+	compactChunkConcurrency          int
+	compactMaxAttempts               int
+	compactLearnedTargetsMu          sync.Mutex
+	compactInflightMu                sync.Mutex
+	compactInflight                  map[string]*compactInflightCall
+	compactLearnedTargets            map[compactLearnedTargetKey]compactLearnedTarget
+	log                              *logger.Logger
+	maxRetries                       int
+	retryBaseDelay                   time.Duration
+	models                           modelsCache
+	geminiCounts                     geminiCountTokensCache
 }
 
 type compactLearnedTargetKey struct {
@@ -336,6 +340,15 @@ func WithCopilotHeaderConfig(cfg CopilotHeaderConfig) Option {
 func WithProvidersConfig(cfg ProvidersConfig) Option {
 	return func(h *ProxyHandler) {
 		h.providersConfig = cfg
+	}
+}
+
+// WithDeferredDynamicProviderModelValidation skips startup-time dynamic model
+// discovery. Call ValidateDynamicProviderModels after any required interactive
+// auth has completed to preserve collision checks without blocking liveness.
+func WithDeferredDynamicProviderModelValidation(deferValidation bool) Option {
+	return func(h *ProxyHandler) {
+		h.deferDynamicProviderModelRefresh = deferValidation
 	}
 }
 
@@ -677,6 +690,14 @@ func (h *ProxyHandler) HandleReadyz(w http.ResponseWriter, r *http.Request) {
 	if err := ctx.Err(); err != nil {
 		return
 	}
+	if h.startupAuthenticationPending.Load() {
+		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", "startup authentication pending")
+		return
+	}
+	if h.dynamicProviderValidationPending.Load() {
+		writeReadyzStatus(w, http.StatusServiceUnavailable, "not_ready", "provider model validation pending")
+		return
+	}
 
 	setup := h.providerSetup()
 	for _, providerID := range setup.providerOrder {
@@ -790,6 +811,20 @@ func shouldSuppressReadyzResponse(parent context.Context, err error) bool {
 	// Only suppress deadline errors when the caller's context already timed out.
 	// The proxy's own readiness timeout should still surface as not_ready.
 	return parent.Err() != nil
+}
+
+func (h *ProxyHandler) SetStartupAuthenticationPending(pending bool) {
+	if h != nil {
+		h.startupAuthenticationPending.Store(pending)
+	}
+}
+
+func (h *ProxyHandler) StartupAuthenticationPending() bool {
+	return h != nil && h.startupAuthenticationPending.Load()
+}
+
+func (h *ProxyHandler) DynamicProviderValidationPending() bool {
+	return h != nil && h.dynamicProviderValidationPending.Load()
 }
 
 func writeReadyzStatus(w http.ResponseWriter, statusCode int, status string, errMessage string) {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -6986,6 +6986,122 @@ func TestHandleOpenAIChatCompletions_RejectsOpenAICodexProvider(t *testing.T) {
 	}
 }
 
+func TestNewProxyHandler_DefersConfiguredCopilotDynamicModelValidation(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	var modelHits atomic.Int32
+	copilotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		modelHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"github-copilot"}]}`))
+	}))
+	defer copilotServer.Close()
+
+	authenticator, err := auth.NewAuthenticator(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewAuthenticator returned error: %v", err)
+	}
+
+	_, err = NewProxyHandler(
+		authenticator,
+		logger.New(logger.LevelInfo),
+		withCopilotBaseURLForTest(copilotServer.URL),
+		WithDeferredDynamicProviderModelValidation(true),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "copilot", Type: "copilot", Default: true},
+				{
+					ID:         "azure",
+					Type:       "azure-openai",
+					BaseURL:    "https://example.openai.azure.com/openai/v1",
+					APIVersion: "2025-04-01-preview",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "azure-only",
+						Deployment: "azure-only",
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+	if got := modelHits.Load(); got != 0 {
+		t.Fatalf("expected deferred startup to skip Copilot /models fetch, got %d hits", got)
+	}
+}
+
+func TestValidateDynamicProviderModelsLoadsDeferredConfiguredCopilotModels(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
+
+	copilotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/models" {
+			t.Fatalf("expected /models lookup, got %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-5.4","object":"model","created":0,"owned_by":"github-copilot","supported_endpoints":["/responses"],"name":"GPT-5.4"}]}`))
+	}))
+	defer copilotServer.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		withCopilotBaseURLForTest(copilotServer.URL),
+		WithDeferredDynamicProviderModelValidation(true),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "copilot", Type: "copilot", Default: true},
+				{
+					ID:         "azure",
+					Type:       "azure-openai",
+					BaseURL:    "https://example.openai.azure.com/openai/v1",
+					APIVersion: "2025-04-01-preview",
+					APIKeyEnv:  "TEST_AZURE_API_KEY",
+					Models: []ProviderModelConfig{{
+						PublicID:   "azure-only",
+						Deployment: "azure-only",
+					}},
+				},
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+	if _, ok := handler.providerSetup().lookupModel("gpt-5.4"); ok {
+		t.Fatal("expected deferred Copilot model to be absent before validation")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	handler.HandleReadyz(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("readyz before validation status = %d, want 503: %s", resp.StatusCode, body)
+	}
+	var ready map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&ready); err != nil {
+		t.Fatalf("decode readyz response: %v", err)
+	}
+	if ready["status"] != "not_ready" || !strings.Contains(ready["error"], "provider model validation pending") {
+		t.Fatalf("unexpected readyz response before validation: %+v", ready)
+	}
+
+	if err := handler.ValidateDynamicProviderModels(context.Background()); err != nil {
+		t.Fatalf("ValidateDynamicProviderModels returned error: %v", err)
+	}
+
+	model, ok := handler.providerSetup().lookupModel("gpt-5.4")
+	if !ok {
+		t.Fatal("expected deferred Copilot model to load after validation")
+	}
+	if model.providerID != "copilot" {
+		t.Fatalf("model provider = %q, want copilot", model.providerID)
+	}
+}
+
 func TestNewProxyHandler_FailsWhenProvidersSharePlainModelID(t *testing.T) {
 	t.Setenv("TEST_AZURE_API_KEY", "azure-test-key")
 

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -400,15 +400,20 @@ func (h *ProxyHandler) initializeProviders() error {
 		return nil
 	}
 
-	setup, err := h.buildConfiguredProviderSetup(context.Background(), h.providersConfig)
+	setup, err := h.buildConfiguredProviderSetupWithDynamicValidation(context.Background(), h.providersConfig, !h.deferDynamicProviderModelRefresh)
 	if err != nil {
 		return err
 	}
 	h.providersState = setup
+	h.dynamicProviderValidationPending.Store(h.deferDynamicProviderModelRefresh && len(setup.providers) > 1 && hasDynamicProvider(setup.providers))
 	return nil
 }
 
 func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg ProvidersConfig) (*providerSetup, error) {
+	return h.buildConfiguredProviderSetupWithDynamicValidation(ctx, cfg, true)
+}
+
+func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx context.Context, cfg ProvidersConfig, validateDynamicModels bool) (*providerSetup, error) {
 	providers, providerOrder, defaultProviderID, err := h.buildProviders(cfg)
 	if err != nil {
 		return nil, err
@@ -424,7 +429,7 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 
 	needsDynamicModelValidation := len(providers) > 1 && hasDynamicProvider(providers)
 
-	if !needsDynamicModelValidation {
+	if !needsDynamicModelValidation || !validateDynamicModels {
 		for _, providerID := range providerOrder {
 			if err := setup.addStaticProviderModels(providerID); err != nil {
 				return nil, err
@@ -459,6 +464,38 @@ func (h *ProxyHandler) buildConfiguredProviderSetup(ctx context.Context, cfg Pro
 	}
 
 	return setup, nil
+}
+
+// ValidateDynamicProviderModels loads dynamic provider catalogs into an already
+// initialized provider setup. It is safe to call after the HTTP listener is up:
+// model-map updates are applied through providerSetup's locked replacement path.
+func (h *ProxyHandler) ValidateDynamicProviderModels(ctx context.Context) error {
+	setup := h.providerSetup()
+	if setup == nil || !setup.hasConfiguredState || len(setup.providers) <= 1 || !hasDynamicProvider(setup.providers) {
+		h.dynamicProviderValidationPending.Store(false)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, modelsUpstreamTimeout)
+	defer cancel()
+
+	for _, providerID := range setup.providerOrder {
+		provider := setup.providerByID(providerID)
+		if !providerUsesDynamicModels(provider) {
+			continue
+		}
+
+		result, err := h.fetchProviderModels(ctx, provider, "", "")
+		if err != nil {
+			return fmt.Errorf("load models for provider %q: %w", provider.id, err)
+		}
+		if err := setup.replaceProviderModels(providerID, result.models); err != nil {
+			return err
+		}
+	}
+
+	h.dynamicProviderValidationPending.Store(false)
+	return nil
 }
 
 func (h *ProxyHandler) buildProviders(cfg ProvidersConfig) (map[string]*providerRuntime, []string, string, error) {

--- a/scripts/k8s-kind-smoke.sh
+++ b/scripts/k8s-kind-smoke.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CLUSTER_NAME="${K8S_SMOKE_CLUSTER_NAME:-vekil-smoke-${GITHUB_RUN_ID:-local}}"
+NAMESPACE="${K8S_SMOKE_NAMESPACE:-vekil-smoke}"
+IMAGE="${K8S_SMOKE_IMAGE:-vekil:k8s-smoke}"
+LOCAL_PORT="${K8S_SMOKE_LOCAL_PORT:-18080}"
+LIVENESS_WINDOW_SECONDS="${K8S_SMOKE_LIVENESS_WINDOW_SECONDS:-15}"
+DELETE_CLUSTER="${K8S_SMOKE_DELETE_CLUSTER:-1}"
+PORT_FORWARD_LOG="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/vekil-kind-port-forward.log"
+
+port_forward_pid=""
+
+redact_device_codes() {
+  sed -E 's/(enter code: )[A-Z0-9-]+/\1[REDACTED_DEVICE_CODE]/g'
+}
+
+cleanup() {
+  local rc=$?
+
+  if [[ -n "${port_forward_pid}" ]] && kill -0 "${port_forward_pid}" 2>/dev/null; then
+    kill "${port_forward_pid}" 2>/dev/null || true
+    wait "${port_forward_pid}" 2>/dev/null || true
+  fi
+
+  if [[ ${rc} -ne 0 ]]; then
+    log "Kubernetes smoke debug output"
+    kubectl -n "${NAMESPACE}" get all -o wide >&2 || true
+    kubectl -n "${NAMESPACE}" describe pod -l app=vekil >&2 || true
+    kubectl -n "${NAMESPACE}" logs -l app=vekil --all-containers --prefix 2>/dev/null | redact_device_codes >&2 || true
+    if [[ -f "${PORT_FORWARD_LOG}" ]]; then
+      log "kubectl port-forward log"
+      cat "${PORT_FORWARD_LOG}" >&2 || true
+    fi
+  fi
+
+  if [[ "${DELETE_CLUSTER}" != "0" ]]; then
+    kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+require_cmd docker
+require_cmd kind
+require_cmd kubectl
+require_cmd curl
+
+cd "${REPO_ROOT}"
+
+log "Building ${IMAGE}"
+docker build -t "${IMAGE}" .
+
+log "Creating kind cluster ${CLUSTER_NAME}"
+kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+kind create cluster --name "${CLUSTER_NAME}" --wait 120s
+
+log "Loading ${IMAGE} into ${CLUSTER_NAME}"
+kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+
+log "Deploying Vekil without credentials"
+kubectl create namespace "${NAMESPACE}"
+kubectl -n "${NAMESPACE}" apply -f - <<EOF_MANIFEST
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vekil
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vekil
+  template:
+    metadata:
+      labels:
+        app: vekil
+    spec:
+      containers:
+        - name: vekil
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 1337
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "1337"
+            - name: TOKEN_DIR
+              value: /home/nonroot/.config/vekil
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 1
+          volumeMounts:
+            - name: token-cache
+              mountPath: /home/nonroot/.config/vekil
+      volumes:
+        - name: token-cache
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vekil
+spec:
+  selector:
+    app: vekil
+  ports:
+    - name: http
+      port: 1337
+      targetPort: http
+EOF_MANIFEST
+
+pod=""
+for _ in $(seq 1 60); do
+  pod="$(kubectl -n "${NAMESPACE}" get pod -l app=vekil -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [[ -n "${pod}" ]]; then
+    phase="$(kubectl -n "${NAMESPACE}" get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    running_since="$(kubectl -n "${NAMESPACE}" get pod "${pod}" -o jsonpath='{.status.containerStatuses[?(@.name=="vekil")].state.running.startedAt}' 2>/dev/null || true)"
+    if [[ "${phase}" == "Running" && -n "${running_since}" ]]; then
+      break
+    fi
+  fi
+  sleep 2
+done
+
+[[ -n "${pod}" ]] || die "Vekil pod was not created"
+running_since="$(kubectl -n "${NAMESPACE}" get pod "${pod}" -o jsonpath='{.status.containerStatuses[?(@.name=="vekil")].state.running.startedAt}' 2>/dev/null || true)"
+[[ -n "${running_since}" ]] || die "Vekil container did not start"
+
+log "Port-forwarding ${pod} to localhost:${LOCAL_PORT}"
+rm -f "${PORT_FORWARD_LOG}"
+kubectl -n "${NAMESPACE}" port-forward "pod/${pod}" "${LOCAL_PORT}:1337" >"${PORT_FORWARD_LOG}" 2>&1 &
+port_forward_pid="$!"
+
+health_body=""
+for _ in $(seq 1 30); do
+  if health_body="$(curl -fsS "http://127.0.0.1:${LOCAL_PORT}/healthz" 2>/dev/null)"; then
+    break
+  fi
+  sleep 1
+done
+
+[[ "${health_body}" == '{"status":"ok"}' ]] || die "unexpected /healthz response: ${health_body:-<none>}"
+
+ready_body_file="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/vekil-kind-readyz.json"
+ready_code="$(curl -sS -o "${ready_body_file}" -w '%{http_code}' "http://127.0.0.1:${LOCAL_PORT}/readyz")"
+if [[ "${ready_code}" != "503" ]]; then
+  die "expected /readyz HTTP 503 while startup auth is pending, got ${ready_code}: $(cat "${ready_body_file}" 2>/dev/null || true)"
+fi
+if ! grep -q 'not_ready' "${ready_body_file}"; then
+  die "expected /readyz not_ready body, got: $(cat "${ready_body_file}" 2>/dev/null || true)"
+fi
+
+log "Waiting ${LIVENESS_WINDOW_SECONDS}s to verify liveness probe does not restart the pod"
+sleep "${LIVENESS_WINDOW_SECONDS}"
+
+restarts="$(kubectl -n "${NAMESPACE}" get pod "${pod}" -o jsonpath='{.status.containerStatuses[?(@.name=="vekil")].restartCount}')"
+if [[ "${restarts}" != "0" ]]; then
+  die "expected zero restarts while device-code login is pending, got ${restarts}"
+fi
+
+pod_ready="$(kubectl -n "${NAMESPACE}" get pod "${pod}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
+if [[ "${pod_ready}" == "True" ]]; then
+  die "expected pod to remain unready until Copilot auth completes"
+fi
+
+log "Kubernetes smoke passed: /healthz is live, /readyz is gated, liveness caused 0 restarts"

--- a/server/server.go
+++ b/server/server.go
@@ -122,6 +122,22 @@ func (r *responseRecorder) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
 }
 
+func withProviderValidationGate(next http.Handler, handler *proxy.ProxyHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handler != nil && (handler.StartupAuthenticationPending() || handler.DynamicProviderValidationPending()) && r.URL.Path != "/healthz" && r.URL.Path != "/readyz" {
+			message := "provider model validation pending"
+			if handler.StartupAuthenticationPending() {
+				message = "startup authentication pending"
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprintf(w, `{"error":{"message":%q,"type":"service_unavailable"}}`, message)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func withRequestLog(next http.Handler, log *logger.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -192,7 +208,7 @@ func New(authenticator *auth.Authenticator, log *logger.Logger, host, port strin
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         addr,
-			Handler:      withRequestLog(mux, log),
+			Handler:      withRequestLog(withProviderValidationGate(mux, handler), log),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: handler.ServerWriteTimeout(),
 			IdleTimeout:  120 * time.Second,
@@ -221,6 +237,21 @@ func (s *Server) Start() error {
 	}()
 
 	return nil
+}
+
+// SetStartupAuthenticationPending gates non-health routes while startup auth is in progress.
+func (s *Server) SetStartupAuthenticationPending(pending bool) {
+	if s.proxyHandler != nil {
+		s.proxyHandler.SetStartupAuthenticationPending(pending)
+	}
+}
+
+// ValidateDynamicProviderModels loads deferred dynamic provider catalogs.
+func (s *Server) ValidateDynamicProviderModels(ctx context.Context) error {
+	if s.proxyHandler == nil {
+		return nil
+	}
+	return s.proxyHandler.ValidateDynamicProviderModels(ctx)
 }
 
 // Stop performs a graceful shutdown of the server.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,6 +49,111 @@ func TestStart_ReturnsErrorWhenPortInUse(t *testing.T) {
 	}
 }
 
+func TestServerBlocksNonHealthRoutesWhileStartupAuthenticationPending(t *testing.T) {
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+	srv.SetStartupAuthenticationPending(true)
+
+	for _, tc := range []struct {
+		method string
+		path   string
+		want   int
+	}{
+		{method: http.MethodGet, path: "/healthz", want: http.StatusOK},
+		{method: http.MethodGet, path: "/readyz", want: http.StatusServiceUnavailable},
+		{method: http.MethodGet, path: "/v1/models", want: http.StatusServiceUnavailable},
+		{method: http.MethodPost, path: "/v1/chat/completions", want: http.StatusServiceUnavailable},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(`{"model":"gpt-5.4"}`))
+			w := httptest.NewRecorder()
+			srv.httpServer.Handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != tc.want {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d: %s", resp.StatusCode, tc.want, body)
+			}
+			if tc.path != "/healthz" {
+				body, _ := io.ReadAll(resp.Body)
+				if !strings.Contains(string(body), "startup authentication pending") {
+					t.Fatalf("response missing startup auth pending message: %s", body)
+				}
+			}
+		})
+	}
+}
+
+func TestServerBlocksNonHealthRoutesWhileProviderValidationPending(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer upstream.Close()
+
+	srv, err := New(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.ParseLevel("error")),
+		"127.0.0.1",
+		"0",
+		WithProxyOptions(
+			proxy.WithDeferredDynamicProviderModelValidation(true),
+			proxy.WithProvidersConfig(proxy.ProvidersConfig{
+				Providers: []proxy.ProviderConfig{
+					{ID: "copilot", Type: "copilot", Default: true},
+					{
+						ID:       "local",
+						Type:     "openai-compatible",
+						BaseURL:  upstream.URL,
+						AuthType: "none",
+						Models: []proxy.ProviderModelConfig{{
+							PublicID: "local-model",
+						}},
+					},
+				},
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize server: %v", err)
+	}
+
+	for _, tc := range []struct {
+		method string
+		path   string
+		want   int
+	}{
+		{method: http.MethodGet, path: "/healthz", want: http.StatusOK},
+		{method: http.MethodGet, path: "/readyz", want: http.StatusServiceUnavailable},
+		{method: http.MethodGet, path: "/v1/models", want: http.StatusServiceUnavailable},
+		{method: http.MethodPost, path: "/v1/chat/completions", want: http.StatusServiceUnavailable},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(`{"model":"gpt-5.4"}`))
+			w := httptest.NewRecorder()
+			srv.httpServer.Handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != tc.want {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d: %s", resp.StatusCode, tc.want, body)
+			}
+			if tc.path != "/healthz" {
+				body, _ := io.ReadAll(resp.Body)
+				if !strings.Contains(string(body), "provider model validation pending") {
+					t.Fatalf("response missing pending validation message: %s", body)
+				}
+			}
+		})
+	}
+}
+
 func TestNew_ConfiguresExtendedWriteTimeout(t *testing.T) {
 	srv, err := New(
 		auth.NewTestAuthenticator("test-token"),


### PR DESCRIPTION
## Summary

- start the HTTP listener before blocking Copilot startup authentication so `/healthz` is available during first-run device-code login
- gate non-health routes while startup authentication or deferred dynamic provider validation is pending
- defer configured Copilot dynamic model validation until after startup auth, while preserving collision checks before readiness/traffic
- serialize pending device authorization with sign-out and explicit GitHub CLI sign-in to avoid repersisting credentials after logout

## Root cause

Zero-config and Copilot-backed startup authenticated synchronously before `server.Start()`, so Kubernetes liveness probes saw connection refused during the device-code login window. The auth lock also held the main token mutex while polling, which could block non-interactive readiness checks.

## Validation

- `git diff --check`
- `go test ./... -count=1`
- `python3 /Users/sozercan/.codex/skills/autoreview/scripts/autoreview --mode local` → clean

Fixes #223
