### PR TITLE
feat(docker): add RTK image variant

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,5 +106,5 @@ jobs:
       - name: Docker build RTK variant
         run: make docker-build-rtk
 
-      - name: Verify RTK variant
-        run: docker run --rm --entrypoint /usr/local/bin/rtk vekil:rtk --version | grep -E '^rtk '
+      - name: Verify RTK variant reduces tool output
+        run: make docker-rtk-e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,3 +102,9 @@ jobs:
 
       - name: Docker build
         run: make docker-build
+
+      - name: Docker build RTK variant
+        run: make docker-build-rtk
+
+      - name: Verify RTK variant
+        run: docker run --rm --entrypoint /usr/local/bin/rtk vekil:rtk --version | grep -E '^rtk '

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,11 +111,23 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
+          target: runtime
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}
             ghcr.io/${{ github.repository }}:latest
+
+      - name: Build and push RTK variant
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          target: runtime-rtk
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}-rtk
+            ghcr.io/${{ github.repository }}:latest-rtk
 
   finalize-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,6 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
-          target: runtime
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
@@ -122,7 +121,7 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
-          target: runtime-rtk
+          file: Dockerfile.rtk
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/.github/workflows/update-rtk.yaml
+++ b/.github/workflows/update-rtk.yaml
@@ -62,7 +62,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "${branch}"
-          git add Dockerfile
+          git add Dockerfile.rtk
           git commit -s -m "${title}"
           git push --force origin "${branch}"
 

--- a/.github/workflows/update-rtk.yaml
+++ b/.github/workflows/update-rtk.yaml
@@ -1,0 +1,74 @@
+name: Update RTK
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "27 9 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-rtk
+  cancel-in-progress: true
+
+jobs:
+  update-rtk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check latest RTK release
+        id: rtk
+        run: scripts/update-rtk-version.sh
+
+      - name: Stop when already current
+        if: ${{ steps.rtk.outputs.changed != 'true' }}
+        run: echo "RTK is already current at ${{ steps.rtk.outputs['current-version'] }}."
+
+      - name: Build RTK variant
+        if: ${{ steps.rtk.outputs.changed == 'true' }}
+        run: make docker-build-rtk
+
+      - name: Verify RTK variant reduces tool output
+        if: ${{ steps.rtk.outputs.changed == 'true' }}
+        run: make docker-rtk-e2e
+
+      - name: Open RTK update pull request
+        if: ${{ steps.rtk.outputs.changed == 'true' }}
+        env:
+          RTK_VERSION: ${{ steps.rtk.outputs['latest-version'] }}
+        run: |
+          set -euo pipefail
+
+          branch="deps/update-rtk-${RTK_VERSION}"
+          title="chore(deps): update RTK to ${RTK_VERSION}"
+          body_file="$(mktemp)"
+
+          cat > "${body_file}" <<EOF_BODY
+          ## Summary
+          - update bundled RTK in the optional Docker image variant to ${RTK_VERSION}
+
+          ## Validation
+          - \`make docker-build-rtk\`
+          - \`make docker-rtk-e2e\`
+          EOF_BODY
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "${branch}"
+          git add Dockerfile
+          git commit -s -m "${title}"
+          git push --force origin "${branch}"
+
+          pr_number="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // ""')"
+          if [[ -n "${pr_number}" ]]; then
+            gh pr edit "${pr_number}" --title "${title}" --body-file "${body_file}"
+          else
+            gh pr create --base main --head "${branch}" --title "${title}" --body-file "${body_file}"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,40 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /vekil .
 
-# Optional RTK downloader used only by the runtime-rtk target.
-FROM debian:trixie-slim AS rtk-downloader
-ARG RTK_VERSION=0.43.0
-ARG TARGETARCH
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl tar \
-    && rm -rf /var/lib/apt/lists/*
-RUN set -eux; \
-    arch="${TARGETARCH:-$(uname -m)}"; \
-    case "${arch}" in \
-        amd64|x86_64) target="x86_64-unknown-linux-musl" ;; \
-        arm64|aarch64) target="aarch64-unknown-linux-gnu" ;; \
-        *) echo "unsupported RTK target architecture: ${arch}" >&2; exit 1 ;; \
-    esac; \
-    version="${RTK_VERSION#v}"; \
-    archive="rtk-${target}.tar.gz"; \
-    base_url="https://github.com/rtk-ai/rtk/releases/download/v${version}"; \
-    curl -fsSLo "/tmp/${archive}" "${base_url}/${archive}"; \
-    curl -fsSLo /tmp/checksums.txt "${base_url}/checksums.txt"; \
-    checksum="$(grep "  ${archive}$" /tmp/checksums.txt)"; \
-    printf '%s\n' "${checksum}" | (cd /tmp && sha256sum -c -); \
-    tar -xzf "/tmp/${archive}" -C /usr/local/bin rtk; \
-    chmod 0755 /usr/local/bin/rtk; \
-    /usr/local/bin/rtk --version
-
-FROM gcr.io/distroless/cc-debian13:nonroot AS runtime-rtk
-COPY --from=builder /vekil /vekil
-COPY --from=rtk-downloader /usr/local/bin/rtk /usr/local/bin/rtk
-ENV HOST=0.0.0.0
-EXPOSE 1337
-ENTRYPOINT ["/vekil"]
-
-# Keep the minimal runtime as the final stage so `docker build .` stays unchanged.
-FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /vekil /vekil
 ENV HOST=0.0.0.0
 EXPOSE 1337

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,40 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /vekil .
 
-FROM gcr.io/distroless/static-debian12:nonroot
+# Optional RTK downloader used only by the runtime-rtk target.
+FROM debian:trixie-slim AS rtk-downloader
+ARG RTK_VERSION=0.43.0
+ARG TARGETARCH
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl tar \
+    && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    arch="${TARGETARCH:-$(uname -m)}"; \
+    case "${arch}" in \
+        amd64|x86_64) target="x86_64-unknown-linux-musl" ;; \
+        arm64|aarch64) target="aarch64-unknown-linux-gnu" ;; \
+        *) echo "unsupported RTK target architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    version="${RTK_VERSION#v}"; \
+    archive="rtk-${target}.tar.gz"; \
+    base_url="https://github.com/rtk-ai/rtk/releases/download/v${version}"; \
+    curl -fsSLo "/tmp/${archive}" "${base_url}/${archive}"; \
+    curl -fsSLo /tmp/checksums.txt "${base_url}/checksums.txt"; \
+    checksum="$(grep "  ${archive}$" /tmp/checksums.txt)"; \
+    printf '%s\n' "${checksum}" | (cd /tmp && sha256sum -c -); \
+    tar -xzf "/tmp/${archive}" -C /usr/local/bin rtk; \
+    chmod 0755 /usr/local/bin/rtk; \
+    /usr/local/bin/rtk --version
+
+FROM gcr.io/distroless/cc-debian13:nonroot AS runtime-rtk
+COPY --from=builder /vekil /vekil
+COPY --from=rtk-downloader /usr/local/bin/rtk /usr/local/bin/rtk
+ENV HOST=0.0.0.0
+EXPOSE 1337
+ENTRYPOINT ["/vekil"]
+
+# Keep the minimal runtime as the final stage so `docker build .` stays unchanged.
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
 COPY --from=builder /vekil /vekil
 ENV HOST=0.0.0.0
 EXPOSE 1337

--- a/Dockerfile.rtk
+++ b/Dockerfile.rtk
@@ -1,0 +1,38 @@
+FROM golang:1.26 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /vekil .
+
+FROM debian:trixie-slim AS rtk-downloader
+ARG RTK_VERSION=0.43.0
+ARG TARGETARCH
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl tar \
+    && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    arch="${TARGETARCH:-$(uname -m)}"; \
+    case "${arch}" in \
+        amd64|x86_64) target="x86_64-unknown-linux-musl" ;; \
+        arm64|aarch64) target="aarch64-unknown-linux-gnu" ;; \
+        *) echo "unsupported RTK target architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    version="${RTK_VERSION#v}"; \
+    archive="rtk-${target}.tar.gz"; \
+    base_url="https://github.com/rtk-ai/rtk/releases/download/v${version}"; \
+    curl -fsSLo "/tmp/${archive}" "${base_url}/${archive}"; \
+    curl -fsSLo /tmp/checksums.txt "${base_url}/checksums.txt"; \
+    checksum="$(grep "  ${archive}$" /tmp/checksums.txt)"; \
+    printf '%s\n' "${checksum}" | (cd /tmp && sha256sum -c -); \
+    tar -xzf "/tmp/${archive}" -C /usr/local/bin rtk; \
+    chmod 0755 /usr/local/bin/rtk; \
+    /usr/local/bin/rtk --version
+
+FROM gcr.io/distroless/cc-debian13:nonroot
+COPY --from=builder /vekil /vekil
+COPY --from=rtk-downloader /usr/local/bin/rtk /usr/local/bin/rtk
+ENV HOST=0.0.0.0
+EXPOSE 1337
+ENTRYPOINT ["/vekil"]

--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,10 @@ clean:
 	rm -rf "$(APP_NAME)" .build
 
 docker-build:
-	docker build --target runtime -t $(BINARY) .
+	docker build -t $(BINARY) .
 
 docker-build-rtk:
-	docker build --target runtime-rtk -t $(BINARY):rtk .
+	docker build -f Dockerfile.rtk -t $(BINARY):rtk .
 
 docker-rtk-e2e:
 	scripts/rtk-container-e2e.sh

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SPARKLE_DOWNLOAD_URL := https://github.com/sparkle-project/Sparkle/releases/down
 SPARKLE_FEED_URL ?= https://github.com/sozercan/vekil/releases/latest/download/appcast.xml
 SPARKLE_PUBLIC_ED_KEY ?=
 
-.PHONY: build build-app build-tray-linux test-app test compaction-lab vet lint clean docker-build docker-build-rtk
+.PHONY: build build-app build-tray-linux test-app test compaction-lab vet lint clean docker-build docker-build-rtk docker-rtk-e2e
 
 build:
 	go build -ldflags="$(LDFLAGS)" -o $(BINARY) .
@@ -116,3 +116,6 @@ docker-build:
 
 docker-build-rtk:
 	docker build --target runtime-rtk -t $(BINARY):rtk .
+
+docker-rtk-e2e:
+	scripts/rtk-container-e2e.sh

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SPARKLE_DOWNLOAD_URL := https://github.com/sparkle-project/Sparkle/releases/down
 SPARKLE_FEED_URL ?= https://github.com/sozercan/vekil/releases/latest/download/appcast.xml
 SPARKLE_PUBLIC_ED_KEY ?=
 
-.PHONY: build build-app build-tray-linux test-app test compaction-lab vet lint clean docker-build
+.PHONY: build build-app build-tray-linux test-app test compaction-lab vet lint clean docker-build docker-build-rtk
 
 build:
 	go build -ldflags="$(LDFLAGS)" -o $(BINARY) .
@@ -112,4 +112,7 @@ clean:
 	rm -rf "$(APP_NAME)" .build
 
 docker-build:
-	docker build -t $(BINARY) .
+	docker build --target runtime -t $(BINARY) .
+
+docker-build-rtk:
+	docker build --target runtime-rtk -t $(BINARY):rtk .

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@ go build -o vekil .
 make build-app
 make docker-build
 make docker-build-rtk   # optional RTK image variant
+make docker-rtk-e2e     # verifies bundled RTK reduces tool output through Vekil
 ```
 
 `go test ./...` and ordinary Go builds do not require Sparkle. The updater code is only compiled for the packaged macOS app build via `make build-app`, which downloads Sparkle 2.9.0 into `.build/sparkle/`, passes the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,6 +6,7 @@
 go build -o vekil .
 make build-app
 make docker-build
+make docker-build-rtk   # optional RTK image variant
 ```
 
 `go test ./...` and ordinary Go builds do not require Sparkle. The updater code is only compiled for the packaged macOS app build via `make build-app`, which downloads Sparkle 2.9.0 into `.build/sparkle/`, passes the `sparkle` build tag, embeds `Sparkle.framework`, and ad-hoc signs the finished app bundle.
@@ -67,6 +68,7 @@ The same release workflow also:
 - generates and uploads `appcast.xml` for Sparkle update checks
 - updates the `vekil` cask in `sozercan/homebrew-repo`
 - pushes the multi-arch container image to GHCR
+- pushes the `-rtk` multi-arch container image variant to GHCR
 
 To publish the Homebrew cask, configure the repository secret `HOMEBREW_REPO_TOKEN` with push access to `sozercan/homebrew-repo`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,7 +63,7 @@ The macOS tray app has its own workflow in [`.github/workflows/macos-app.yaml`](
 
 Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 
-RTK version bumps for the optional Docker variant are automated by [`.github/workflows/update-rtk.yaml`](../.github/workflows/update-rtk.yaml). The scheduled workflow runs [`scripts/update-rtk-version.sh`](../scripts/update-rtk-version.sh), updates the pinned `RTK_VERSION` Docker build arg when `rtk-ai/rtk` publishes a new latest release, validates the rebuilt variant with `make docker-build-rtk` and `make docker-rtk-e2e`, and opens a signed PR.
+RTK version bumps for the optional Docker variant are automated by [`.github/workflows/update-rtk.yaml`](../.github/workflows/update-rtk.yaml). The scheduled workflow runs [`scripts/update-rtk-version.sh`](../scripts/update-rtk-version.sh), updates the pinned `RTK_VERSION` Docker build arg in `Dockerfile.rtk` when `rtk-ai/rtk` publishes a new latest release, validates the rebuilt variant with `make docker-build-rtk` and `make docker-rtk-e2e`, and opens a signed PR.
 
 The same release workflow also:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,6 +63,8 @@ The macOS tray app has its own workflow in [`.github/workflows/macos-app.yaml`](
 
 Tag pushes to [`.github/workflows/release.yaml`](../.github/workflows/release.yaml) use [`.goreleaser.yaml`](../.goreleaser.yaml) to publish the CLI binaries and checksums to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 
+RTK version bumps for the optional Docker variant are automated by [`.github/workflows/update-rtk.yaml`](../.github/workflows/update-rtk.yaml). The scheduled workflow runs [`scripts/update-rtk-version.sh`](../scripts/update-rtk-version.sh), updates the pinned `RTK_VERSION` Docker build arg when `rtk-ai/rtk` publishes a new latest release, validates the rebuilt variant with `make docker-build-rtk` and `make docker-rtk-e2e`, and opens a signed PR.
+
 The same release workflow also:
 
 - builds `vekil-macos-arm64.zip` on a macOS runner and uploads it to the tagged release

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ Build a local image:
 ```bash
 docker build -t vekil .
 # Optional RTK variant:
-# docker build --target runtime-rtk -t vekil:rtk .
+# docker build -f Dockerfile.rtk -t vekil:rtk .
 docker run -p 1337:1337 \
   -v ~/.config/vekil:/home/nonroot/.config/vekil \
   vekil

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,10 +55,26 @@ If the config includes `type: "openai-codex"`, also mount the Codex home read-on
 
 If you customize `CODEX_HOME`, set the container-side path and mount your host directory there. The published image supports `linux/amd64` and `linux/arm64`.
 
+### RTK image variant
+
+Use the `-rtk` image variant when your providers config enables the optional [`rtk_cli` tool optimizer](tool-optimizers.md#rtk_cli-provider). The default image stays minimal; the RTK variant only adds the `rtk` binary and does not enable tool optimizers by itself.
+
+```bash
+docker run -p 1337:1337 \
+  -v ~/.config/vekil:/home/nonroot/.config/vekil \
+  -v /path/to/providers.yaml:/config/providers.yaml:ro \
+  ghcr.io/sozercan/vekil:latest-rtk \
+  --providers-config /config/providers.yaml
+```
+
+Inside the variant, set the optimizer path to `/usr/local/bin/rtk` for explicitness.
+
 Build a local image:
 
 ```bash
 docker build -t vekil .
+# Optional RTK variant:
+# docker build --target runtime-rtk -t vekil:rtk .
 docker run -p 1337:1337 \
   -v ~/.config/vekil:/home/nonroot/.config/vekil \
   vekil

--- a/docs/tool-optimizers.md
+++ b/docs/tool-optimizers.md
@@ -36,7 +36,7 @@ tool_optimizers:
 
 With this config, Vekil asks RTK to rewrite shell commands and reduce shell output where supported. The minimal `rtk_cli` provider relies on two defaults: `path` defaults to `rtk`, and omitted `stages` means the provider is eligible for both `command_rewrite` and `output_reduce`. For example, depending on RTK policy, command rewrite may replace common shell commands with RTK-aware equivalents such as `rtk ls`, `rtk read`, or `rtk grep`.
 
-When running Vekil in Docker, use the `ghcr.io/sozercan/vekil:latest-rtk` image variant or build one locally with `docker build --target runtime-rtk -t vekil:rtk .`. The default image intentionally does not include RTK. In the RTK variant, prefer `path: /usr/local/bin/rtk` so the config does not depend on `PATH` lookup.
+When running Vekil in Docker, use the `ghcr.io/sozercan/vekil:latest-rtk` image variant or build one locally with `docker build -f Dockerfile.rtk -t vekil:rtk .`. The default image intentionally does not include RTK. In the RTK variant, prefer `path: /usr/local/bin/rtk` so the config does not depend on `PATH` lookup.
 
 Advanced custom optimizer example:
 

--- a/docs/tool-optimizers.md
+++ b/docs/tool-optimizers.md
@@ -36,6 +36,8 @@ tool_optimizers:
 
 With this config, Vekil asks RTK to rewrite shell commands and reduce shell output where supported. The minimal `rtk_cli` provider relies on two defaults: `path` defaults to `rtk`, and omitted `stages` means the provider is eligible for both `command_rewrite` and `output_reduce`. For example, depending on RTK policy, command rewrite may replace common shell commands with RTK-aware equivalents such as `rtk ls`, `rtk read`, or `rtk grep`.
 
+When running Vekil in Docker, use the `ghcr.io/sozercan/vekil:latest-rtk` image variant or build one locally with `docker build --target runtime-rtk -t vekil:rtk .`. The default image intentionally does not include RTK. In the RTK variant, prefer `path: /usr/local/bin/rtk` so the config does not depend on `PATH` lookup.
+
 Advanced custom optimizer example:
 
 ```yaml

--- a/scripts/k8s-kind-smoke.sh
+++ b/scripts/k8s-kind-smoke.sh
@@ -111,7 +111,7 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 1
+            initialDelaySeconds: 15
             periodSeconds: 2
             failureThreshold: 3
           readinessProbe:

--- a/scripts/rtk-container-e2e.sh
+++ b/scripts/rtk-container-e2e.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+free_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+require_cmd curl
+require_cmd docker
+require_cmd python3
+
+TMP_PARENT="${RTK_CONTAINER_E2E_TMP_PARENT:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}}"
+cleanup_smoke_dir=0
+if [[ -n "${RTK_CONTAINER_E2E_DIR:-}" ]]; then
+  SMOKE_DIR="${RTK_CONTAINER_E2E_DIR}"
+else
+  SMOKE_DIR="$(mktemp -d "${TMP_PARENT%/}/rtk-container-e2e.XXXXXX")"
+  cleanup_smoke_dir=1
+fi
+if [[ "${SMOKE_DIR}" != /* ]]; then
+  SMOKE_DIR="${PWD}/${SMOKE_DIR}"
+fi
+
+IMAGE="${RTK_CONTAINER_E2E_IMAGE:-vekil:rtk}"
+UPSTREAM_PORT="${RTK_CONTAINER_E2E_UPSTREAM_PORT:-$(free_port)}"
+PROXY_PORT="${RTK_CONTAINER_E2E_PROXY_PORT:-$(free_port)}"
+CONTAINER_NAME="${RTK_CONTAINER_E2E_CONTAINER:-vekil-rtk-e2e-${RANDOM}-${RANDOM}}"
+UPSTREAM_LOG="${SMOKE_DIR}/upstream.log"
+PROXY_LOG="${SMOKE_DIR}/proxy.log"
+PROVIDERS_CONFIG="${SMOKE_DIR}/providers.yaml"
+REQUEST_JSON="${SMOKE_DIR}/request.json"
+RESPONSE_JSON="${SMOKE_DIR}/response.json"
+ORIGINAL_OUTPUT_FILE="${SMOKE_DIR}/original-output.txt"
+UPSTREAM_SCRIPT="${SMOKE_DIR}/mock_responses_upstream.py"
+
+upstream_pid=""
+
+cleanup() {
+  local rc=$?
+
+  if [[ ${rc} -ne 0 ]]; then
+    log "RTK container e2e failed; debug files are in ${SMOKE_DIR}"
+    if [[ -f "${UPSTREAM_LOG}" ]]; then
+      log "Mock upstream log"
+      cat "${UPSTREAM_LOG}" >&2 || true
+    fi
+    log "Vekil container log"
+    docker logs "${CONTAINER_NAME}" >&2 || true
+    if [[ -f "${PROXY_LOG}" ]]; then
+      cat "${PROXY_LOG}" >&2 || true
+    fi
+    if [[ -f "${RESPONSE_JSON}" ]]; then
+      log "Proxy response"
+      cat "${RESPONSE_JSON}" >&2 || true
+    fi
+  elif [[ "${cleanup_smoke_dir}" == "1" ]]; then
+    rm -rf "${SMOKE_DIR}"
+  fi
+
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  if [[ -n "${upstream_pid}" ]] && kill -0 "${upstream_pid}" 2>/dev/null; then
+    kill "${upstream_pid}" 2>/dev/null || true
+    wait "${upstream_pid}" 2>/dev/null || true
+  fi
+
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+mkdir -p "${SMOKE_DIR}"
+
+log "Verifying RTK binary is present in ${IMAGE}"
+docker run --rm --entrypoint /usr/local/bin/rtk "${IMAGE}" --version | grep -E '^rtk ' >/dev/null
+
+cat > "${UPSTREAM_SCRIPT}" <<'PY'
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import sys
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/healthz":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+            return
+        if self.path == "/v1/models":
+            self._write_json({"object": "list", "data": [{"id": "rtk-e2e", "object": "model"}]})
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw)
+        except Exception as exc:
+            payload = {"decode_error": str(exc), "raw": raw.decode("utf-8", "replace")}
+        self._write_json({
+            "id": "resp_mock",
+            "object": "response",
+            "status": "completed",
+            "model": payload.get("model", "rtk-e2e"),
+            "input_echo": payload,
+            "output": [],
+        })
+
+    def _write_json(self, body):
+        data = json.dumps(body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt, *args):
+        print(fmt % args, file=sys.stderr)
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+PY
+
+cat > "${ORIGINAL_OUTPUT_FILE}" <<'EOF_DIFF'
+diff --git a/main.go b/main.go
+index 1111111..2222222 100644
+--- a/main.go
++++ b/main.go
+@@ -1,7 +1,7 @@
+ package main
+ 
+ func main() {
+-	println("old")
++	println("new")
+ }
+ 
+ func helper() {
+-	println("unused old helper output")
++	println("unused new helper output")
+ }
+EOF_DIFF
+
+log "Starting mock OpenAI-compatible upstream on 127.0.0.1:${UPSTREAM_PORT}"
+python3 "${UPSTREAM_SCRIPT}" "${UPSTREAM_PORT}" >"${UPSTREAM_LOG}" 2>&1 &
+upstream_pid=$!
+for _ in $(seq 1 50); do
+  if curl -fsS "http://127.0.0.1:${UPSTREAM_PORT}/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+curl -fsS "http://127.0.0.1:${UPSTREAM_PORT}/healthz" >/dev/null
+
+cat > "${PROVIDERS_CONFIG}" <<EOF_CONFIG
+providers:
+  - id: mock
+    type: openai-compatible
+    default: true
+    base_url: http://host.docker.internal:${UPSTREAM_PORT}/v1
+    auth_type: none
+    model_discovery: static
+    models:
+      - public_id: rtk-e2e
+        endpoints:
+          - /responses
+tool_optimizers:
+  enabled: true
+  output_reduce:
+    enabled: true
+    min_input_bytes: 0
+    max_input_bytes: 0
+    timeout_ms: 5000
+  providers:
+    - id: rtk
+      type: rtk_cli
+      path: /usr/local/bin/rtk
+      stages:
+        - output_reduce
+EOF_CONFIG
+
+python3 - "${ORIGINAL_OUTPUT_FILE}" "${REQUEST_JSON}" <<'PY'
+import json
+import sys
+original_output = open(sys.argv[1], encoding="utf-8").read()
+request = {
+    "model": "rtk-e2e",
+    "input": [
+        {
+            "type": "function_call",
+            "name": "shell_command",
+            "call_id": "call_diff",
+            "arguments": json.dumps({"command": "git diff"}),
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_diff",
+            "output": original_output,
+        },
+    ],
+}
+with open(sys.argv[2], "w", encoding="utf-8") as f:
+    json.dump(request, f)
+PY
+
+log "Starting Vekil RTK variant on 127.0.0.1:${PROXY_PORT}"
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  --add-host=host.docker.internal:host-gateway \
+  -p "127.0.0.1:${PROXY_PORT}:1337" \
+  -v "${PROVIDERS_CONFIG}:/config/providers.yaml:ro" \
+  "${IMAGE}" \
+  --providers-config /config/providers.yaml >"${PROXY_LOG}"
+
+for _ in $(seq 1 100); do
+  if curl -fsS "http://127.0.0.1:${PROXY_PORT}/readyz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+curl -fsS "http://127.0.0.1:${PROXY_PORT}/readyz" >/dev/null
+
+log "Posting Responses request with git diff tool output"
+curl -fsS \
+  -H 'content-type: application/json' \
+  --data-binary "@${REQUEST_JSON}" \
+  "http://127.0.0.1:${PROXY_PORT}/v1/responses" >"${RESPONSE_JSON}"
+
+python3 - "${ORIGINAL_OUTPUT_FILE}" "${RESPONSE_JSON}" <<'PY'
+import json
+import sys
+
+original = open(sys.argv[1], encoding="utf-8").read()
+response = json.load(open(sys.argv[2], encoding="utf-8"))
+try:
+    reduced = response["input_echo"]["input"][1]["output"]
+except Exception as exc:
+    raise SystemExit(f"response did not echo reduced tool output: {exc}; response={response!r}")
+
+if reduced == original:
+    raise SystemExit("RTK output reducer returned the original git diff unchanged")
+if len(reduced.encode("utf-8")) >= len(original.encode("utf-8")):
+    raise SystemExit(
+        f"RTK output was not smaller: original={len(original.encode('utf-8'))} reduced={len(reduced.encode('utf-8'))}"
+    )
+if "diff --git" in reduced or "index 1111111..2222222" in reduced:
+    raise SystemExit(f"RTK output still contains raw git diff headers: {reduced!r}")
+if "main.go" not in reduced or "+2 -2" not in reduced:
+    raise SystemExit(f"RTK output did not look like reduced git diff summary: {reduced!r}")
+
+print(
+    "RTK reduced git diff tool output through Vekil: "
+    f"{len(original.encode('utf-8'))} -> {len(reduced.encode('utf-8'))} bytes"
+)
+PY
+
+log "RTK container e2e passed"

--- a/scripts/rtk-container-e2e.sh
+++ b/scripts/rtk-container-e2e.sh
@@ -138,7 +138,7 @@ class Handler(BaseHTTPRequestHandler):
         print(fmt % args, file=sys.stderr)
 
 if __name__ == "__main__":
-    ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()
+    ThreadingHTTPServer(("0.0.0.0", int(sys.argv[1])), Handler).serve_forever()
 PY
 
 cat > "${ORIGINAL_OUTPUT_FILE}" <<'EOF_DIFF'
@@ -160,7 +160,7 @@ index 1111111..2222222 100644
  }
 EOF_DIFF
 
-log "Starting mock OpenAI-compatible upstream on 127.0.0.1:${UPSTREAM_PORT}"
+log "Starting mock OpenAI-compatible upstream on 0.0.0.0:${UPSTREAM_PORT}"
 python3 "${UPSTREAM_SCRIPT}" "${UPSTREAM_PORT}" >"${UPSTREAM_LOG}" 2>&1 &
 upstream_pid=$!
 for _ in $(seq 1 50); do

--- a/scripts/update-rtk-version.sh
+++ b/scripts/update-rtk-version.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "${key}" "${value}" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+require_cmd python3
+
+DOCKERFILE="${RTK_UPDATE_DOCKERFILE:-Dockerfile}"
+REPO="${RTK_UPDATE_REPO:-rtk-ai/rtk}"
+
+[[ -f "${DOCKERFILE}" ]] || die "Dockerfile not found: ${DOCKERFILE}"
+
+current="$(sed -nE 's/^ARG RTK_VERSION=([^[:space:]]+).*/\1/p' "${DOCKERFILE}" | head -n 1)"
+[[ -n "${current}" ]] || die "could not find ARG RTK_VERSION in ${DOCKERFILE}"
+
+if [[ -n "${RTK_VERSION_OVERRIDE:-}" ]]; then
+  latest_tag="${RTK_VERSION_OVERRIDE}"
+else
+  latest_tag="$(python3 - "${REPO}" <<'PY'
+import json
+import os
+import sys
+import urllib.request
+
+repo = sys.argv[1]
+request = urllib.request.Request(
+    f"https://api.github.com/repos/{repo}/releases/latest",
+    headers={"Accept": "application/vnd.github+json", "User-Agent": "vekil-rtk-version-check"},
+)
+token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+if token:
+    request.add_header("Authorization", f"Bearer {token}")
+
+with urllib.request.urlopen(request, timeout=30) as response:
+    release = json.load(response)
+
+tag = release.get("tag_name", "").strip()
+if not tag:
+    raise SystemExit("latest release did not include tag_name")
+print(tag)
+PY
+)"
+fi
+
+latest="${latest_tag#v}"
+[[ -n "${latest}" ]] || die "latest RTK version is empty"
+
+write_output current-version "${current}"
+write_output latest-version "${latest}"
+
+if [[ "${current}" == "${latest}" ]]; then
+  log "RTK is already up to date (${current})"
+  write_output changed false
+  exit 0
+fi
+
+log "Updating RTK from ${current} to ${latest}"
+python3 - "${DOCKERFILE}" "${latest}" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+latest = sys.argv[2]
+text = path.read_text()
+updated, count = re.subn(r"^ARG RTK_VERSION=\S+", f"ARG RTK_VERSION={latest}", text, count=1, flags=re.MULTILINE)
+if count != 1:
+    raise SystemExit(f"expected to update exactly one RTK_VERSION line, updated {count}")
+path.write_text(updated)
+PY
+
+write_output changed true

--- a/scripts/update-rtk-version.sh
+++ b/scripts/update-rtk-version.sh
@@ -25,7 +25,7 @@ write_output() {
 
 require_cmd python3
 
-DOCKERFILE="${RTK_UPDATE_DOCKERFILE:-Dockerfile}"
+DOCKERFILE="${RTK_UPDATE_DOCKERFILE:-Dockerfile.rtk}"
 REPO="${RTK_UPDATE_REPO:-rtk-ai/rtk}"
 
 [[ -f "${DOCKERFILE}" ]] || die "Dockerfile not found: ${DOCKERFILE}"


### PR DESCRIPTION
## Summary
- add a `Dockerfile.rtk` image variant that bundles a pinned RTK binary while keeping the default Dockerfile independent of RTK
- add Makefile, CI, and release workflow support for `-rtk` image tags
- add an RTK container e2e smoke that sends git diff tool output through Vekil and asserts RTK reduces it before forwarding upstream
- add a scheduled/manual RTK updater workflow that bumps `RTK_VERSION`, validates the rebuilt image, and opens a signed PR when a new RTK release is available
- document Docker usage for the optional `rtk_cli` optimizer variant and RTK update automation

## Validation
- `make test`
- `make docker-build`
- `DOCKER_BUILDKIT=0 make docker-build`
- `make docker-build-rtk`
- `make docker-rtk-e2e`
- `scripts/update-rtk-version.sh`
- `RTK_UPDATE_DOCKERFILE=<temp> RTK_VERSION_OVERRIDE=v9.8.7 scripts/update-rtk-version.sh`
- `K8S_SMOKE_CLUSTER_NAME=... K8S_SMOKE_LOCAL_PORT=18180 scripts/k8s-kind-smoke.sh`
- `docker run --rm --entrypoint /usr/local/bin/rtk vekil:rtk --version`
- `docker build --platform linux/amd64 -f Dockerfile.rtk -t vekil:rtk-amd64 .`
- `docker run --rm --platform linux/amd64 --entrypoint /usr/local/bin/rtk vekil:rtk-amd64 --version`
