### PR TITLE
perf(proxy): reduce streaming and replay overhead

### DIFF
--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -60,6 +60,8 @@ Use `curl -N` or another SSE-capable client so streamed frames are not buffered 
 
 `countTokens` uses the same accepted route prefixes as the other Gemini compatibility routes. It normalizes the Gemini request into the same prompt/tool payload used by `generateContent`, performs a minimal upstream `/chat/completions` probe, and returns `usage.prompt_tokens` as Gemini `totalTokens`. Normalized successful requests are cached for 60 seconds. If the probe hits a transient transport error, 429, 5xx, or a 200 response with missing usage, the proxy returns a dependency-free local token estimate instead of failing the counting request. It still surfaces permanent client/configuration failures such as 400, 401, and 403 without estimating.
 
-### Function calling `VALIDATED` mode
+### Function calling modes
+
+Gemini `functionCallingConfig.mode: "NONE"` is translated to OpenAI `tool_choice: "none"`. For non-streaming `generateContent` requests, this lets the proxy use a non-streaming upstream request even when tool declarations are present, because the selected mode forbids tool calls.
 
 Gemini `functionCallingConfig.mode: "VALIDATED"` is accepted and translated to OpenAI `tool_choice: "auto"`. OpenAI Chat Completions has no equivalent schema-validation-guarantee tier, so this is a lossy compatibility mapping: the model may decide whether to call a tool, but any Gemini-specific validation guarantee is not preserved by the OpenAI-shaped upstream request.

--- a/proxy/compaction.go
+++ b/proxy/compaction.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
@@ -21,6 +22,10 @@ func encodeSyntheticCompaction(summary string) string {
 }
 
 func rewriteSyntheticCompactionRequest(body []byte) ([]byte, int) {
+	if !responsesBodyMayContainSyntheticCompaction(body) {
+		return body, 0
+	}
+
 	var req map[string]json.RawMessage
 	if err := json.Unmarshal(body, &req); err != nil {
 		return body, 0
@@ -54,6 +59,23 @@ func rewriteSyntheticCompactionRequest(body []byte) ([]byte, int) {
 	return rewrittenBody, rewriteCount
 }
 
+func responsesBodyMayContainSyntheticCompaction(body []byte) bool {
+	return bytes.Contains(body, []byte(syntheticCompactionPrefix)) ||
+		bytes.Contains(body, []byte(legacySyntheticCompactionPrefix)) ||
+		responsesBodyMayContainCompactionToken(body)
+}
+
+func responsesBodyMayContainContextCompaction(body []byte) bool {
+	return responsesBodyMayContainCompactionToken(body)
+}
+
+func responsesBodyMayContainCompactionToken(body []byte) bool {
+	// Fast-path ordinary requests that cannot contain proxy-owned compaction
+	// items. If the body contains any JSON unicode escapes, fall back to the
+	// legacy parser so escaped marker strings keep their previous behavior.
+	return bytes.Contains(body, []byte("compaction")) || bytes.Contains(body, []byte(`\u`))
+}
+
 func rewriteSyntheticCompactionRequestFields(requestFields map[string]json.RawMessage) (map[string]json.RawMessage, int) {
 	rawInput, ok := requestFields["input"]
 	if !ok {
@@ -84,6 +106,10 @@ func rewriteSyntheticCompactionRequestFields(requestFields map[string]json.RawMe
 }
 
 func sanitizeContextCompactionRequest(body []byte) ([]byte, int) {
+	if !responsesBodyMayContainContextCompaction(body) {
+		return body, 0
+	}
+
 	var req map[string]json.RawMessage
 	if err := json.Unmarshal(body, &req); err != nil {
 		return body, 0

--- a/proxy/gemini.go
+++ b/proxy/gemini.go
@@ -307,20 +307,6 @@ func hashOpenAIRequest(req *models.OpenAIRequest) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func cloneOpenAIRequest(req *models.OpenAIRequest) (*models.OpenAIRequest, error) {
-	raw, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-
-	var clone models.OpenAIRequest
-	if err := json.Unmarshal(raw, &clone); err != nil {
-		return nil, err
-	}
-
-	return &clone, nil
-}
-
 func parseGeminiPath(path string) (string, string, error) {
 	prefixes := []string{"/v1beta/models/", "/v1/models/", "/models/"}
 	for _, prefix := range prefixes {

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -77,7 +77,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 	}
 	h.maybeReduceOpenAIChatToolOutputs(r.Context(), oaiReq, h.toolContexts, scope)
 
-	forceStream := !stream && len(oaiReq.Tools) > 0
+	forceStream := !stream && len(oaiReq.Tools) > 0 && !openAIToolChoiceIsNone(oaiReq.ToolChoice)
 	if forceStream {
 		streamFlag := true
 		oaiReq.Stream = &streamFlag
@@ -312,14 +312,7 @@ func geminiContentHasInlineMedia(content *models.GeminiContent) bool {
 }
 
 func (h *ProxyHandler) runGeminiCountTokensProbe(baseReq *models.OpenAIRequest) (*models.OpenAIResponse, error) {
-	probeReq, err := cloneOpenAIRequest(baseReq)
-	if err != nil {
-		return nil, &geminiProtocolError{
-			statusCode: http.StatusInternalServerError,
-			status:     "INTERNAL",
-			message:    "failed to clone countTokens request",
-		}
-	}
+	probeReq := copyOpenAIRequestForGeminiCountTokensProbe(baseReq)
 
 	streamFlag := false
 	temperature := 0.0
@@ -338,6 +331,17 @@ func (h *ProxyHandler) runGeminiCountTokensProbe(baseReq *models.OpenAIRequest) 
 		return h.executeGeminiCountTokensProbeFinal(probeReq)
 	}
 	return oaiResp, err
+}
+
+func copyOpenAIRequestForGeminiCountTokensProbe(baseReq *models.OpenAIRequest) *models.OpenAIRequest {
+	// The probe path only replaces top-level fields below (streaming, token
+	// limits, and temperature). Shared slices/raw messages remain read-only, so a
+	// struct copy avoids the JSON round-trip deep clone on every countTokens miss.
+	if baseReq == nil {
+		return &models.OpenAIRequest{}
+	}
+	probeReq := *baseReq
+	return &probeReq
 }
 
 func (h *ProxyHandler) executeGeminiCountTokensProbe(probeReq *models.OpenAIRequest) (*models.OpenAIResponse, bool, error) {

--- a/proxy/gemini_test.go
+++ b/proxy/gemini_test.go
@@ -1440,6 +1440,161 @@ func TestHandleGeminiModelsGenerateContent_ForcedStreamingUsesStreamingUpstreamT
 	assertDeadlineApprox(t, <-deadlineCh, streamingUpstreamTimeout)
 }
 
+func TestHandleGeminiModelsGenerateContentDoesNotForceStreamWhenToolChoiceNone(t *testing.T) {
+	handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request: %v", err)
+		}
+
+		if oaiReq.Stream != nil && *oaiReq.Stream {
+			t.Fatal("Stream = true, want unset or false when Gemini tool_choice translates to none")
+		}
+		if oaiReq.StreamOptions != nil {
+			t.Fatalf("StreamOptions = %#v, want nil when upstream stream is not forced", oaiReq.StreamOptions)
+		}
+		if len(oaiReq.Tools) != 1 {
+			t.Fatalf("len(Tools) = %d, want 1", len(oaiReq.Tools))
+		}
+		if !openAIToolChoiceIsNone(oaiReq.ToolChoice) {
+			t.Fatalf("ToolChoice = %s, want none", string(oaiReq.ToolChoice))
+		}
+
+		return jsonHTTPResponse(`{
+			"id":"chatcmpl-gemini-tool-none",
+			"model":"gemini-2.5-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"Tool use disabled"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}
+		}`), nil
+	}))
+
+	reqBody := `{
+		"model": "models/gemini-2.5-pro",
+		"contents": [{"role":"user","parts":[{"text":"Hi"}]}],
+		"tools": [{"functionDeclarations":[{"name":"lookup_weather","parameters":{"type":"object"}}]}],
+		"toolConfig": {"functionCallingConfig": {"mode": "NONE"}}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/models/models/gemini-2.5-pro:generateContent", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleGeminiModels(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("StatusCode = %d, want 200: %s", resp.StatusCode, string(body))
+	}
+
+	var geminiResp models.GeminiGenerateContentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if geminiResp.UsageMetadata == nil || geminiResp.UsageMetadata.TotalTokenCount != 8 {
+		t.Fatalf("UsageMetadata = %#v, want totalTokenCount=8", geminiResp.UsageMetadata)
+	}
+	if len(geminiResp.Candidates) != 1 || geminiResp.Candidates[0].Content == nil || len(geminiResp.Candidates[0].Content.Parts) != 1 {
+		t.Fatalf("Candidates = %#v, want one text candidate", geminiResp.Candidates)
+	}
+	if got := geminiResp.Candidates[0].Content.Parts[0].Text; got == nil || *got != "Tool use disabled" {
+		t.Fatalf("text = %v, want Tool use disabled", got)
+	}
+}
+
+func TestRunGeminiCountTokensProbeDoesNotMutateBaseRequest(t *testing.T) {
+	var calls atomic.Int32
+	handler := newRoundTripTestProxyHandler(t, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		call := calls.Add(1)
+		var oaiReq models.OpenAIRequest
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &oaiReq); err != nil {
+			t.Fatalf("unmarshal upstream request %d: %v", call, err)
+		}
+
+		if oaiReq.Stream == nil || *oaiReq.Stream {
+			t.Fatalf("request %d Stream = %v, want false", call, oaiReq.Stream)
+		}
+		if oaiReq.StreamOptions != nil {
+			t.Fatalf("request %d StreamOptions = %#v, want nil", call, oaiReq.StreamOptions)
+		}
+		if oaiReq.Temperature == nil || *oaiReq.Temperature != 0 {
+			t.Fatalf("request %d Temperature = %v, want 0", call, oaiReq.Temperature)
+		}
+
+		if call == 1 {
+			if oaiReq.MaxCompletionTokens == nil || *oaiReq.MaxCompletionTokens != 1 {
+				t.Fatalf("first request MaxCompletionTokens = %v, want 1", oaiReq.MaxCompletionTokens)
+			}
+			if oaiReq.MaxTokens != nil {
+				t.Fatalf("first request MaxTokens = %v, want nil", oaiReq.MaxTokens)
+			}
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"max_completion_tokens unsupported"}}`)),
+			}, nil
+		}
+
+		if call != 2 {
+			t.Fatalf("unexpected request %d", call)
+		}
+		if oaiReq.MaxCompletionTokens != nil {
+			t.Fatalf("fallback request MaxCompletionTokens = %v, want nil", oaiReq.MaxCompletionTokens)
+		}
+		if oaiReq.MaxTokens == nil || *oaiReq.MaxTokens != 1 {
+			t.Fatalf("fallback request MaxTokens = %v, want 1", oaiReq.MaxTokens)
+		}
+		return jsonHTTPResponse(`{
+			"id":"chatcmpl-gemini-counttokens",
+			"model":"gemini-2.5-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"length"}],
+			"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22}
+		}`), nil
+	}))
+
+	originalMaxTokens := 42
+	originalTemperature := 0.8
+	originalStreamOptions := &models.StreamOptions{IncludeUsage: true}
+	baseReq := &models.OpenAIRequest{
+		Model: "gemini-2.5-pro",
+		Messages: []models.OpenAIMessage{{
+			Role:    "user",
+			Content: json.RawMessage(`"count these tokens"`),
+		}},
+		MaxTokens:     &originalMaxTokens,
+		Temperature:   &originalTemperature,
+		StreamOptions: originalStreamOptions,
+	}
+
+	oaiResp, err := handler.runGeminiCountTokensProbe(baseReq)
+	if err != nil {
+		t.Fatalf("runGeminiCountTokensProbe() error = %v", err)
+	}
+	if oaiResp == nil || oaiResp.Usage == nil || oaiResp.Usage.TotalTokens != 22 {
+		t.Fatalf("probe response = %#v, want totalTokens=22", oaiResp)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("upstream calls = %d, want 2", got)
+	}
+
+	if baseReq.Stream != nil {
+		t.Fatalf("base Stream = %v, want nil", baseReq.Stream)
+	}
+	if baseReq.StreamOptions != originalStreamOptions {
+		t.Fatalf("base StreamOptions pointer changed: %#v", baseReq.StreamOptions)
+	}
+	if baseReq.MaxTokens != &originalMaxTokens || *baseReq.MaxTokens != 42 {
+		t.Fatalf("base MaxTokens = %v, want original 42", baseReq.MaxTokens)
+	}
+	if baseReq.MaxCompletionTokens != nil {
+		t.Fatalf("base MaxCompletionTokens = %v, want nil", baseReq.MaxCompletionTokens)
+	}
+	if baseReq.Temperature != &originalTemperature || *baseReq.Temperature != 0.8 {
+		t.Fatalf("base Temperature = %v, want original 0.8", baseReq.Temperature)
+	}
+}
+
 func TestHandleGeminiModelsGenerateContentIgnoresTopKAndThinkingConfig(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		var oaiReq models.OpenAIRequest
@@ -2611,5 +2766,60 @@ func TestHandleGeminiModelsCountTokensDoesNotEstimatePermanentUpstreamErrors(t *
 				t.Fatalf("expected real error response, got %#v", errResp)
 			}
 		})
+	}
+}
+
+func BenchmarkRunGeminiCountTokensProbe(b *testing.B) {
+	handler := newRoundTripTestProxyHandler(b, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		return jsonHTTPResponse(`{
+			"id":"chatcmpl-gemini-counttokens-bench",
+			"model":"gemini-2.5-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"length"}],
+			"usage":{"prompt_tokens":256,"completion_tokens":1,"total_tokens":257}
+		}`), nil
+	}))
+	baseReq := benchmarkGeminiCountTokensOpenAIRequest()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := handler.runGeminiCountTokensProbe(baseReq); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkGeminiCountTokensOpenAIRequest() *models.OpenAIRequest {
+	content := json.RawMessage(`"Count these benchmark tokens while preserving the translated Gemini payload."`)
+	messages := make([]models.OpenAIMessage, 0, 64)
+	for i := 0; i < cap(messages); i++ {
+		messages = append(messages, models.OpenAIMessage{
+			Role:    "user",
+			Content: content,
+		})
+	}
+
+	maxTokens := 1024
+	temperature := 0.7
+	topP := 0.95
+	parallelToolCalls := true
+	return &models.OpenAIRequest{
+		Model:    "gemini-2.5-pro",
+		Messages: messages,
+		Tools: []models.OpenAITool{{
+			Type: "function",
+			Function: models.OpenAIFunction{
+				Name:        "lookup_weather",
+				Description: "Returns weather for a city.",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+			},
+		}},
+		ToolChoice:        json.RawMessage(`"auto"`),
+		MaxTokens:         &maxTokens,
+		Temperature:       &temperature,
+		TopP:              &topP,
+		ParallelToolCalls: &parallelToolCalls,
 	}
 }

--- a/proxy/openai_stream_reader.go
+++ b/proxy/openai_stream_reader.go
@@ -42,7 +42,10 @@ func (a *sseDataAccumulator) dispatch(onData func(string, string) bool) bool {
 		a.eventType = ""
 		return true
 	}
-	data := strings.Join(a.dataLines, "\n")
+	data := a.dataLines[0]
+	if len(a.dataLines) > 1 {
+		data = strings.Join(a.dataLines, "\n")
+	}
 	eventType := a.eventType
 	a.dataLines = a.dataLines[:0]
 	a.eventType = ""
@@ -140,7 +143,25 @@ func (e *openAIStreamError) Error() string {
 	return "upstream stream error"
 }
 
+// shouldParseOpenAIStreamError is a cheap guard for the hot path: ordinary
+// chat-completion chunks should not pay a second JSON unmarshal just to discover
+// they are not post-commit error events.
+func shouldParseOpenAIStreamError(eventType, data string) bool {
+	if strings.EqualFold(strings.TrimSpace(eventType), "error") {
+		return true
+	}
+	data = strings.TrimLeft(data, " \t\r\n")
+	if data == "" || data[0] != '{' {
+		return false
+	}
+	return strings.Contains(data, `"error"`)
+}
+
 func parseOpenAIStreamError(eventType, data string) (*openAIStreamError, bool) {
+	if !shouldParseOpenAIStreamError(eventType, data) {
+		return nil, false
+	}
+
 	var envelope struct {
 		Error *struct {
 			Type    string `json:"type"`

--- a/proxy/openai_stream_reader_bench_test.go
+++ b/proxy/openai_stream_reader_bench_test.go
@@ -1,0 +1,64 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sozercan/vekil/models"
+)
+
+var (
+	benchmarkOpenAIStreamError   *openAIStreamError
+	benchmarkOpenAIStreamErrorOK bool
+	benchmarkSSEEventType        string
+	benchmarkSSEData             string
+	benchmarkOpenAIStreamChunks  int
+)
+
+func BenchmarkParseOpenAIStreamErrorOrdinaryChunk(b *testing.B) {
+	data := `{"id":"chatcmpl-bench","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello world"}}]}`
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkOpenAIStreamError, benchmarkOpenAIStreamErrorOK = parseOpenAIStreamError("", data)
+	}
+}
+
+func BenchmarkSSEDataAccumulatorDispatchSingleDataLine(b *testing.B) {
+	data := `{"id":"chatcmpl-bench","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello world"}}]}`
+	acc := sseDataAccumulator{dataLines: make([]string, 0, 1)}
+	onData := func(eventType, data string) bool {
+		benchmarkSSEEventType = eventType
+		benchmarkSSEData = data
+		return true
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		acc.eventType = "chat.completion.chunk"
+		acc.dataLines = append(acc.dataLines, data)
+		if !acc.dispatch(onData) {
+			b.Fatal("dispatch stopped")
+		}
+	}
+}
+
+func BenchmarkConsumeOpenAIStreamChunksOrdinary(b *testing.B) {
+	chunk := `{"id":"chatcmpl-bench","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello world"}}]}`
+	input := strings.Repeat("data: "+chunk+"\n\n", 64) + "data: [DONE]\n\n"
+	onChunk := func(models.OpenAIStreamChunk) bool {
+		benchmarkOpenAIStreamChunks++
+		return true
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchmarkOpenAIStreamChunks = 0
+		sawDone, err := consumeOpenAIStreamChunks(strings.NewReader(input), onChunk)
+		if err != nil {
+			b.Fatalf("consumeOpenAIStreamChunks returned error: %v", err)
+		}
+		if !sawDone || benchmarkOpenAIStreamChunks != 64 {
+			b.Fatalf("sawDone=%v chunks=%d, want true/64", sawDone, benchmarkOpenAIStreamChunks)
+		}
+	}
+}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -402,6 +402,7 @@ func (ps *providerSetup) modelsForProvider(providerID string) []providerModel {
 
 func (h *ProxyHandler) initializeProviders() error {
 	if len(h.providersConfig.Providers) == 0 {
+		h.providersState = defaultProviderSetup(h)
 		return nil
 	}
 

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+var benchmarkProviderSetupSink *providerSetup
+
 func TestLoadProvidersConfigFileAzureV1BaseURLAndModelMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -1092,5 +1094,97 @@ func TestBuildProvidersAzureAuthModeValidation(t *testing.T) {
 				t.Fatalf("buildProviders() error = %v, want %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestInitializeProvidersCachesDefaultProviderSetup(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test/"}
+	if err := handler.initializeProviders(); err != nil {
+		t.Fatalf("initializeProviders() error = %v", err)
+	}
+
+	first := handler.providerSetup()
+	second := handler.providerSetup()
+	if first == nil {
+		t.Fatal("providerSetup() = nil, want default setup")
+	}
+	if first != second {
+		t.Fatal("providerSetup() returned different default setup pointers; want cached setup")
+	}
+	if first.hasConfiguredState {
+		t.Fatal("default setup hasConfiguredState = true, want false")
+	}
+	if got, want := first.defaultProviderID, "copilot"; got != want {
+		t.Fatalf("defaultProviderID = %q, want %q", got, want)
+	}
+	if !reflect.DeepEqual(first.providerOrder, []string{"copilot"}) {
+		t.Fatalf("providerOrder = %v, want [copilot]", first.providerOrder)
+	}
+
+	provider := first.defaultProvider()
+	if provider == nil {
+		t.Fatal("defaultProvider() = nil, want copilot provider")
+	}
+	if got, want := provider.baseURL, "https://copilot.example.test"; got != want {
+		t.Fatalf("default provider baseURL = %q, want %q", got, want)
+	}
+}
+
+func TestInitializeProvidersConfiguredSetupStillUsesConfiguredState(t *testing.T) {
+	t.Parallel()
+
+	handler := &ProxyHandler{
+		copilotURL: "https://copilot.example.test",
+		providersConfig: ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:       "local-openai",
+				Type:     "openai-compatible",
+				Default:  true,
+				BaseURL:  "https://local-openai.example.test",
+				AuthType: "none",
+				Models: []ProviderModelConfig{{
+					PublicID: "local-chat",
+				}},
+			}},
+		},
+	}
+	if err := handler.initializeProviders(); err != nil {
+		t.Fatalf("initializeProviders() error = %v", err)
+	}
+
+	setup := handler.providerSetup()
+	if setup == nil {
+		t.Fatal("providerSetup() = nil, want configured setup")
+	}
+	if !setup.hasConfiguredState {
+		t.Fatal("configured setup hasConfiguredState = false, want true")
+	}
+	if got, want := setup.defaultProviderID, "local-openai"; got != want {
+		t.Fatalf("defaultProviderID = %q, want %q", got, want)
+	}
+	if _, ok := setup.providers["copilot"]; ok {
+		t.Fatal("configured setup unexpectedly contains zero-config copilot provider")
+	}
+	model, ok := setup.lookupModel("local-chat")
+	if !ok {
+		t.Fatal("lookupModel(local-chat) = false, want configured model")
+	}
+	if got, want := model.providerID, "local-openai"; got != want {
+		t.Fatalf("model providerID = %q, want %q", got, want)
+	}
+}
+
+func BenchmarkDefaultProviderSetup(b *testing.B) {
+	handler := &ProxyHandler{copilotURL: "https://api.githubcopilot.com"}
+	if err := handler.initializeProviders(); err != nil {
+		b.Fatalf("initializeProviders() error = %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkProviderSetupSink = handler.providerSetup()
 	}
 }

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -1966,6 +1966,8 @@ const responsesInternalChatMessageMetadataPassthroughField = "internal_chat_mess
 
 var responsesInternalChatMessageMetadataPassthroughFieldBytes = []byte(responsesInternalChatMessageMetadataPassthroughField)
 
+var responsesCompactionMarkerBytes = []byte("compaction")
+
 func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *providerRuntime) ([]byte, []string) {
 	if provider == nil {
 		return bodyBytes, nil
@@ -3116,6 +3118,10 @@ func (h *ProxyHandler) maybeBuildResponsesCompactionTriggerResponse(ctx context.
 }
 
 func compactTriggerRequestFields(bodyBytes []byte) (map[string]json.RawMessage, bool, error) {
+	if !bytes.Contains(bodyBytes, responsesCompactionMarkerBytes) && !bytes.Contains(bodyBytes, []byte(`\u`)) {
+		return nil, false, nil
+	}
+
 	var requestFields map[string]json.RawMessage
 	if err := json.Unmarshal(bodyBytes, &requestFields); err != nil {
 		return nil, false, nil

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -142,6 +142,7 @@ type responsesWebSocketSession struct {
 	lastResponseID string
 	lastSignature  string
 	historyItems   []json.RawMessage
+	historyBytes   int
 	toolContexts   *ToolExecutionContextStore
 	toolScope      string
 	done           chan struct{}
@@ -157,6 +158,8 @@ type responsesWebSocketRequestPlan struct {
 	currentInput       []json.RawMessage
 	fullReplaySegments [][]json.RawMessage
 	useTurnStateDelta  bool
+	compactionChecked  bool
+	compactionTrigger  bool
 }
 
 type responsesWebSocketRequestMetrics struct {
@@ -191,11 +194,17 @@ func (p responsesWebSocketRequestPlan) historyUpdateInput() (bool, []json.RawMes
 }
 
 func (p responsesWebSocketRequestPlan) hasCompactionTrigger() bool {
+	if p.compactionChecked {
+		return p.compactionTrigger
+	}
 	return responsesInputContainsCompactionTrigger(p.currentInput)
 }
 
 func responsesInputContainsCompactionTrigger(input []json.RawMessage) bool {
 	for _, raw := range input {
+		if !bytes.Contains(raw, responsesCompactionMarkerBytes) && !bytes.Contains(raw, []byte(`\u`)) {
+			continue
+		}
 		if responsesInputItemType(raw) == "compaction_trigger" {
 			return true
 		}
@@ -697,8 +706,10 @@ func (s *responsesWebSocketSession) recordTurnStats(h *ProxyHandler, model strin
 
 func (s *responsesWebSocketSession) planRequest(h *ProxyHandler, request *responsesWebSocketCreateRequest) (responsesWebSocketRequestPlan, error) {
 	plan := responsesWebSocketRequestPlan{
-		signature:    request.signature(),
-		currentInput: request.Input,
+		signature:         request.signature(),
+		currentInput:      request.Input,
+		compactionChecked: true,
+		compactionTrigger: responsesInputContainsCompactionTrigger(request.Input),
 	}
 	if request.PreviousResponseID == "" {
 		plan.resetHistory = true
@@ -873,9 +884,11 @@ func (s *responsesWebSocketSession) rememberResponse(resetHistory bool, response
 	s.lastSignature = signature
 	if resetHistory {
 		s.historyItems = nil
+		s.historyBytes = 0
 	}
 	s.historyItems = append(s.historyItems, currentInput...)
 	s.historyItems = append(s.historyItems, outputItems...)
+	s.historyBytes += rawMessagesSize(currentInput) + rawMessagesSize(outputItems)
 }
 
 func (s *responsesWebSocketSession) rememberPlannedResponse(plan responsesWebSocketRequestPlan, responseID string, outputItems []json.RawMessage) {
@@ -904,7 +917,7 @@ func (s *responsesWebSocketSession) maybeAutoCompactHistory(h *ProxyHandler, req
 			logger.Err(err),
 			logger.F("model", request.Model),
 			logger.F("history_items", len(s.historyItems)),
-			logger.F("history_bytes", rawMessagesSize(s.historyItems)),
+			logger.F("history_bytes", s.currentHistoryBytes()),
 		)
 		return metrics
 	}
@@ -997,6 +1010,7 @@ func (s *responsesWebSocketSession) maybeRetryCompactedCreateRequest(h *ProxyHan
 		}
 
 		s.historyItems = compactedHistory
+		s.historyBytes = rawMessagesSize(compactedHistory)
 		h.log.Debug("responses websocket compacted oversized replay; retrying request",
 			logger.F("model", request.Model),
 			logger.F("previous_response_id", request.PreviousResponseID),
@@ -1056,7 +1070,7 @@ func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.
 		if !cfg.autoCompactEnabled() {
 			return result, false, nil
 		}
-		if !responsesWebSocketHistoryExceedsThreshold(s.historyItems, cfg) {
+		if !responsesWebSocketHistoryExceedsThresholdWithBytes(s.historyItems, s.currentHistoryBytes(), cfg) {
 			return result, false, nil
 		}
 	}
@@ -1074,6 +1088,7 @@ func (s *responsesWebSocketSession) compactHistory(h *ProxyHandler, ctx context.
 		return result, ok, err
 	}
 	s.historyItems = compacted
+	s.historyBytes = rawMessagesSize(compacted)
 	return result, true, nil
 }
 
@@ -1149,7 +1164,7 @@ func (s *responsesWebSocketSession) logRequestMetrics(h *ProxyHandler, request *
 		logger.F("delta_fallback", metrics.deltaFallback),
 		logger.F("auto_compacted", metrics.autoCompacted),
 		logger.F("history_items", len(s.historyItems)),
-		logger.F("history_bytes", rawMessagesSize(s.historyItems)),
+		logger.F("history_bytes", s.currentHistoryBytes()),
 		logger.F("compacted_from_items", metrics.compactedFromItems),
 		logger.F("compacted_from_bytes", metrics.compactedFromBytes),
 		logger.F("compacted_to_items", metrics.compactedToItems),
@@ -1448,16 +1463,35 @@ func responsesWebSocketMetadataHeaders(headers http.Header) map[string]interface
 }
 
 func responsesWebSocketHistoryExceedsThreshold(items []json.RawMessage, cfg ResponsesWebSocketConfig) bool {
+	return responsesWebSocketHistoryExceedsThresholdWithBytes(items, 0, cfg)
+}
+
+func responsesWebSocketHistoryExceedsThresholdWithBytes(items []json.RawMessage, historyBytes int, cfg ResponsesWebSocketConfig) bool {
 	if len(items) <= 1 {
 		return false
 	}
 	if cfg.AutoCompactMaxItems > 0 && len(items) > cfg.AutoCompactMaxItems && responsesWebSocketHistoryCanReduceItemCount(items, cfg.AutoCompactKeepTail) {
 		return true
 	}
-	if cfg.AutoCompactMaxBytes > 0 && rawMessagesSize(items) > cfg.AutoCompactMaxBytes {
-		return true
+	if cfg.AutoCompactMaxBytes > 0 {
+		if historyBytes <= 0 {
+			historyBytes = rawMessagesSize(items)
+		}
+		if historyBytes > cfg.AutoCompactMaxBytes {
+			return true
+		}
 	}
 	return false
+}
+
+func (s *responsesWebSocketSession) currentHistoryBytes() int {
+	if len(s.historyItems) == 0 {
+		return 0
+	}
+	if s.historyBytes <= 0 {
+		return rawMessagesSize(s.historyItems)
+	}
+	return s.historyBytes
 }
 
 func responsesWebSocketHistoryCanReduceItemCount(items []json.RawMessage, keepTail int) bool {

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -942,10 +942,11 @@ func (s *anthropicStreamState) finish() bool {
 }
 
 type aggregatedOpenAIChoice struct {
-	role         string
-	content      strings.Builder
-	toolCalls    map[int]*models.OpenAIToolCall
-	finishReason *string
+	role              string
+	content           strings.Builder
+	toolCalls         map[int]*models.OpenAIToolCall
+	toolCallArguments map[int]*strings.Builder
+	finishReason      *string
 }
 
 type openAIResponseAggregator struct {
@@ -1014,7 +1015,7 @@ func (a *openAIResponseAggregator) addChoice(choice models.OpenAIStreamChoice) {
 			call.Function.Name = toolCall.Function.Name
 		}
 
-		call.Function.Arguments += toolCall.Function.Arguments
+		aggChoice.appendToolCallArguments(toolIndex, toolCall.Function.Arguments)
 	}
 
 	if choice.FinishReason != nil {
@@ -1035,6 +1036,24 @@ func (a *openAIResponseAggregator) choice(index int) *aggregatedOpenAIChoice {
 	}
 	a.choicesByIndex[index] = aggChoice
 	return aggChoice
+}
+
+// appendToolCallArguments keeps streamed argument fragments out of the
+// OpenAIToolCall until build time so long tool-call argument streams do not pay
+// repeated string-concatenation copies on every delta.
+func (c *aggregatedOpenAIChoice) appendToolCallArguments(index int, arguments string) {
+	if arguments == "" {
+		return
+	}
+	if c.toolCallArguments == nil {
+		c.toolCallArguments = make(map[int]*strings.Builder)
+	}
+	builder, ok := c.toolCallArguments[index]
+	if !ok {
+		builder = &strings.Builder{}
+		c.toolCallArguments[index] = builder
+	}
+	builder.WriteString(arguments)
 }
 
 func (a *openAIResponseAggregator) buildResponse() *models.OpenAIResponse {
@@ -1075,11 +1094,14 @@ func (a *openAIResponseAggregator) buildMessage(choice *aggregatedOpenAIChoice) 
 	sort.Ints(toolIndexes)
 
 	for _, toolIndex := range toolIndexes {
-		toolCall := choice.toolCalls[toolIndex]
+		toolCall := *choice.toolCalls[toolIndex]
+		if argumentBuilder := choice.toolCallArguments[toolIndex]; argumentBuilder != nil {
+			toolCall.Function.Arguments = argumentBuilder.String()
+		}
 		if !json.Valid([]byte(toolCall.Function.Arguments)) {
 			toolCall.Function.Arguments = "{}"
 		}
-		message.ToolCalls = append(message.ToolCalls, *toolCall)
+		message.ToolCalls = append(message.ToolCalls, toolCall)
 	}
 
 	return message

--- a/proxy/streaming_bench_test.go
+++ b/proxy/streaming_bench_test.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/sozercan/vekil/models"
+)
+
+var benchmarkOpenAIResponse *models.OpenAIResponse
+
+func BenchmarkOpenAIResponseAggregatorToolCallArguments(b *testing.B) {
+	idx := 0
+	chunks := make([]models.OpenAIStreamChunk, 0, 130)
+	chunks = append(chunks, models.OpenAIStreamChunk{
+		ID:      "chatcmpl-bench-tools",
+		Object:  "chat.completion.chunk",
+		Created: 123,
+		Model:   "gpt-4o",
+		Choices: []models.OpenAIStreamChoice{{
+			Index: 0,
+			Delta: models.OpenAIMessage{Role: "assistant", ToolCalls: []models.OpenAIToolCall{{
+				ID:    "call_shell",
+				Type:  "function",
+				Index: &idx,
+				Function: models.OpenAIFunctionCall{
+					Name:      "shell_command",
+					Arguments: `{"parts":[`,
+				},
+			}}},
+		}},
+	})
+	for i := 0; i < 128; i++ {
+		fragment := strconv.Quote("arg-" + strconv.Itoa(i))
+		if i < 127 {
+			fragment += ","
+		}
+		chunks = append(chunks, models.OpenAIStreamChunk{
+			ID:      "chatcmpl-bench-tools",
+			Object:  "chat.completion.chunk",
+			Created: 123,
+			Model:   "gpt-4o",
+			Choices: []models.OpenAIStreamChoice{{
+				Index: 0,
+				Delta: models.OpenAIMessage{ToolCalls: []models.OpenAIToolCall{{
+					Index:    &idx,
+					Function: models.OpenAIFunctionCall{Arguments: fragment},
+				}}},
+			}},
+		})
+	}
+	chunks = append(chunks, models.OpenAIStreamChunk{
+		ID:      "chatcmpl-bench-tools",
+		Object:  "chat.completion.chunk",
+		Created: 123,
+		Model:   "gpt-4o",
+		Choices: []models.OpenAIStreamChoice{{
+			Index: 0,
+			Delta: models.OpenAIMessage{ToolCalls: []models.OpenAIToolCall{{
+				Index:    &idx,
+				Function: models.OpenAIFunctionCall{Arguments: `]}`},
+			}}},
+		}},
+	})
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		agg := newOpenAIResponseAggregator()
+		for _, chunk := range chunks {
+			agg.addChunk(chunk)
+		}
+		benchmarkOpenAIResponse = agg.buildResponse()
+		if got := len(benchmarkOpenAIResponse.Choices[0].Message.ToolCalls); got != 1 {
+			b.Fatalf("tool calls = %d, want 1", got)
+		}
+	}
+}

--- a/proxy/streaming_test.go
+++ b/proxy/streaming_test.go
@@ -449,6 +449,112 @@ func TestConsumeOpenAIStreamChunks_MultiLineDataEvent(t *testing.T) {
 	}
 }
 
+func TestSSEDataAccumulatorDispatchesSingleAndMultiLineData(t *testing.T) {
+	t.Run("single line", func(t *testing.T) {
+		var gotEvent, gotData string
+		acc := sseDataAccumulator{}
+		acc.consumeLine("event: chat.completion.chunk\n", func(eventType, data string) bool {
+			gotEvent, gotData = eventType, data
+			return true
+		})
+		acc.consumeLine("data: {\"id\":\"single\"}\n", func(eventType, data string) bool {
+			gotEvent, gotData = eventType, data
+			return true
+		})
+		acc.consumeLine("\n", func(eventType, data string) bool {
+			gotEvent, gotData = eventType, data
+			return true
+		})
+
+		if gotEvent != "chat.completion.chunk" {
+			t.Fatalf("eventType = %q, want chat.completion.chunk", gotEvent)
+		}
+		if gotData != `{"id":"single"}` {
+			t.Fatalf("data = %q, want single data line", gotData)
+		}
+	})
+
+	t.Run("multi line", func(t *testing.T) {
+		var gotData string
+		acc := sseDataAccumulator{}
+		acc.consumeLine("data: {\"id\":\"multi\",\n", func(_ string, data string) bool {
+			gotData = data
+			return true
+		})
+		acc.consumeLine("data: \"created\":123}\n", func(_ string, data string) bool {
+			gotData = data
+			return true
+		})
+		acc.consumeLine("\n", func(_ string, data string) bool {
+			gotData = data
+			return true
+		})
+
+		want := "{\"id\":\"multi\",\n\"created\":123}"
+		if gotData != want {
+			t.Fatalf("data = %q, want %q", gotData, want)
+		}
+	})
+}
+
+func TestParseOpenAIStreamErrorSemantics(t *testing.T) {
+	if streamErr, ok := parseOpenAIStreamError("", `{"choices":[{"delta":{"content":"error"}}]}`); ok || streamErr != nil {
+		t.Fatalf("ordinary chunk parsed as stream error: err=%#v ok=%v", streamErr, ok)
+	}
+	if streamErr, ok := parseOpenAIStreamError("", ` {"error":{"type":"rate_limit_error","code":"rate_limit_exceeded","message":"slow down"}}`); !ok || streamErr.httpStatus() != 429 || streamErr.Error() != "slow down" {
+		t.Fatalf("error envelope = (%#v, %v), want rate limit error", streamErr, ok)
+	}
+	if streamErr, ok := parseOpenAIStreamError(" error ", `{"type":"overloaded_error","message":"busy"}`); !ok || streamErr.httpStatus() != 503 || streamErr.Error() != "busy" {
+		t.Fatalf("event error = (%#v, %v), want overloaded error", streamErr, ok)
+	}
+	if streamErr, ok := parseOpenAIStreamError("error", "upstream disconnected"); !ok || streamErr.Error() != "upstream disconnected" {
+		t.Fatalf("plain event error = (%#v, %v), want sanitized message", streamErr, ok)
+	}
+}
+
+func TestOpenAIResponseAggregatorInterleavesToolCallArgumentFragments(t *testing.T) {
+	idx0, idx1 := 0, 1
+	agg := newOpenAIResponseAggregator()
+	agg.addChunk(models.OpenAIStreamChunk{
+		ID:      "chatcmpl-tools",
+		Object:  "chat.completion.chunk",
+		Created: 123,
+		Model:   "gpt-4o",
+		Choices: []models.OpenAIStreamChoice{{
+			Index: 0,
+			Delta: models.OpenAIMessage{Role: "assistant", ToolCalls: []models.OpenAIToolCall{
+				{ID: "call_0", Type: "function", Index: &idx0, Function: models.OpenAIFunctionCall{Name: "first", Arguments: `{"a":`}},
+				{ID: "call_1", Type: "function", Index: &idx1, Function: models.OpenAIFunctionCall{Name: "second", Arguments: `{"b":`}},
+			}},
+		}},
+	})
+	agg.addChunk(models.OpenAIStreamChunk{
+		ID:      "chatcmpl-tools",
+		Object:  "chat.completion.chunk",
+		Created: 123,
+		Model:   "gpt-4o",
+		Choices: []models.OpenAIStreamChoice{{
+			Index: 0,
+			Delta: models.OpenAIMessage{ToolCalls: []models.OpenAIToolCall{
+				{Index: &idx1, Function: models.OpenAIFunctionCall{Arguments: `"two"}`}},
+				{Index: &idx0, Function: models.OpenAIFunctionCall{Arguments: `"one"}`}},
+			}},
+		}},
+	})
+
+	resp := agg.buildResponse()
+	if len(resp.Choices) != 1 || len(resp.Choices[0].Message.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %#v, want two calls", resp.Choices)
+	}
+	calls := resp.Choices[0].Message.ToolCalls
+	if calls[0].Function.Arguments != `{"a":"one"}` {
+		t.Fatalf("call 0 arguments = %q", calls[0].Function.Arguments)
+	}
+	if calls[1].Function.Arguments != `{"b":"two"}` {
+		t.Fatalf("call 1 arguments = %q", calls[1].Function.Arguments)
+	}
+}
+
 func TestStreamOpenAIToAnthropic_TextOnly(t *testing.T) {
 	stop := "stop"
 	idx := 0


### PR DESCRIPTION
## Summary

- Skip unnecessary Responses compaction JSON walks on ordinary request bodies.
- Cache WebSocket compaction-trigger planning and track session history bytes incrementally.
- Cache zero-config provider setup instead of rebuilding default provider maps on hot paths.
- Reduce OpenAI SSE/chat streaming overhead for ordinary chunks and streamed tool-call arguments.
- Avoid forced Gemini upstream streaming when `tool_choice` is `none`, and make `countTokens` probes use a top-level request copy.

## Performance

- Responses WSS full-replay long-history benchmark: ~4.6x faster, ~89% lower bytes/op, ~99% fewer allocs.
- Responses WSS delta-replay long-history benchmark: ~8.4x faster, ~88% lower bytes/op, ~97% fewer allocs.
- OpenAI stream ordinary chunk error check: ~9.7x faster, zero allocations.
- Gemini countTokens probe benchmark: ~2.1x faster, ~64% lower bytes/op.

## Validation

- `git diff --check`
- `go test ./... -count=1`
- `make vet`
- `make build`
- `go run ./cmd/compaction-lab`
- `SMOKE_PROVIDER=zen PROXY_PORT=8899 PROVIDERS_CONFIG=examples/opencode-zen-free.yaml scripts/live-cli-smoke.sh`
- `PROXY_PORT=8898 scripts/live-compact-smoke.sh`
- `python3 /Users/sozercan/.codex/skills/autoreview/scripts/autoreview --mode local --parallel-tests "go test ./... -count=1"`
