### PR TITLE
fix(responses): retry unverifiable encrypted replay

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -14,6 +14,8 @@ For responses-only Azure deployments such as the `gpt-5.4-pro` example configura
 
 Streaming Responses requests preserve upstream headers and are otherwise passed through directly. One narrow exception exists for `POST /v1/responses` with `stream: true`: if the first semantic SSE event is an immediate transient `response.failed` admission error such as `too_many_requests`, `model_overloaded`, `bad_gateway`, or `gateway_timeout`, the proxy translates that pre-commit failure into a normal HTTP error before flushing `200 OK`. All other streaming failures stay passthrough SSE.
 
+If an upstream rejects a `/responses` request with `400 invalid_request_body` because replayed `encrypted_content` cannot be verified or decrypted, Vekil retries once after removing the opaque encrypted replay items it cannot interpret. The original request remains near-zero-copy when the selected upstream accepts its own encrypted tokens; the retry only applies after that specific upstream rejection. Vekil-owned compaction checkpoints are still expanded to developer context before forwarding.
+
 `GET /v1/responses` can upgrade to a websocket bridge for Codex-style clients when `--responses-ws-enabled` or `RESPONSES_WS_ENABLED=true` is set. The proxy:
 
 - accepts `response.create` frames, including websocket-only top-level fields such as `client_metadata` and `initiator`

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3888,6 +3888,139 @@ func TestHandleResponses_PreservesOpaqueCompaction(t *testing.T) {
 	}
 }
 
+func TestHandleResponses_RetriesWithoutUnverifiableEncryptedContent(t *testing.T) {
+	const encryptedToken = "gAAAAABencryptedReasoningPayloadpQ=="
+	var upstreamRequestsMu sync.Mutex
+	upstreamRequests := make([]map[string]interface{}, 0, 2)
+	var attempts atomic.Int32
+
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read upstream request body: %v", err)
+		}
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Fatalf("upstream received invalid JSON: %v", err)
+		}
+
+		upstreamRequestsMu.Lock()
+		upstreamRequests = append(upstreamRequests, body)
+		upstreamRequestsMu.Unlock()
+
+		switch attempts.Add(1) {
+		case 1:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, `{"error":{"message":"The encrypted content %s could not be verified. Reason: Encrypted content could not be decrypted or parsed.","code":"invalid_request_body"}}`, encryptedToken)
+		case 2:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-sanitized-encrypted-content","object":"response","status":"completed","output":[]}`))
+		default:
+			t.Fatalf("unexpected upstream attempt %d", attempts.Load())
+		}
+	})
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"model":                "gpt-5.4",
+		"previous_response_id": "resp-prev",
+		"input": []interface{}{
+			map[string]interface{}{
+				"type":              "reasoning",
+				"id":                "rs-prev",
+				"encrypted_content": encryptedToken,
+			},
+			map[string]interface{}{
+				"type":              "compaction",
+				"encrypted_content": encryptedToken,
+			},
+			map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]string{
+					{"type": "input_text", "text": "continue without opaque state"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected retry to recover with 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	upstreamRequestsMu.Lock()
+	requests := append([]map[string]interface{}(nil), upstreamRequests...)
+	upstreamRequestsMu.Unlock()
+	if len(requests) != 2 {
+		t.Fatalf("expected initial request and sanitized retry, got %d", len(requests))
+	}
+
+	initialInput := upstreamInputItems(t, requests[0])
+	if len(initialInput) != 3 {
+		t.Fatalf("expected initial replay to include opaque items, got %d items", len(initialInput))
+	}
+	if initialInput[0]["type"] != "reasoning" || initialInput[0]["encrypted_content"] != encryptedToken {
+		t.Fatalf("expected initial request to include encrypted reasoning item, got %#v", initialInput[0])
+	}
+	if initialInput[1]["type"] != "compaction" || initialInput[1]["encrypted_content"] != encryptedToken {
+		t.Fatalf("expected initial request to include encrypted compaction item, got %#v", initialInput[1])
+	}
+
+	retryInput := upstreamInputItems(t, requests[1])
+	if len(retryInput) != 1 {
+		t.Fatalf("expected retry to drop unverifiable opaque items and keep user input, got %d: %#v", len(retryInput), retryInput)
+	}
+	if got := requireMessageTextWithRole(t, retryInput[0], "user"); got != "continue without opaque state" {
+		t.Fatalf("expected retry to preserve user message, got %q", got)
+	}
+	if got := requests[1]["previous_response_id"]; got != "resp-prev" {
+		t.Fatalf("expected retry to preserve previous_response_id, got %#v", got)
+	}
+}
+
+func TestHandleResponses_PreservesLargeNonEncryptedContentBadRequestBody(t *testing.T) {
+	const suffix = "--large-non-matching-error-end"
+	largeError := strings.Repeat("x", compactUpstreamErrorBodySize+1024) + suffix
+	var attempts atomic.Int32
+
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(largeError))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.4","input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleResponses(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected upstream 400 passthrough, got %d: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if got := string(body); got != largeError {
+		t.Fatalf("expected non-matching 400 body to be preserved in full, got len=%d want len=%d suffix=%v", len(got), len(largeError), strings.HasSuffix(got, suffix))
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected no retry for non-matching 400, got %d upstream attempts", got)
+	}
+}
+
 func TestHandleResponses_RetriesCompacted413Replay(t *testing.T) {
 	var upstreamRequestsMu sync.Mutex
 	upstreamRequests := make([]map[string]interface{}, 0, 3)

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -2196,6 +2196,179 @@ func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, bod
 	return resp, err
 }
 
+func (h *ProxyHandler) maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx context.Context, bodyBytes []byte, extraHeaders http.Header, resp *http.Response) (*http.Response, error) {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest {
+		return resp, nil
+	}
+
+	respBodyPrefix, err := io.ReadAll(io.LimitReader(resp.Body, int64(compactUpstreamErrorBodySize)+1))
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	classificationBody := respBodyPrefix
+	if len(classificationBody) > compactUpstreamErrorBodySize {
+		classificationBody = classificationBody[:compactUpstreamErrorBodySize]
+	}
+	restoreOriginalResp := func() *http.Response {
+		cloned := new(http.Response)
+		*cloned = *resp
+		if resp.Header != nil {
+			cloned.Header = resp.Header.Clone()
+		}
+		cloned.Body = prefixedReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(respBodyPrefix), resp.Body),
+			close:  resp.Body.Close,
+		}
+		return cloned
+	}
+
+	if !isUnverifiableEncryptedContentError(resp.StatusCode, classificationBody) {
+		return restoreOriginalResp(), nil
+	}
+
+	retryBody, strippedItems := sanitizeResponsesUnverifiableEncryptedContentBody(bodyBytes)
+	if strippedItems == 0 {
+		return restoreOriginalResp(), nil
+	}
+
+	h.log.Info("retrying responses request without unverifiable encrypted content",
+		logger.F("encrypted_items_stripped", strippedItems),
+	)
+	retryResp, retryErr := h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, retryBody, extraHeaders)
+	if retryErr != nil {
+		h.log.Debug("responses encrypted-content retry request failed", logger.Err(retryErr))
+		return restoreOriginalResp(), nil
+	}
+	_ = resp.Body.Close()
+	return retryResp, nil
+}
+
+type prefixedReadCloser struct {
+	io.Reader
+	close func() error
+}
+
+func (r prefixedReadCloser) Close() error {
+	if r.close == nil {
+		return nil
+	}
+	return r.close()
+}
+
+func isUnverifiableEncryptedContentError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return false
+	}
+
+	message := strings.ToLower(strings.TrimSpace(envelope.Error.Message))
+	if !strings.Contains(message, "encrypted content") {
+		return false
+	}
+	if strings.Contains(message, "decrypt") || strings.Contains(message, "could not be verified") || strings.Contains(message, "could not be parsed") {
+		return true
+	}
+
+	return strings.EqualFold(strings.TrimSpace(envelope.Error.Code), "invalid_request_body")
+}
+
+func sanitizeResponsesUnverifiableEncryptedContentBody(body []byte) ([]byte, int) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body, 0
+	}
+
+	rawInput, ok := payload["input"]
+	if !ok {
+		return body, 0
+	}
+	rewrittenInput, strippedItems, err := sanitizeResponsesUnverifiableEncryptedContentInput(rawInput)
+	if err != nil || strippedItems == 0 {
+		return body, 0
+	}
+	payload["input"] = rewrittenInput
+
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return body, 0
+	}
+	return rewritten, strippedItems
+}
+
+func sanitizeResponsesUnverifiableEncryptedContentInput(raw json.RawMessage) (json.RawMessage, int, error) {
+	var input []json.RawMessage
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return raw, 0, err
+	}
+
+	rewritten := make([]json.RawMessage, 0, len(input))
+	strippedItems := 0
+	for _, rawItem := range input {
+		item, keep, count, err := sanitizeResponsesUnverifiableEncryptedContentItem(rawItem)
+		if err != nil {
+			rewritten = append(rewritten, rawItem)
+			continue
+		}
+		strippedItems += count
+		if keep {
+			rewritten = append(rewritten, item)
+		}
+	}
+	if strippedItems == 0 {
+		return raw, 0, nil
+	}
+
+	encoded, err := json.Marshal(rewritten)
+	if err != nil {
+		return raw, 0, err
+	}
+	return encoded, strippedItems, nil
+}
+
+func sanitizeResponsesUnverifiableEncryptedContentItem(raw json.RawMessage) (json.RawMessage, bool, int, error) {
+	var item map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return raw, true, 0, err
+	}
+
+	itemType := rawJSONString(item["type"])
+	if itemType == "reasoning" {
+		return nil, false, 1, nil
+	}
+
+	if _, ok := item["encrypted_content"]; !ok {
+		return raw, true, 0, nil
+	}
+	if responsesInputItemIsProxyCompactionContext(raw) {
+		return raw, true, 0, nil
+	}
+
+	switch itemType {
+	case "compaction", "context_compaction":
+		// Unknown opaque checkpoint tokens cannot be interpreted once the selected
+		// upstream has rejected them. Drop the item rather than retrying an invalid
+		// shell such as {"type":"compaction"} without its required payload.
+		return nil, false, 1, nil
+	}
+
+	delete(item, "encrypted_content")
+	rewritten, err := json.Marshal(item)
+	if err != nil {
+		return raw, true, 0, err
+	}
+	return rewritten, true, 1, nil
+}
+
 // postResponsesWithFallbackHeadersTracked behaves like
 // postResponsesWithFallbackHeaders, but also returns the model the request was
 // ultimately served by — empty unless the model-fallback path engaged. The

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -236,7 +236,11 @@ func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*h
 }
 
 func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	return h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, body, extraHeaders)
+	resp, err := h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, body, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return h.maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx, body, extraHeaders, resp)
 }
 
 func (h *ProxyHandler) postAnthropicMessages(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- retry `/v1/responses` once when upstream rejects replayed `encrypted_content` as unverifiable/decrypt-failed
- sanitize only the opaque encrypted replay state Vekil cannot interpret while preserving user input and request metadata
- preserve unrelated large upstream 400 response bodies without truncating passthrough errors
- document the encrypted-content retry behavior

## Root cause

Vekil expanded its own compaction checkpoints but forwarded unknown opaque `encrypted_content` replay items unchanged. If those tokens were minted for a different upstream/model/session, the selected upstream could reject the request with `invalid_request_body` because it could not verify or decrypt the encrypted payload.

## Validation

- `go test ./proxy -run 'TestHandleResponses_RetriesWithoutUnverifiableEncryptedContent|TestHandleResponses_PreservesLargeNonEncryptedContentBadRequestBody' -count=1 -v`
- `go test ./proxy -count=1`
- `make test`
- `make vet`
- `python3 /Users/sozercan/.codex/skills/autoreview/scripts/autoreview --mode local --parallel-tests "make test && make vet"`

Final autoreview result: `autoreview clean: no accepted/actionable findings reported`.
