### PR TITLE
fix(proxy): normalize chat completion responses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,13 +42,13 @@ Gemini compatibility is a translation layer over OpenAI Chat Completions. See [G
 
 ## `POST /v1/chat/completions` (OpenAI)
 
-Near zero-copy passthrough for requests without tools. Successful non-streaming responses are conservatively normalized to strict OpenAI Chat Completions shape when upstreams omit required compatibility fields: missing `object` becomes `"chat.completion"`, missing `created`/`id`/`usage` are filled, requested `model` is used when absent, and choice `message`/`index`/`finish_reason` gaps are repaired while vendor-specific metadata is preserved.
+Near zero-copy passthrough for requests without tools. Successful non-streaming responses are conservatively normalized to strict OpenAI Chat Completions shape when upstreams omit required compatibility fields: missing `object` becomes `"chat.completion"`, missing `created`/`id`/`usage` are filled, requested `model` is used when absent, and choice `message`/`index`/`finish_reason` gaps are repaired while vendor-specific metadata is preserved. Streaming chat chunks are similarly normalized only for missing chunk envelope fields such as `object: "chat.completion.chunk"`, `id`, `created`, `model`, `choices[].index`, and `choices[].delta`.
 
 When tools are present, the proxy injects `parallel_tool_calls: true`, forces upstream streaming for reliable parallel tool calls, and aggregates the result back to non-streaming JSON.
 
 The proxy enforces the selected model's configured endpoint allowlist before forwarding. If a model is `/responses`-only, `POST /v1/chat/completions` fails fast with `400` instead of probing an unsupported upstream route.
 
-For client-requested streams that omit `stream_options`, the proxy asks the upstream for a final usage chunk (`stream_options.include_usage`) so streamed traffic still records token totals in the dashboard. That injected usage-only chunk is consumed internally and **not** forwarded to the client, so the streamed SSE the client sees is unchanged from a standard OpenAI stream (no extra `choices: []` terminal chunk). If the client supplied its own `stream_options`, its choice is preserved untouched.
+For client-requested streams that omit `stream_options`, the proxy asks the upstream for a final usage chunk (`stream_options.include_usage`) so streamed traffic still records token totals in the dashboard. That injected usage-only chunk is consumed internally and **not** forwarded to the client, so clients do not see an extra `choices: []` terminal chunk. If the client supplied its own `stream_options`, its choice is preserved untouched.
 
 ## Responses Compatibility Endpoints
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,7 +42,9 @@ Gemini compatibility is a translation layer over OpenAI Chat Completions. See [G
 
 ## `POST /v1/chat/completions` (OpenAI)
 
-Near zero-copy passthrough for requests without tools. When tools are present, the proxy injects `parallel_tool_calls: true`, forces upstream streaming for reliable parallel tool calls, and aggregates the result back to non-streaming JSON.
+Near zero-copy passthrough for requests without tools. Successful non-streaming responses are conservatively normalized to strict OpenAI Chat Completions shape when upstreams omit required compatibility fields: missing `object` becomes `"chat.completion"`, missing `created`/`id`/`usage` are filled, requested `model` is used when absent, and choice `message`/`index`/`finish_reason` gaps are repaired while vendor-specific metadata is preserved.
+
+When tools are present, the proxy injects `parallel_tool_calls: true`, forces upstream streaming for reliable parallel tool calls, and aggregates the result back to non-streaming JSON.
 
 The proxy enforces the selected model's configured endpoint allowlist before forwarding. If a model is `/responses`-only, `POST /v1/chat/completions` fails fast with `400` instead of probing an unsupported upstream route.
 

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -212,6 +212,9 @@ func normalizeOpenAIChatCompletionResponse(body []byte, requestedModel string, n
 	if payload == nil {
 		return nil, false, fmt.Errorf("chat completion response is not a JSON object")
 	}
+	if hasNonNullJSONField(payload, "error") {
+		return body, false, nil
+	}
 
 	changed := false
 	if !hasNonEmptyStringJSONField(payload, "object") {
@@ -403,6 +406,18 @@ func normalizeOpenAIChatCompletionMessage(choice map[string]json.RawMessage) (js
 		}
 		changed = true
 	}
+	if !hasNonNullJSONField(message, "tool_calls") {
+		if toolCalls, ok := choice["tool_calls"]; ok && len(bytes.TrimSpace(toolCalls)) > 0 && string(bytes.TrimSpace(toolCalls)) != "null" {
+			message["tool_calls"] = toolCalls
+			changed = true
+		}
+	}
+	if !hasNonNullJSONField(message, "function_call") {
+		if functionCall, ok := choice["function_call"]; ok && len(bytes.TrimSpace(functionCall)) > 0 && string(bytes.TrimSpace(functionCall)) != "null" {
+			message["function_call"] = functionCall
+			changed = true
+		}
+	}
 
 	if !changed {
 		return choice["message"], false
@@ -427,8 +442,20 @@ func firstProviderChoiceContent(choice map[string]json.RawMessage) (json.RawMess
 	return nil, false
 }
 
+func choiceMessageHasToolCall(choice map[string]json.RawMessage) bool {
+	raw, ok := choice["message"]
+	if !ok || len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+		return false
+	}
+	var message map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &message); err != nil || message == nil {
+		return false
+	}
+	return hasNonNullJSONField(message, "tool_calls") || hasNonNullJSONField(message, "function_call")
+}
+
 func defaultOpenAIChatChoiceFinishReason(choice map[string]json.RawMessage) string {
-	if hasNonNullJSONField(choice, "tool_calls") || hasNonNullJSONField(choice, "function_call") {
+	if hasNonNullJSONField(choice, "tool_calls") || hasNonNullJSONField(choice, "function_call") || choiceMessageHasToolCall(choice) {
 		return "tool_calls"
 	}
 	if raw, ok := choice["stop_reason"]; ok {

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -1,0 +1,352 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sozercan/vekil/models"
+)
+
+const openAIChatCompletionObject = "chat.completion"
+
+// normalizeOpenAIChatCompletionResponse fills in OpenAI Chat Completions fields
+// that strict SDK clients require while preserving upstream/vendor-specific
+// fields. It is intentionally map-based instead of models.OpenAIResponse-based
+// so unknown top-level and nested fields survive unchanged.
+func normalizeOpenAIChatCompletionResponse(body []byte, requestedModel string, now time.Time) ([]byte, bool, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, false, err
+	}
+	if payload == nil {
+		return nil, false, fmt.Errorf("chat completion response is not a JSON object")
+	}
+
+	changed := false
+	if !hasNonNullJSONField(payload, "object") {
+		payload["object"] = mustMarshalRaw(openAIChatCompletionObject)
+		changed = true
+	}
+	if !hasNonNullJSONField(payload, "created") {
+		created := now.Unix()
+		if created <= 0 {
+			created = time.Now().Unix()
+		}
+		payload["created"] = mustMarshalRaw(created)
+		changed = true
+	}
+	if !hasNonEmptyStringJSONField(payload, "id") {
+		payload["id"] = mustMarshalRaw("chatcmpl-" + uuid.NewString())
+		changed = true
+	}
+	if !hasNonEmptyStringJSONField(payload, "model") {
+		if model := strings.TrimSpace(requestedModel); model != "" {
+			payload["model"] = mustMarshalRaw(model)
+			changed = true
+		}
+	}
+
+	usage, usageChanged := normalizeOpenAIChatCompletionUsage(payload["usage"])
+	if usageChanged {
+		payload["usage"] = usage
+		changed = true
+	}
+
+	if !hasNonNullJSONField(payload, "choices") {
+		payload["choices"] = json.RawMessage("[]")
+		changed = true
+	} else {
+		choices, choicesChanged, err := normalizeOpenAIChatCompletionChoices(payload["choices"])
+		if err != nil {
+			return nil, false, err
+		}
+		if choicesChanged {
+			payload["choices"] = choices
+			changed = true
+		}
+	}
+
+	if !changed {
+		return body, false, nil
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+func normalizeOpenAIChatCompletionStruct(resp *models.OpenAIResponse, requestedModel string) {
+	if resp == nil {
+		return
+	}
+	if strings.TrimSpace(resp.ID) == "" {
+		resp.ID = "chatcmpl-" + uuid.NewString()
+	}
+	if strings.TrimSpace(resp.Object) == "" {
+		resp.Object = openAIChatCompletionObject
+	}
+	if resp.Created == 0 {
+		resp.Created = time.Now().Unix()
+	}
+	if strings.TrimSpace(resp.Model) == "" {
+		resp.Model = strings.TrimSpace(requestedModel)
+	}
+	if resp.Usage == nil {
+		resp.Usage = &models.OpenAIUsage{}
+	} else if resp.Usage.TotalTokens == 0 && (resp.Usage.PromptTokens != 0 || resp.Usage.CompletionTokens != 0) {
+		resp.Usage.TotalTokens = resp.Usage.PromptTokens + resp.Usage.CompletionTokens
+	}
+
+	for i := range resp.Choices {
+		choice := &resp.Choices[i]
+		if choice.FinishReason == nil || strings.TrimSpace(*choice.FinishReason) == "" {
+			finishReason := defaultOpenAIChatStructFinishReason(*choice)
+			choice.FinishReason = &finishReason
+		}
+		if strings.TrimSpace(choice.Message.Role) == "" {
+			choice.Message.Role = "assistant"
+		}
+		if len(bytes.TrimSpace(choice.Message.Content)) == 0 {
+			choice.Message.Content = json.RawMessage(`""`)
+		}
+	}
+}
+
+func defaultOpenAIChatStructFinishReason(choice models.OpenAIChoice) string {
+	if len(choice.Message.ToolCalls) > 0 {
+		return "tool_calls"
+	}
+	return "stop"
+}
+
+func normalizeOpenAIChatCompletionChoices(raw json.RawMessage) (json.RawMessage, bool, error) {
+	var choices []json.RawMessage
+	if err := json.Unmarshal(raw, &choices); err != nil {
+		return nil, false, err
+	}
+
+	changed := false
+	for i := range choices {
+		choiceRaw, choiceChanged, err := normalizeOpenAIChatCompletionChoice(choices[i], i)
+		if err != nil {
+			return nil, false, err
+		}
+		if choiceChanged {
+			choices[i] = choiceRaw
+			changed = true
+		}
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+	out, err := json.Marshal(choices)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+func normalizeOpenAIChatCompletionChoice(raw json.RawMessage, arrayIndex int) (json.RawMessage, bool, error) {
+	var choice map[string]json.RawMessage
+	if len(bytes.TrimSpace(raw)) > 0 && string(bytes.TrimSpace(raw)) != "null" {
+		if err := json.Unmarshal(raw, &choice); err != nil {
+			return nil, false, err
+		}
+	}
+	if choice == nil {
+		choice = make(map[string]json.RawMessage)
+	}
+
+	changed := false
+	if !hasNonNullJSONField(choice, "index") {
+		choice["index"] = mustMarshalRaw(arrayIndex)
+		changed = true
+	}
+	if !hasNonNullJSONField(choice, "finish_reason") {
+		choice["finish_reason"] = mustMarshalRaw(defaultOpenAIChatChoiceFinishReason(choice))
+		changed = true
+	}
+
+	message, messageChanged := normalizeOpenAIChatCompletionMessage(choice)
+	if messageChanged {
+		choice["message"] = message
+		changed = true
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+	out, err := json.Marshal(choice)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+func normalizeOpenAIChatCompletionMessage(choice map[string]json.RawMessage) (json.RawMessage, bool) {
+	var message map[string]json.RawMessage
+	changed := false
+	if raw, ok := choice["message"]; ok && len(bytes.TrimSpace(raw)) > 0 && string(bytes.TrimSpace(raw)) != "null" {
+		if err := json.Unmarshal(raw, &message); err == nil && message != nil {
+			// Preserve existing message object fields below.
+		} else {
+			message = make(map[string]json.RawMessage)
+			changed = true
+		}
+	} else {
+		message = make(map[string]json.RawMessage)
+		changed = true
+	}
+
+	if !hasNonEmptyStringJSONField(message, "role") {
+		message["role"] = mustMarshalRaw("assistant")
+		changed = true
+	}
+	if !hasNonNullJSONField(message, "content") {
+		if content, ok := firstProviderChoiceContent(choice); ok {
+			message["content"] = content
+		} else {
+			message["content"] = mustMarshalRaw("")
+		}
+		changed = true
+	}
+
+	if !changed {
+		return choice["message"], false
+	}
+	out, err := json.Marshal(message)
+	if err != nil {
+		return choice["message"], false
+	}
+	return out, true
+}
+
+func firstProviderChoiceContent(choice map[string]json.RawMessage) (json.RawMessage, bool) {
+	for _, key := range []string{"content", "text", "output_text"} {
+		raw, ok := choice[key]
+		if !ok || len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+			continue
+		}
+		if isJSONString(raw) {
+			return raw, true
+		}
+	}
+	return nil, false
+}
+
+func defaultOpenAIChatChoiceFinishReason(choice map[string]json.RawMessage) string {
+	if hasNonNullJSONField(choice, "tool_calls") || hasNonNullJSONField(choice, "function_call") {
+		return "tool_calls"
+	}
+	if raw, ok := choice["stop_reason"]; ok {
+		var reason string
+		if err := json.Unmarshal(raw, &reason); err == nil {
+			switch strings.TrimSpace(reason) {
+			case "tool_use":
+				return "tool_calls"
+			case "max_tokens":
+				return "length"
+			case "end_turn", "stop_sequence":
+				return "stop"
+			}
+		}
+	}
+	return "stop"
+}
+
+func normalizeOpenAIChatCompletionUsage(raw json.RawMessage) (json.RawMessage, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+		return json.RawMessage(`{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}`), true
+	}
+
+	var usage map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &usage); err != nil || usage == nil {
+		return raw, false
+	}
+
+	changed := false
+	prompt, hasPrompt := jsonRawNumberAsInt64(usage["prompt_tokens"])
+	completion, hasCompletion := jsonRawNumberAsInt64(usage["completion_tokens"])
+	if !hasPrompt {
+		usage["prompt_tokens"] = json.RawMessage("0")
+		prompt = 0
+		changed = true
+	}
+	if !hasCompletion {
+		usage["completion_tokens"] = json.RawMessage("0")
+		completion = 0
+		changed = true
+	}
+	if _, hasTotal := jsonRawNumberAsInt64(usage["total_tokens"]); !hasTotal {
+		if hasPrompt || hasCompletion {
+			usage["total_tokens"] = json.RawMessage(strconv.FormatInt(prompt+completion, 10))
+		} else {
+			usage["total_tokens"] = json.RawMessage("0")
+		}
+		changed = true
+	}
+
+	if !changed {
+		return raw, false
+	}
+	out, err := json.Marshal(usage)
+	if err != nil {
+		return raw, false
+	}
+	return out, true
+}
+
+func hasNonNullJSONField(m map[string]json.RawMessage, key string) bool {
+	raw, ok := m[key]
+	if !ok {
+		return false
+	}
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && string(trimmed) != "null"
+}
+
+func hasNonEmptyStringJSONField(m map[string]json.RawMessage, key string) bool {
+	raw, ok := m[key]
+	if !ok {
+		return false
+	}
+	var value string
+	return json.Unmarshal(raw, &value) == nil && strings.TrimSpace(value) != ""
+}
+
+func isJSONString(raw json.RawMessage) bool {
+	var value string
+	return json.Unmarshal(raw, &value) == nil
+}
+
+func jsonRawNumberAsInt64(raw json.RawMessage) (int64, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+		return 0, false
+	}
+	var number json.Number
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&number); err != nil {
+		return 0, false
+	}
+	value, err := number.Int64()
+	if err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func mustMarshalRaw(v interface{}) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -18,10 +18,11 @@ const (
 )
 
 type openAIChatCompletionChunkNormalizer struct {
-	requestedModel string
-	streamID       string
-	created        int64
-	model          string
+	requestedModel    string
+	streamID          string
+	syntheticStreamID bool
+	created           int64
+	model             string
 }
 
 func newOpenAIChatCompletionChunkNormalizer(requestedModel string) *openAIChatCompletionChunkNormalizer {
@@ -64,10 +65,19 @@ func (n *openAIChatCompletionChunkNormalizer) normalize(eventType, data string) 
 		changed = true
 	}
 	if hasNonEmptyStringJSONField(payload, "id") {
-		n.streamID = jsonRawString(payload["id"])
+		upstreamID := jsonRawString(payload["id"])
+		if n.streamID == "" {
+			n.streamID = upstreamID
+		} else if n.syntheticStreamID && upstreamID != n.streamID {
+			payload["id"] = mustMarshalRaw(n.streamID)
+			changed = true
+		} else {
+			n.streamID = upstreamID
+		}
 	} else {
 		if n.streamID == "" {
 			n.streamID = "chatcmpl-" + uuid.NewString()
+			n.syntheticStreamID = true
 		}
 		payload["id"] = mustMarshalRaw(n.streamID)
 		changed = true
@@ -178,6 +188,12 @@ func defaultOpenAIChatCompletionChunkDelta(choice map[string]json.RawMessage) js
 	}
 	if role, ok := firstProviderChoiceStringField(choice, "role"); ok {
 		delta["role"] = role
+	}
+	if toolCalls, ok := choice["tool_calls"]; ok && rawToolCallsNonEmpty(toolCalls) {
+		delta["tool_calls"] = toolCalls
+	}
+	if functionCall, ok := choice["function_call"]; ok && rawFunctionCallNonEmpty(functionCall) {
+		delta["function_call"] = functionCall
 	}
 	if len(delta) == 0 {
 		return json.RawMessage("{}")
@@ -358,7 +374,7 @@ func normalizeOpenAIChatCompletionChoice(raw json.RawMessage, arrayIndex int) (j
 		choice["index"] = mustMarshalRaw(arrayIndex)
 		changed = true
 	}
-	if !hasNonNullJSONField(choice, "finish_reason") {
+	if !hasNonEmptyStringJSONField(choice, "finish_reason") {
 		choice["finish_reason"] = mustMarshalRaw(defaultOpenAIChatChoiceFinishReason(choice))
 		changed = true
 	}
@@ -407,13 +423,13 @@ func normalizeOpenAIChatCompletionMessage(choice map[string]json.RawMessage) (js
 		changed = true
 	}
 	if !hasNonNullJSONField(message, "tool_calls") {
-		if toolCalls, ok := choice["tool_calls"]; ok && len(bytes.TrimSpace(toolCalls)) > 0 && string(bytes.TrimSpace(toolCalls)) != "null" {
+		if toolCalls, ok := choice["tool_calls"]; ok && rawToolCallsNonEmpty(toolCalls) {
 			message["tool_calls"] = toolCalls
 			changed = true
 		}
 	}
 	if !hasNonNullJSONField(message, "function_call") {
-		if functionCall, ok := choice["function_call"]; ok && len(bytes.TrimSpace(functionCall)) > 0 && string(bytes.TrimSpace(functionCall)) != "null" {
+		if functionCall, ok := choice["function_call"]; ok && rawFunctionCallNonEmpty(functionCall) {
 			message["function_call"] = functionCall
 			changed = true
 		}
@@ -451,11 +467,31 @@ func choiceMessageHasToolCall(choice map[string]json.RawMessage) bool {
 	if err := json.Unmarshal(raw, &message); err != nil || message == nil {
 		return false
 	}
-	return hasNonNullJSONField(message, "tool_calls") || hasNonNullJSONField(message, "function_call")
+	return rawToolCallsNonEmpty(message["tool_calls"]) || rawFunctionCallNonEmpty(message["function_call"])
+}
+
+func choiceHasToolCall(choice map[string]json.RawMessage) bool {
+	return rawToolCallsNonEmpty(choice["tool_calls"]) || rawFunctionCallNonEmpty(choice["function_call"]) || choiceMessageHasToolCall(choice)
+}
+
+func rawToolCallsNonEmpty(raw json.RawMessage) bool {
+	if len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+		return false
+	}
+	var calls []json.RawMessage
+	return json.Unmarshal(raw, &calls) == nil && len(calls) > 0
+}
+
+func rawFunctionCallNonEmpty(raw json.RawMessage) bool {
+	if len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+		return false
+	}
+	var call map[string]json.RawMessage
+	return json.Unmarshal(raw, &call) == nil && len(call) > 0
 }
 
 func defaultOpenAIChatChoiceFinishReason(choice map[string]json.RawMessage) string {
-	if hasNonNullJSONField(choice, "tool_calls") || hasNonNullJSONField(choice, "function_call") || choiceMessageHasToolCall(choice) {
+	if choiceHasToolCall(choice) {
 		return "tool_calls"
 	}
 	if raw, ok := choice["stop_reason"]; ok {

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -12,7 +12,193 @@ import (
 	"github.com/sozercan/vekil/models"
 )
 
-const openAIChatCompletionObject = "chat.completion"
+const (
+	openAIChatCompletionObject      = "chat.completion"
+	openAIChatCompletionChunkObject = "chat.completion.chunk"
+)
+
+type openAIChatCompletionChunkNormalizer struct {
+	requestedModel string
+	streamID       string
+	created        int64
+	model          string
+}
+
+func newOpenAIChatCompletionChunkNormalizer(requestedModel string) *openAIChatCompletionChunkNormalizer {
+	return &openAIChatCompletionChunkNormalizer{requestedModel: strings.TrimSpace(requestedModel)}
+}
+
+func openAIChatStreamEventMayCarryChunk(eventType string) bool {
+	switch strings.TrimSpace(eventType) {
+	case "", "message", openAIChatCompletionChunkObject:
+		return true
+	default:
+		return false
+	}
+}
+
+func (n *openAIChatCompletionChunkNormalizer) normalize(eventType, data string) (string, bool) {
+	// OpenAI chat completion streams usually use unnamed SSE events. Also accept
+	// explicit event names that are equivalent to the default SSE "message" event
+	// or that directly label a chat chunk. Leave other side-band events
+	// (event: ping, event: metadata, event: error, etc.) untouched so provider
+	// metadata is not converted into a synthetic chat chunk.
+	if n == nil || !openAIChatStreamEventMayCarryChunk(eventType) {
+		return data, false
+	}
+	if strings.TrimSpace(data) == "" || strings.TrimSpace(data) == "[DONE]" {
+		return data, false
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(data), &payload); err != nil || payload == nil {
+		return data, false
+	}
+	if hasNonNullJSONField(payload, "error") {
+		return data, false
+	}
+
+	changed := false
+	if !hasNonEmptyStringJSONField(payload, "object") {
+		payload["object"] = mustMarshalRaw(openAIChatCompletionChunkObject)
+		changed = true
+	}
+	if hasNonEmptyStringJSONField(payload, "id") {
+		n.streamID = jsonRawString(payload["id"])
+	} else {
+		if n.streamID == "" {
+			n.streamID = "chatcmpl-" + uuid.NewString()
+		}
+		payload["id"] = mustMarshalRaw(n.streamID)
+		changed = true
+	}
+	if created, ok := jsonRawNumberAsInt64(payload["created"]); ok && created > 0 {
+		n.created = created
+	} else {
+		if n.created == 0 {
+			n.created = time.Now().Unix()
+		}
+		payload["created"] = mustMarshalRaw(n.created)
+		changed = true
+	}
+	if hasNonEmptyStringJSONField(payload, "model") {
+		n.model = jsonRawString(payload["model"])
+	} else {
+		model := strings.TrimSpace(n.model)
+		if model == "" {
+			model = n.requestedModel
+		}
+		if model != "" {
+			payload["model"] = mustMarshalRaw(model)
+			changed = true
+		}
+	}
+
+	if !hasNonNullJSONField(payload, "choices") {
+		payload["choices"] = json.RawMessage("[]")
+		changed = true
+	} else if choices, choicesChanged, err := normalizeOpenAIChatCompletionChunkChoices(payload["choices"]); err == nil && choicesChanged {
+		payload["choices"] = choices
+		changed = true
+	}
+
+	if !changed {
+		return data, false
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return data, false
+	}
+	return string(out), true
+}
+
+func normalizeOpenAIChatCompletionChunkChoices(raw json.RawMessage) (json.RawMessage, bool, error) {
+	var choices []json.RawMessage
+	if err := json.Unmarshal(raw, &choices); err != nil {
+		return nil, false, err
+	}
+
+	changed := false
+	for i := range choices {
+		choiceRaw, choiceChanged, err := normalizeOpenAIChatCompletionChunkChoice(choices[i], i)
+		if err != nil {
+			return nil, false, err
+		}
+		if choiceChanged {
+			choices[i] = choiceRaw
+			changed = true
+		}
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+	out, err := json.Marshal(choices)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+func normalizeOpenAIChatCompletionChunkChoice(raw json.RawMessage, arrayIndex int) (json.RawMessage, bool, error) {
+	var choice map[string]json.RawMessage
+	if len(bytes.TrimSpace(raw)) > 0 && string(bytes.TrimSpace(raw)) != "null" {
+		if err := json.Unmarshal(raw, &choice); err != nil {
+			return nil, false, err
+		}
+	}
+	if choice == nil {
+		choice = make(map[string]json.RawMessage)
+	}
+
+	changed := false
+	if !hasNonNullJSONField(choice, "index") {
+		choice["index"] = mustMarshalRaw(arrayIndex)
+		changed = true
+	}
+	if !hasNonNullJSONField(choice, "delta") {
+		choice["delta"] = defaultOpenAIChatCompletionChunkDelta(choice)
+		changed = true
+	}
+
+	if !changed {
+		return raw, false, nil
+	}
+	out, err := json.Marshal(choice)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+func defaultOpenAIChatCompletionChunkDelta(choice map[string]json.RawMessage) json.RawMessage {
+	delta := make(map[string]json.RawMessage)
+	if content, ok := firstProviderChoiceContent(choice); ok {
+		delta["content"] = content
+	}
+	if role, ok := firstProviderChoiceStringField(choice, "role"); ok {
+		delta["role"] = role
+	}
+	if len(delta) == 0 {
+		return json.RawMessage("{}")
+	}
+	out, err := json.Marshal(delta)
+	if err != nil {
+		return json.RawMessage("{}")
+	}
+	return out
+}
+
+func firstProviderChoiceStringField(choice map[string]json.RawMessage, key string) (json.RawMessage, bool) {
+	raw, ok := choice[key]
+	if !ok || len(bytes.TrimSpace(raw)) == 0 || string(bytes.TrimSpace(raw)) == "null" {
+		return nil, false
+	}
+	if isJSONString(raw) {
+		return raw, true
+	}
+	return nil, false
+}
 
 // normalizeOpenAIChatCompletionResponse fills in OpenAI Chat Completions fields
 // that strict SDK clients require while preserving upstream/vendor-specific
@@ -28,7 +214,7 @@ func normalizeOpenAIChatCompletionResponse(body []byte, requestedModel string, n
 	}
 
 	changed := false
-	if !hasNonNullJSONField(payload, "object") {
+	if !hasNonEmptyStringJSONField(payload, "object") {
 		payload["object"] = mustMarshalRaw(openAIChatCompletionObject)
 		changed = true
 	}
@@ -319,6 +505,14 @@ func hasNonEmptyStringJSONField(m map[string]json.RawMessage, key string) bool {
 	}
 	var value string
 	return json.Unmarshal(raw, &value) == nil && strings.TrimSpace(value) != ""
+}
+
+func jsonRawString(raw json.RawMessage) string {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(value)
 }
 
 func isJSONString(raw json.RawMessage) bool {

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -551,6 +551,8 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	err = h.routeChatCompletionsResponse(w, resp, mode, chatCompletionsResponseHandlers{
 		stream: func(resp *http.Response) {
 			copyPassthroughHeaders(w.Header(), resp.Header)
+			// TODO: add a separate ChatCompletionChunk normalizer if strict streaming
+			// clients encounter upstream chunks missing OpenAI-required chunk fields.
 			finalResponse := h.openAIChatStreamFinalResponseCallback(r.Context(), h.toolContexts, scope)
 			usage := openAIChatStreamUsageCallback(r.Context())
 			// A post-commit upstream stream error (the 200 header is already sent)
@@ -562,13 +564,14 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 			StreamOpenAIChatPassthrough(w, resp.Body, mode.injectedClientStreamUsage, onError, finalResponse, usage)
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
+			normalizeOpenAIChatCompletionStruct(oaiResp, requestedModel)
 			observeOpenAIUsage(r.Context(), oaiResp.Usage)
 			h.maybeRewriteOrCaptureOpenAIChatToolCommands(r.Context(), oaiResp, h.toolContexts, scope, false)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(oaiResp)
 		},
 		passthrough: func(resp *http.Response) error {
-			return h.maybeWriteOptimizedOpenAIChatPassthrough(r.Context(), w, resp, h.toolContexts, scope)
+			return h.maybeWriteOptimizedOpenAIChatPassthrough(r.Context(), w, resp, requestedModel, h.toolContexts, scope)
 		},
 	})
 	if err != nil {

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -551,8 +551,6 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	err = h.routeChatCompletionsResponse(w, resp, mode, chatCompletionsResponseHandlers{
 		stream: func(resp *http.Response) {
 			copyPassthroughHeaders(w.Header(), resp.Header)
-			// TODO: add a separate ChatCompletionChunk normalizer if strict streaming
-			// clients encounter upstream chunks missing OpenAI-required chunk fields.
 			finalResponse := h.openAIChatStreamFinalResponseCallback(r.Context(), h.toolContexts, scope)
 			usage := openAIChatStreamUsageCallback(r.Context())
 			// A post-commit upstream stream error (the 200 header is already sent)
@@ -561,7 +559,7 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 			onError := func(status int) { observeResponseFailureStatus(r.Context(), status) }
 			// dropInjectedUsage drops the upstream usage-only chunk the proxy asked
 			// for when the client did not opt into stream_options.include_usage.
-			StreamOpenAIChatPassthrough(w, resp.Body, mode.injectedClientStreamUsage, onError, finalResponse, usage)
+			StreamOpenAIChatPassthrough(w, resp.Body, requestedModel, mode.injectedClientStreamUsage, onError, finalResponse, usage)
 		},
 		aggregate: func(oaiResp *models.OpenAIResponse) {
 			normalizeOpenAIChatCompletionStruct(oaiResp, requestedModel)

--- a/proxy/dashboard_review_fixes_test.go
+++ b/proxy/dashboard_review_fixes_test.go
@@ -604,7 +604,7 @@ func TestStreamOpenAIChatPassthroughDetectsErrorEvent(t *testing.T) {
 			body := io.NopCloser(strings.NewReader(tc.stream))
 			w := httptest.NewRecorder()
 			errored := false
-			StreamOpenAIChatPassthrough(w, body, false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
+			StreamOpenAIChatPassthrough(w, body, "gpt-4", false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
 			if !errored {
 				t.Fatalf("expected onError to fire for %q", tc.name)
 			}
@@ -615,7 +615,7 @@ func TestStreamOpenAIChatPassthroughDetectsErrorEvent(t *testing.T) {
 	body := io.NopCloser(strings.NewReader("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"))
 	w := httptest.NewRecorder()
 	errored := false
-	StreamOpenAIChatPassthrough(w, body, false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
+	StreamOpenAIChatPassthrough(w, body, "gpt-4", false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
 	if errored {
 		t.Fatal("onError must not fire for a normal content stream")
 	}
@@ -804,7 +804,7 @@ func TestStreamOpenAIChatPassthroughMarksTransportError(t *testing.T) {
 	body := &errAfterReader{data: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n")}
 	w := httptest.NewRecorder()
 	errored := false
-	StreamOpenAIChatPassthrough(w, body, false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
+	StreamOpenAIChatPassthrough(w, body, "gpt-4", false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
 	if !errored {
 		t.Fatal("expected onError to fire on a mid-stream transport error")
 	}
@@ -816,7 +816,7 @@ func TestStreamOpenAIChatPassthroughMarksPrematureEnd(t *testing.T) {
 	body := io.NopCloser(strings.NewReader("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n")) // no [DONE]
 	w := httptest.NewRecorder()
 	errored := false
-	StreamOpenAIChatPassthrough(w, body, false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
+	StreamOpenAIChatPassthrough(w, body, "gpt-4", false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
 	if !errored {
 		t.Fatal("expected onError to fire when the stream ends before [DONE]")
 	}
@@ -834,7 +834,7 @@ func TestStreamOpenAIChatPassthroughFailsOpenOnOversizedLine(t *testing.T) {
 	body := io.NopCloser(strings.NewReader(stream))
 	w := httptest.NewRecorder()
 	errored := false
-	StreamOpenAIChatPassthrough(w, body, false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
+	StreamOpenAIChatPassthrough(w, body, "gpt-4", false, func(int) { errored = true }, nil, func(*models.OpenAIUsage) {})
 
 	if errored {
 		t.Fatal("oversized line is not a failure; onError must not fire")
@@ -881,7 +881,7 @@ func TestStreamOpenAIChatPassthroughErrorStatusClassified(t *testing.T) {
 	body := io.NopCloser(strings.NewReader("data: {\"error\":{\"type\":\"rate_limit_error\",\"code\":\"too_many_requests\"}}\n\n"))
 	w := httptest.NewRecorder()
 	var gotStatus int
-	StreamOpenAIChatPassthrough(w, body, false, func(status int) { gotStatus = status }, nil, func(*models.OpenAIUsage) {})
+	StreamOpenAIChatPassthrough(w, body, "gpt-4", false, func(status int) { gotStatus = status }, nil, func(*models.OpenAIUsage) {})
 	if gotStatus != http.StatusTooManyRequests {
 		t.Fatalf("onError status = %d want 429 (classified)", gotStatus)
 	}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -9235,6 +9235,33 @@ func TestOpenAIResponsesStreaming_PreservesUpstreamHeaders(t *testing.T) {
 	}
 }
 
+func TestOpenAIChatCompletionsStreamingNotNormalized(t *testing.T) {
+	sseBody := "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\ndata: [DONE]\n\n"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); got != sseBody {
+		t.Fatalf("stream body changed:\n got: %q\nwant: %q", got, sseBody)
+	}
+	if strings.Contains(string(body), "chat.completion") {
+		t.Fatalf("streaming chunks should not be normalized by the non-streaming normalizer: %s", body)
+	}
+}
+
 // TestOpenAIChatCompletionsUpstreamErrorPassthrough validates that upstream error
 // responses are forwarded with correct status and content-type.
 func TestOpenAIChatCompletionsUpstreamErrorPassthrough(t *testing.T) {
@@ -9264,6 +9291,298 @@ func TestOpenAIChatCompletionsUpstreamErrorPassthrough(t *testing.T) {
 	}
 	if errResp["error"]["type"] != "invalid_request_error" {
 		t.Errorf("error.type = %v, want invalid_request_error", errResp["error"]["type"])
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesMissingTopLevelFields(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices": [{"message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+			"copilot_usage": {"prompt_tokens": 10}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var object string
+	if err := json.Unmarshal(raw["object"], &object); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if object != "chat.completion" {
+		t.Fatalf("object = %q, want chat.completion", object)
+	}
+
+	var created int64
+	if err := json.Unmarshal(raw["created"], &created); err != nil {
+		t.Fatalf("unmarshal created: %v", err)
+	}
+	if created == 0 {
+		t.Fatal("created = 0, want non-zero Unix seconds")
+	}
+
+	var id string
+	if err := json.Unmarshal(raw["id"], &id); err != nil {
+		t.Fatalf("unmarshal id: %v", err)
+	}
+	if !strings.HasPrefix(id, "chatcmpl-") {
+		t.Fatalf("id = %q, want chatcmpl- prefix", id)
+	}
+
+	var model string
+	if err := json.Unmarshal(raw["model"], &model); err != nil {
+		t.Fatalf("unmarshal model: %v", err)
+	}
+	if model != "gpt-5-mini" {
+		t.Fatalf("model = %q, want requested model", model)
+	}
+
+	if _, ok := raw["copilot_usage"]; !ok {
+		t.Fatal("copilot_usage was not preserved")
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesChoicesUsageAndPreservesVendorFields(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-upstream",
+			"model": "gpt-5-mini",
+			"choices": [
+				{"message": {}},
+				{"content": "provider content"},
+				{"content": {"type": "structured"}}
+			],
+			"usage": {"prompt_tokens": 4, "completion_tokens": 6, "reasoning_tokens": 2},
+			"prompt_filter_results": [{"prompt_index": 0}],
+			"content_filter_results": {"hate": {"filtered": false}}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-5-mini","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["choices"], &choices); err != nil {
+		t.Fatalf("unmarshal choices: %v", err)
+	}
+	if len(choices) != 3 {
+		t.Fatalf("choices length = %d, want 3", len(choices))
+	}
+	for i, choice := range choices {
+		var index int
+		if err := json.Unmarshal(choice["index"], &index); err != nil {
+			t.Fatalf("choice[%d] index: %v", i, err)
+		}
+		if index != i {
+			t.Fatalf("choice[%d].index = %d, want %d", i, index, i)
+		}
+		var finishReason string
+		if err := json.Unmarshal(choice["finish_reason"], &finishReason); err != nil {
+			t.Fatalf("choice[%d] finish_reason: %v", i, err)
+		}
+		if finishReason != "stop" {
+			t.Fatalf("choice[%d].finish_reason = %q, want stop", i, finishReason)
+		}
+	}
+
+	var msg0 map[string]json.RawMessage
+	if err := json.Unmarshal(choices[0]["message"], &msg0); err != nil {
+		t.Fatalf("choice[0] message: %v", err)
+	}
+	var role0 string
+	if err := json.Unmarshal(msg0["role"], &role0); err != nil {
+		t.Fatalf("choice[0] role: %v", err)
+	}
+	if role0 != "assistant" {
+		t.Fatalf("choice[0].message.role = %q, want assistant", role0)
+	}
+	var content0 string
+	if err := json.Unmarshal(msg0["content"], &content0); err != nil {
+		t.Fatalf("choice[0] content: %v", err)
+	}
+	if content0 != "" {
+		t.Fatalf("choice[0].message.content = %q, want empty string", content0)
+	}
+
+	var msg1 map[string]json.RawMessage
+	if err := json.Unmarshal(choices[1]["message"], &msg1); err != nil {
+		t.Fatalf("choice[1] message: %v", err)
+	}
+	var role1, content1 string
+	if err := json.Unmarshal(msg1["role"], &role1); err != nil {
+		t.Fatalf("choice[1] role: %v", err)
+	}
+	if err := json.Unmarshal(msg1["content"], &content1); err != nil {
+		t.Fatalf("choice[1] content: %v", err)
+	}
+	if role1 != "assistant" || content1 != "provider content" {
+		t.Fatalf("choice[1] message = role %q content %q, want assistant/provider content", role1, content1)
+	}
+
+	var msg2 map[string]json.RawMessage
+	if err := json.Unmarshal(choices[2]["message"], &msg2); err != nil {
+		t.Fatalf("choice[2] message: %v", err)
+	}
+	var content2 string
+	if err := json.Unmarshal(msg2["content"], &content2); err != nil {
+		t.Fatalf("choice[2] content: %v", err)
+	}
+	if content2 != "" {
+		t.Fatalf("choice[2].message.content = %q, want empty string for non-string provider content", content2)
+	}
+
+	var usage map[string]json.RawMessage
+	if err := json.Unmarshal(raw["usage"], &usage); err != nil {
+		t.Fatalf("unmarshal usage: %v", err)
+	}
+	wantUsage := map[string]int{"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10}
+	for key, want := range wantUsage {
+		var got int
+		if err := json.Unmarshal(usage[key], &got); err != nil {
+			t.Fatalf("usage[%s]: %v", key, err)
+		}
+		if got != want {
+			t.Fatalf("usage[%s] = %d, want %d", key, got, want)
+		}
+	}
+	if _, ok := usage["reasoning_tokens"]; !ok {
+		t.Fatal("usage.reasoning_tokens was not preserved")
+	}
+	if _, ok := raw["prompt_filter_results"]; !ok {
+		t.Fatal("prompt_filter_results was not preserved")
+	}
+	if _, ok := raw["content_filter_results"]; !ok {
+		t.Fatal("content_filter_results was not preserved")
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesSuccessful2xxResponses(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"created"}}]}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, body)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	var object string
+	if err := json.Unmarshal(raw["object"], &object); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if object != "chat.completion" {
+		t.Fatalf("object = %q, want chat.completion", object)
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesMissingUsage(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-usage",
+			"object": "chat.completion",
+			"created": 1700000000,
+			"model": "gpt-4",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}]
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	var usage map[string]int
+	if err := json.Unmarshal(raw["usage"], &usage); err != nil {
+		t.Fatalf("unmarshal usage: %v", err)
+	}
+	for _, key := range []string{"prompt_tokens", "completion_tokens", "total_tokens"} {
+		if got := usage[key]; got != 0 {
+			t.Fatalf("usage[%s] = %d, want 0", key, got)
+		}
+	}
+}
+
+func TestOpenAIChatCompletionsDoesNotNormalizeErrorResponses(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad request","type":"invalid_request_error"}}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := raw["object"]; ok {
+		t.Fatal("error response should not be normalized with object")
+	}
+	if _, ok := raw["created"]; ok {
+		t.Fatal("error response should not be normalized with created")
 	}
 }
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -9522,6 +9522,129 @@ func TestOpenAIChatCompletionsNormalizesMissingTopLevelFields(t *testing.T) {
 	}
 }
 
+func TestOpenAIChatCompletionsDoesNotNormalize2xxErrorPayload(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error":{"message":"provider failed","type":"server_error"}}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(w.Result().Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := raw["error"]; !ok {
+		t.Fatal("error payload was not preserved")
+	}
+	for _, key := range []string{"object", "id", "created", "choices", "usage"} {
+		if _, ok := raw[key]; ok {
+			t.Fatalf("2xx error payload should not be normalized with %q: %s", key, mustCompactRawForTest(raw))
+		}
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesProviderToolCallsIntoMessage(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-provider-tools",
+			"object":"chat.completion",
+			"created":1700000000,
+			"model":"gpt-4",
+			"choices":[{
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]
+			}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(w.Result().Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	choices := decodeChoicesForTest(t, raw["choices"])
+	var finishReason string
+	if err := json.Unmarshal(choices[0]["finish_reason"], &finishReason); err != nil {
+		t.Fatalf("decode finish_reason: %v", err)
+	}
+	if finishReason != "tool_calls" {
+		t.Fatalf("finish_reason = %q, want tool_calls", finishReason)
+	}
+	var message map[string]json.RawMessage
+	if err := json.Unmarshal(choices[0]["message"], &message); err != nil {
+		t.Fatalf("decode message: %v", err)
+	}
+	if _, ok := message["tool_calls"]; !ok {
+		t.Fatalf("message.tool_calls missing: %s", choices[0]["message"])
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesFinishReasonFromMessageToolCalls(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-message-tools",
+			"object":"chat.completion",
+			"created":1700000000,
+			"model":"gpt-4",
+			"choices":[{
+				"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]}
+			}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(w.Result().Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	choices := decodeChoicesForTest(t, raw["choices"])
+	var finishReason string
+	if err := json.Unmarshal(choices[0]["finish_reason"], &finishReason); err != nil {
+		t.Fatalf("decode finish_reason: %v", err)
+	}
+	if finishReason != "tool_calls" {
+		t.Fatalf("finish_reason = %q, want tool_calls", finishReason)
+	}
+}
+
+func decodeChoicesForTest(t testing.TB, raw json.RawMessage) []map[string]json.RawMessage {
+	t.Helper()
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &choices); err != nil {
+		t.Fatalf("decode choices: %v", err)
+	}
+	if len(choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	return choices
+}
+
+func mustCompactRawForTest(raw map[string]json.RawMessage) string {
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return "<invalid>"
+	}
+	return string(b)
+}
+
 func TestOpenAIChatCompletionsNormalizesEmptyObject(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -9325,6 +9325,75 @@ func TestOpenAIChatCompletionsStreamingNormalizesChunks(t *testing.T) {
 	}
 }
 
+func TestOpenAIChatCompletionsStreamingKeepsSyntheticIDStable(t *testing.T) {
+	sseBody := "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\ndata: {\"id\":\"chatcmpl-upstream\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\ndata: [DONE]\n\n"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	events := parseSSEEvents(w.Body.String())
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3; body=%s", len(events), w.Body.String())
+	}
+	var first, second map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(events[0].Data), &first); err != nil {
+		t.Fatalf("decode first chunk: %v", err)
+	}
+	if err := json.Unmarshal([]byte(events[1].Data), &second); err != nil {
+		t.Fatalf("decode second chunk: %v", err)
+	}
+	var firstID, secondID string
+	if err := json.Unmarshal(first["id"], &firstID); err != nil {
+		t.Fatalf("decode first id: %v", err)
+	}
+	if err := json.Unmarshal(second["id"], &secondID); err != nil {
+		t.Fatalf("decode second id: %v", err)
+	}
+	if firstID == "" || !strings.HasPrefix(firstID, "chatcmpl-") {
+		t.Fatalf("first id = %q, want synthetic chatcmpl- id", firstID)
+	}
+	if secondID != firstID {
+		t.Fatalf("second id = %q, want stable synthetic id %q", secondID, firstID)
+	}
+}
+
+func TestOpenAIChatCompletionsStreamingSynthesizesDeltaToolCalls(t *testing.T) {
+	sseBody := "data: {\"id\":\"chatcmpl-tools\",\"choices\":[{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{}\"}}]}]}\n\ndata: [DONE]\n\n"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	events := parseSSEEvents(w.Body.String())
+	var chunk map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(events[0].Data), &chunk); err != nil {
+		t.Fatalf("decode chunk: %v", err)
+	}
+	choices := decodeChoicesForTest(t, chunk["choices"])
+	var delta map[string]json.RawMessage
+	if err := json.Unmarshal(choices[0]["delta"], &delta); err != nil {
+		t.Fatalf("decode delta: %v", err)
+	}
+	if _, ok := delta["tool_calls"]; !ok {
+		t.Fatalf("delta.tool_calls missing: %s", choices[0]["delta"])
+	}
+}
+
 func TestOpenAIChatCompletionsStreamingNamedMessageEventNormalized(t *testing.T) {
 	sseBody := "event: message\ndata: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n"
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
@@ -9643,6 +9712,72 @@ func mustCompactRawForTest(raw map[string]json.RawMessage) string {
 		return "<invalid>"
 	}
 	return string(b)
+}
+
+func TestOpenAIChatCompletionsDoesNotTreatEmptyToolFieldsAsToolCalls(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-empty-tools",
+			"object":"chat.completion",
+			"created":1700000000,
+			"model":"gpt-4",
+			"choices":[{"message":{"role":"assistant","content":"done","tool_calls":[]}}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(w.Result().Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	choices := decodeChoicesForTest(t, raw["choices"])
+	var finishReason string
+	if err := json.Unmarshal(choices[0]["finish_reason"], &finishReason); err != nil {
+		t.Fatalf("decode finish_reason: %v", err)
+	}
+	if finishReason != "stop" {
+		t.Fatalf("finish_reason = %q, want stop for empty tool_calls", finishReason)
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesBlankFinishReason(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-blank-finish",
+			"object":"chat.completion",
+			"created":1700000000,
+			"model":"gpt-4",
+			"choices":[{"index":0,"finish_reason":"","message":{"role":"assistant","content":"done"}}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(w.Result().Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	choices := decodeChoicesForTest(t, raw["choices"])
+	var finishReason string
+	if err := json.Unmarshal(choices[0]["finish_reason"], &finishReason); err != nil {
+		t.Fatalf("decode finish_reason: %v", err)
+	}
+	if finishReason != "stop" {
+		t.Fatalf("finish_reason = %q, want stop", finishReason)
+	}
 }
 
 func TestOpenAIChatCompletionsNormalizesEmptyObject(t *testing.T) {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -9098,7 +9098,7 @@ func TestOpenAIErrorResponseShape(t *testing.T) {
 }
 
 // TestOpenAIChatCompletionsStreaming validates that streaming responses are
-// passed through correctly with proper SSE headers.
+// forwarded with proper SSE headers.
 func TestOpenAIChatCompletionsStreaming(t *testing.T) {
 	sseBody := "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\ndata: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\ndata: [DONE]\n\n"
 
@@ -9138,7 +9138,7 @@ func TestOpenAIChatCompletionsStreaming(t *testing.T) {
 		t.Errorf("Content-Type = %q, want text/event-stream", ct)
 	}
 
-	// Verify SSE body is passed through
+	// Verify SSE body is forwarded
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)
 	if !strings.Contains(bodyStr, "data: {") {
@@ -9151,7 +9151,7 @@ func TestOpenAIChatCompletionsStreaming(t *testing.T) {
 
 // TestOpenAIResponsesStreaming validates streaming passthrough for the Responses API.
 func TestOpenAIResponsesStreaming(t *testing.T) {
-	sseBody := "event: response.created\ndata: {\"id\":\"resp-1\",\"type\":\"response\"}\n\nevent: response.completed\ndata: {\"id\":\"resp-1\",\"status\":\"completed\"}\n\n"
+	sseBody := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"object\":\"response\",\"created_at\":1700000000,\"status\":\"in_progress\"}}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"object\":\"response\",\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}\n\n"
 
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {
@@ -9195,8 +9195,28 @@ func TestOpenAIResponsesStreaming(t *testing.T) {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "response.created") {
-		t.Error("streaming response should contain event data")
+	if got := string(body); got != sseBody {
+		t.Fatalf("Responses stream should be preserved exactly:\n got: %q\nwant: %q", got, sseBody)
+	}
+	events := parseSSEEvents(string(body))
+	if len(events) != 2 {
+		t.Fatalf("Responses stream events = %d, want 2", len(events))
+	}
+	if events[0].Event != "response.created" || events[1].Event != "response.completed" {
+		t.Fatalf("Responses event types = %q/%q, want response.created/response.completed", events[0].Event, events[1].Event)
+	}
+	var createdEvent struct {
+		Type     string `json:"type"`
+		Response struct {
+			ID     string `json:"id"`
+			Object string `json:"object"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(events[0].Data), &createdEvent); err != nil {
+		t.Fatalf("unmarshal response.created event: %v", err)
+	}
+	if createdEvent.Type != "response.created" || createdEvent.Response.ID != "resp-1" || createdEvent.Response.Object != "response" {
+		t.Fatalf("unexpected response.created payload: %+v", createdEvent)
 	}
 }
 
@@ -9235,8 +9255,8 @@ func TestOpenAIResponsesStreaming_PreservesUpstreamHeaders(t *testing.T) {
 	}
 }
 
-func TestOpenAIChatCompletionsStreamingNotNormalized(t *testing.T) {
-	sseBody := "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\ndata: [DONE]\n\n"
+func TestOpenAIChatCompletionsStreamingNormalizesChunks(t *testing.T) {
+	sseBody := "data: {\"id\":\"chatcmpl-stream\",\"object\":\"\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n"
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -9254,11 +9274,155 @@ func TestOpenAIChatCompletionsStreamingNotNormalized(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if got := string(body); got != sseBody {
-		t.Fatalf("stream body changed:\n got: %q\nwant: %q", got, sseBody)
+	events := parseSSEEvents(string(body))
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2; body=%s", len(events), body)
 	}
-	if strings.Contains(string(body), "chat.completion") {
-		t.Fatalf("streaming chunks should not be normalized by the non-streaming normalizer: %s", body)
+	var chunk map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(events[0].Data), &chunk); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+	var object string
+	if err := json.Unmarshal(chunk["object"], &object); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if object != "chat.completion.chunk" {
+		t.Fatalf("object = %q, want chat.completion.chunk", object)
+	}
+	var created int64
+	if err := json.Unmarshal(chunk["created"], &created); err != nil {
+		t.Fatalf("unmarshal created: %v", err)
+	}
+	if created == 0 {
+		t.Fatal("created = 0, want non-zero Unix seconds")
+	}
+	var model string
+	if err := json.Unmarshal(chunk["model"], &model); err != nil {
+		t.Fatalf("unmarshal model: %v", err)
+	}
+	if model != "gpt-4" {
+		t.Fatalf("model = %q, want requested model", model)
+	}
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(chunk["choices"], &choices); err != nil {
+		t.Fatalf("unmarshal choices: %v", err)
+	}
+	if len(choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(choices))
+	}
+	var index int
+	if err := json.Unmarshal(choices[0]["index"], &index); err != nil {
+		t.Fatalf("unmarshal choice index: %v", err)
+	}
+	if index != 0 {
+		t.Fatalf("choice index = %d, want 0", index)
+	}
+	if _, ok := choices[0]["delta"]; !ok {
+		t.Fatal("choice delta missing")
+	}
+	if events[1].Data != "[DONE]" {
+		t.Fatalf("terminal event = %q, want [DONE]", events[1].Data)
+	}
+}
+
+func TestOpenAIChatCompletionsStreamingNamedMessageEventNormalized(t *testing.T) {
+	sseBody := "event: message\ndata: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	events := parseSSEEvents(string(body))
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2; body=%s", len(events), body)
+	}
+	if events[0].Event != "message" {
+		t.Fatalf("event type = %q, want message", events[0].Event)
+	}
+	var chunk map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(events[0].Data), &chunk); err != nil {
+		t.Fatalf("unmarshal named message chunk: %v", err)
+	}
+	var object string
+	if err := json.Unmarshal(chunk["object"], &object); err != nil {
+		t.Fatalf("unmarshal chunk object: %v", err)
+	}
+	if object != "chat.completion.chunk" {
+		t.Fatalf("named message chunk object = %q, want chat.completion.chunk", object)
+	}
+}
+
+func TestOpenAIChatCompletionsStreamingSidebandEventNotNormalized(t *testing.T) {
+	sseBody := "event: ping\ndata: {\"time\":1700000000}\n\ndata: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\ndata: [DONE]\n\n"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	events := parseSSEEvents(string(body))
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3; body=%s", len(events), body)
+	}
+	if events[0].Event != "ping" || events[0].Data != `{"time":1700000000}` {
+		t.Fatalf("sideband event changed: %+v", events[0])
+	}
+	if strings.Contains(events[0].Data, "chat.completion.chunk") {
+		t.Fatalf("sideband event was normalized as a chat chunk: %s", events[0].Data)
+	}
+	var chunk map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(events[1].Data), &chunk); err != nil {
+		t.Fatalf("unmarshal normalized chat chunk: %v", err)
+	}
+	var object string
+	if err := json.Unmarshal(chunk["object"], &object); err != nil {
+		t.Fatalf("unmarshal chunk object: %v", err)
+	}
+	if object != "chat.completion.chunk" {
+		t.Fatalf("chat chunk object = %q, want chat.completion.chunk", object)
+	}
+}
+
+func TestOpenAIChatCompletionsStreamingErrorEventNotNormalized(t *testing.T) {
+	sseBody := "event: error\ndata: {\"error\":{\"message\":\"rate limit\",\"type\":\"rate_limit_error\"}}\n\n"
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected committed stream status 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); got != sseBody {
+		t.Fatalf("stream error event changed:\n got: %q\nwant: %q", got, sseBody)
 	}
 }
 
@@ -9355,6 +9519,38 @@ func TestOpenAIChatCompletionsNormalizesMissingTopLevelFields(t *testing.T) {
 
 	if _, ok := raw["copilot_usage"]; !ok {
 		t.Fatal("copilot_usage was not preserved")
+	}
+}
+
+func TestOpenAIChatCompletionsNormalizesEmptyObject(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-empty-object",
+			"object": "",
+			"created": 1700000000,
+			"model": "gpt-4",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+		}`))
+	})
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.HandleOpenAIChatCompletions(w, req)
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(w.Result().Body).Decode(&raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	var object string
+	if err := json.Unmarshal(raw["object"], &object); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if object != "chat.completion" {
+		t.Fatalf("object = %q, want chat.completion", object)
 	}
 }
 
@@ -9731,7 +9927,7 @@ func TestOpenAIResponsesResponseShape(t *testing.T) {
 	}
 
 	// Verify key Responses API fields are preserved in passthrough
-	for _, f := range []string{"id", "object", "status", "model", "output", "usage"} {
+	for _, f := range []string{"id", "object", "created_at", "status", "model", "output", "usage"} {
 		if _, ok := raw[f]; !ok {
 			t.Errorf("response missing field %q", f)
 		}

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -96,7 +96,7 @@ func StreamOpenAIPassthroughWithFinalResponse(
 	onFinalResponse func(*models.OpenAIResponse),
 	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
-	streamOpenAIPassthrough(w, body, false, nil, onFinalResponse, onUsageCallbacks...)
+	streamOpenAIPassthrough(w, body, false, nil, onFinalResponse, nil, onUsageCallbacks...)
 }
 
 // StreamOpenAIPassthroughDroppingInjectedUsage behaves like
@@ -112,7 +112,7 @@ func StreamOpenAIPassthroughDroppingInjectedUsage(
 	onFinalResponse func(*models.OpenAIResponse),
 	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
-	streamOpenAIPassthrough(w, body, true, nil, onFinalResponse, onUsageCallbacks...)
+	streamOpenAIPassthrough(w, body, true, nil, onFinalResponse, nil, onUsageCallbacks...)
 }
 
 // StreamOpenAIChatPassthrough forwards an OpenAI chat SSE stream to the client
@@ -128,12 +128,13 @@ func StreamOpenAIPassthroughDroppingInjectedUsage(
 func StreamOpenAIChatPassthrough(
 	w http.ResponseWriter,
 	body io.ReadCloser,
+	requestedModel string,
 	dropInjectedUsage bool,
 	onError func(status int),
 	onFinalResponse func(*models.OpenAIResponse),
 	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
-	streamOpenAIPassthrough(w, body, dropInjectedUsage, onError, onFinalResponse, onUsageCallbacks...)
+	streamOpenAIPassthrough(w, body, dropInjectedUsage, onError, onFinalResponse, newOpenAIChatCompletionChunkNormalizer(requestedModel).normalize, onUsageCallbacks...)
 }
 
 // streamOpenAIPassthrough forwards an upstream OpenAI SSE stream to the client.
@@ -144,12 +145,15 @@ func StreamOpenAIChatPassthrough(
 // dropInjectedUsage path decide whether to emit an event after parsing it: when
 // set, a usage-only chunk (empty choices + usage) is fed to the usage/final
 // callbacks but not written to the client.
+type openAIStreamDataTransformer func(eventType, data string) (string, bool)
+
 func streamOpenAIPassthrough(
 	w http.ResponseWriter,
 	body io.ReadCloser,
 	dropInjectedUsage bool,
 	onError func(status int),
 	onFinalResponse func(*models.OpenAIResponse),
+	transformData openAIStreamDataTransformer,
 	onUsageCallbacks ...func(*models.OpenAIUsage),
 ) {
 	defer func() { _ = body.Close() }()
@@ -167,7 +171,7 @@ func streamOpenAIPassthrough(
 	}
 
 	onUsage := firstOpenAIUsageCallback(onUsageCallbacks)
-	if onFinalResponse == nil && onUsage == nil && onError == nil {
+	if onFinalResponse == nil && onUsage == nil && onError == nil && transformData == nil {
 		_, _ = io.Copy(&flushWriter{w: w, flusher: flusher}, body)
 		return
 	}
@@ -183,6 +187,7 @@ func streamOpenAIPassthrough(
 	errorReported := false
 	var accumulator sseDataAccumulator
 	pending := make([]string, 0, 4)
+	var transformedCurrentData *string
 	processData := func(eventType string, data string) bool {
 		if data == "[DONE]" {
 			sawDone = true
@@ -197,6 +202,13 @@ func streamOpenAIPassthrough(
 			if streamErr, isErr := parseOpenAIStreamError(eventType, data); isErr {
 				onError(streamErr.httpStatus())
 				errorReported = true
+			}
+		}
+
+		if transformData != nil {
+			if transformed, changed := transformData(eventType, data); changed {
+				data = transformed
+				transformedCurrentData = &data
 			}
 		}
 
@@ -222,13 +234,20 @@ func streamOpenAIPassthrough(
 		defer func() {
 			pending = pending[:0]
 			dropCurrent = false
+			transformedCurrentData = nil
 		}()
 		if dropCurrent {
 			return true
 		}
-		for _, l := range pending {
-			if _, err := io.WriteString(w, l); err != nil {
+		if transformedCurrentData != nil {
+			if !writeTransformedSSEEvent(w, pending, *transformedCurrentData) {
 				return false
+			}
+		} else {
+			for _, l := range pending {
+				if _, err := io.WriteString(w, l); err != nil {
+					return false
+				}
 			}
 		}
 		if flusher != nil {
@@ -255,6 +274,7 @@ func streamOpenAIPassthrough(
 			pending = pending[:0]
 			accumulator = sseDataAccumulator{}
 			dropCurrent = false
+			transformedCurrentData = nil
 			if _, werr := io.WriteString(w, line); werr != nil {
 				return
 			}
@@ -276,6 +296,7 @@ func streamOpenAIPassthrough(
 					rawForwardOversizedEvent = false
 					accumulator = sseDataAccumulator{}
 					dropCurrent = false
+					transformedCurrentData = nil
 				}
 			} else {
 				pending = append(pending, line)
@@ -317,6 +338,41 @@ func streamOpenAIPassthrough(
 		return
 	}
 	onFinalResponse(aggregator.buildResponse())
+}
+
+func writeTransformedSSEEvent(w http.ResponseWriter, pending []string, data string) bool {
+	insertedData := false
+	writeData := func(ending string) bool {
+		if ending == "" {
+			ending = "\n"
+		}
+		for _, line := range strings.Split(data, "\n") {
+			if _, err := fmt.Fprintf(w, "data: %s%s", line, ending); err != nil {
+				return false
+			}
+		}
+		insertedData = true
+		return true
+	}
+
+	for _, line := range pending {
+		content, ending := splitSSELineEnding(line)
+		if _, ok := parseSSELine(content); ok {
+			if !insertedData && !writeData(ending) {
+				return false
+			}
+			continue
+		}
+		if strings.TrimSpace(content) == "" && !insertedData {
+			if !writeData(ending) {
+				return false
+			}
+		}
+		if _, err := io.WriteString(w, line); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func firstOpenAIUsageCallback(callbacks []func(*models.OpenAIUsage)) func(*models.OpenAIUsage) {

--- a/proxy/tool_optimizer_chat.go
+++ b/proxy/tool_optimizer_chat.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sozercan/vekil/logger"
 	"github.com/sozercan/vekil/models"
@@ -305,9 +306,9 @@ func (h *ProxyHandler) rewriteOpenAIChatRequestBodyWithToolOptimizers(ctx contex
 	return rewritten
 }
 
-func (h *ProxyHandler) maybeWriteOptimizedOpenAIChatPassthrough(ctx context.Context, w http.ResponseWriter, resp *http.Response, store *ToolExecutionContextStore, scope string) error {
+func (h *ProxyHandler) maybeWriteOptimizedOpenAIChatPassthrough(ctx context.Context, w http.ResponseWriter, resp *http.Response, requestedModel string, store *ToolExecutionContextStore, scope string) error {
 	if h == nil || h.toolOptimizers == nil || !h.toolOptimizers.ShouldInspectNonStreamingResponses() || resp == nil || resp.Body == nil || resp.StatusCode != http.StatusOK {
-		h.writeOpenAIPassthroughObservingUsage(ctx, w, resp)
+		h.writeOpenAIChatCompletionResponse(ctx, w, resp, requestedModel)
 		return nil
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -320,9 +321,19 @@ func (h *ProxyHandler) maybeWriteOptimizedOpenAIChatPassthrough(ctx context.Cont
 		return nil
 	}
 
+	normalizedBody, normalized, normalizeErr := normalizeOpenAIChatCompletionResponse(bodyBytes, requestedModel, time.Now())
+	if normalizeErr == nil {
+		bodyBytes = normalizedBody
+	}
+
 	var parsed models.OpenAIResponse
 	if err := json.Unmarshal(bodyBytes, &parsed); err != nil {
+		observeOpenAIUsage(ctx, sniffOpenAIUsage(bodyBytes))
 		copyPassthroughHeaders(w.Header(), resp.Header)
+		if normalized {
+			w.Header().Del("Content-Length")
+			w.Header().Set("Content-Length", strconv.Itoa(len(bodyBytes)))
+		}
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write(bodyBytes)
 		return nil
@@ -340,7 +351,7 @@ func (h *ProxyHandler) maybeWriteOptimizedOpenAIChatPassthrough(ctx context.Cont
 	}
 
 	copyPassthroughHeaders(w.Header(), resp.Header)
-	if changedCount > 0 {
+	if normalized || changedCount > 0 {
 		w.Header().Del("Content-Length")
 		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
 	}

--- a/proxy/tool_optimizer_upstream_http.go
+++ b/proxy/tool_optimizer_upstream_http.go
@@ -38,7 +38,7 @@ func (h *ProxyHandler) writeResponsesUpstreamResponse(ctx context.Context, w htt
 // body to the client byte-for-byte while sniffing usage tokens for traffic
 // stats. It preserves the near-zero-copy contract: on a 200 it reads the body
 // to parse usage and writes the same bytes back unchanged (headers and
-// Content-Length untouched); any non-200 or read failure falls back to a plain
+// Content-Length untouched); any non-2xx or read failure falls back to a plain
 // streamed copy. Memory is bounded via usageSniffMaxBuffer: an oversized body
 // streams through with the usage parse skipped rather than being buffered whole.
 // ctx must be the inbound request context so the usage lands on the right
@@ -48,7 +48,8 @@ func writeResponsesPassthroughObservingUsage(ctx context.Context, w http.Respons
 		writeUpstreamResponse(w, resp)
 		return
 	}
-	writePassthroughSniffingUsage(w, resp, func(body []byte) {
+	writePassthroughSniffingUsage(w, resp, func(body []byte) ([]byte, bool) {
 		observeResponsesUsage(ctx, sniffResponsesUsageBody(body))
+		return body, false
 	})
 }

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sozercan/vekil/models"
 )
@@ -269,17 +271,27 @@ func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) {
 	_, _ = io.Copy(w, resp.Body)
 }
 
-// writeOpenAIPassthroughObservingUsage writes a non-streaming OpenAI chat
-// response to the client byte-for-byte while sniffing usage tokens for traffic
-// stats. It preserves the near-zero-copy contract: the original body bytes and
-// headers (including Content-Length) are sent unchanged; only a best-effort
-// usage parse is layered on top, and any parse failure is silently ignored.
-// Memory is bounded: bodies larger than usageSniffMaxBuffer stream through
-// without a usage parse rather than being buffered whole (see
-// writePassthroughSniffingUsage).
+// writeOpenAIChatCompletionResponse writes a non-streaming OpenAI chat response,
+// normalizing missing required Chat Completions fields for strict SDK clients
+// while preserving vendor-specific fields. It only rewrites successful JSON
+// responses that fit in usageSniffMaxBuffer; errors, invalid JSON, and oversized
+// responses fail open to passthrough behavior.
+func (h *ProxyHandler) writeOpenAIChatCompletionResponse(ctx context.Context, w http.ResponseWriter, resp *http.Response, requestedModel string) {
+	writePassthroughSniffingUsage(w, resp, func(body []byte) ([]byte, bool) {
+		out, changed, err := normalizeOpenAIChatCompletionResponse(body, requestedModel, time.Now())
+		if err != nil {
+			observeOpenAIUsage(ctx, sniffOpenAIUsage(body))
+			return body, false
+		}
+		observeOpenAIUsage(ctx, sniffOpenAIUsage(out))
+		return out, changed
+	})
+}
+
 func (h *ProxyHandler) writeOpenAIPassthroughObservingUsage(ctx context.Context, w http.ResponseWriter, resp *http.Response) {
-	writePassthroughSniffingUsage(w, resp, func(body []byte) {
+	writePassthroughSniffingUsage(w, resp, func(body []byte) ([]byte, bool) {
 		observeOpenAIUsage(ctx, sniffOpenAIUsage(body))
+		return body, false
 	})
 }
 
@@ -292,17 +304,16 @@ func (h *ProxyHandler) writeOpenAIPassthroughObservingUsage(ctx context.Context,
 const usageSniffMaxBuffer = 4 << 20 // 4 MiB
 
 // writePassthroughSniffingUsage writes a non-streaming upstream response to the
-// client while buffering at most usageSniffMaxBuffer bytes to sniff usage via
-// the supplied parse callback. A body that fits the cap is buffered, parsed, and
-// written back byte-for-byte (headers, including Content-Length, untouched). A
-// body that exceeds the cap is not buffered whole: the bounded prefix is written
-// and the remainder is streamed through with io.Copy, so proxy memory stays
-// bounded at the cost of skipping usage stats for that one oversized response
-// (fail-open). Non-200 responses and read errors fall back to a plain copy.
-func writePassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, sniff func([]byte)) {
+// client while buffering at most usageSniffMaxBuffer bytes so the supplied
+// transform can sniff usage and optionally rewrite the complete body. A 2xx body
+// that fits the cap is buffered and passed to transform; if transform reports a
+// rewrite, Content-Length is adjusted. Oversized bodies stream through without a
+// transform so proxy memory stays bounded. Non-2xx responses and read errors
+// fall back to a plain copy.
+func writePassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, transform func([]byte) ([]byte, bool)) {
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		copyPassthroughHeaders(w.Header(), resp.Header)
 		w.WriteHeader(resp.StatusCode)
 		_, _ = io.Copy(w, resp.Body)
@@ -319,10 +330,18 @@ func writePassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, s
 	}
 
 	if len(prefix) <= usageSniffMaxBuffer {
-		// Whole body fits: parse usage, then write the same bytes unchanged.
-		sniff(prefix)
+		// Whole body fits: parse/transform it, then write the result.
+		out := prefix
+		changed := false
+		if transform != nil {
+			out, changed = transform(prefix)
+		}
+		if changed {
+			w.Header().Del("Content-Length")
+			w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+		}
 		w.WriteHeader(resp.StatusCode)
-		_, _ = w.Write(prefix)
+		_, _ = w.Write(out)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Normalize successful `/v1/chat/completions` responses to strict OpenAI Chat Completions shape for non-streaming responses and streaming chat chunks.
- Fill missing required top-level/chunk envelope fields, choice fields, and usage fields while preserving provider/vendor metadata.
- Keep non-2xx errors, streaming error events, side-band SSE events, and Responses passthrough payloads unchanged.
- Add Responses contract coverage without introducing broad Responses normalization.

## Root cause
Some upstream chat completion responses omitted required OpenAI-compatible fields such as `object: "chat.completion"`, causing strict OpenAI SDK/pydantic-ai clients to reject otherwise successful responses.

## Validation
- `go test ./proxy -run 'TestOpenAIChatCompletionsStreaming|TestOpenAIChatCompletionsNormalizes|TestOpenAIResponsesStreaming|TestOpenAIResponsesResponseShape|TestOpenAIChatCompletionsDoesNotNormalizeErrorResponses' -count=1`
- `make test`
- `make vet`
- `make build`
- autoreview clean: no accepted/actionable findings reported
