### PR TITLE
feat: interpolate env vars in provider config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,31 @@ Use `--providers-config` or `PROVIDERS_CONFIG` when you need explicit ownership 
 - See [Tool Optimizers](tool-optimizers.md) for the optional `tool_optimizers` block that can live alongside `providers` in the same config file.
 - Set the optional top-level `insight_model` key to a public model ID the config serves to enable the dashboard's AI insights button. See [Traffic Dashboard](dashboard.md#ai-insights-optional).
 
+
+### Environment Variable Interpolation
+
+Provider config string fields support `${env:VAR_NAME}` interpolation after JSON/YAML parsing. Use this for host-specific URLs, API keys, or header values without hardcoding secrets into the config file:
+
+```yaml
+providers:
+  - id: azure-openai
+    type: azure-openai
+    default: true
+    base_url: ${env:AZURE_OPENAI_BASE_URL}
+    api_key: ${env:AZURE_OPENAI_API_KEY}
+    models:
+      - public_id: gpt-5.4-pro
+        deployment: ${env:AZURE_OPENAI_DEPLOYMENT}
+        endpoints: [/responses]
+
+  - id: copilot
+    type: copilot
+    exclude_models:
+      - ${env:COPILOT_EXCLUDED_MODEL}
+```
+
+If a referenced variable is unset, startup fails loudly with the field path and variable name, for example `field "providers[0].api_key" references undefined env var AZURE_OPENAI_API_KEY`. Backslash-prefix the expression (`\${env:VAR_NAME}`) to keep it literal. Non-string fields are not interpolated, and default-value syntax such as `${env:VAR:-default}` is intentionally unsupported.
+
 ## Responses WebSocket Bridge
 
 The Codex-style `GET /v1/responses` websocket bridge is disabled by default and remains a proxy-owned transport over upstream HTTP `/responses`. See [Responses WebSocket Bridge](responses-websocket.md) for websocket flags, auto-compaction settings, chunked compaction knobs, and a debug run example.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,6 @@ Use `--providers-config` or `PROVIDERS_CONFIG` when you need explicit ownership 
 - See [Tool Optimizers](tool-optimizers.md) for the optional `tool_optimizers` block that can live alongside `providers` in the same config file.
 - Set the optional top-level `insight_model` key to a public model ID the config serves to enable the dashboard's AI insights button. See [Traffic Dashboard](dashboard.md#ai-insights-optional).
 
-
 ### Environment Variable Interpolation
 
 Provider config string fields support `${env:VAR_NAME}` interpolation after JSON/YAML parsing. Use this for host-specific URLs, API keys, or header values without hardcoding secrets into the config file:

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -239,6 +240,9 @@ func LoadProvidersConfigFile(path string) (ProvidersConfig, error) {
 	if err := decodeProvidersConfigFile(path, body, &cfg); err != nil {
 		return cfg, err
 	}
+	if err := interpolateProvidersConfigEnv(&cfg); err != nil {
+		return cfg, fmt.Errorf("providers config %q: %w", path, err)
+	}
 	return cfg, nil
 }
 
@@ -258,6 +262,131 @@ func decodeProvidersConfigFile(path string, body []byte, cfg *ProvidersConfig) e
 		}
 	}
 	return nil
+}
+
+func interpolateProvidersConfigEnv(cfg *ProvidersConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	return interpolateProviderConfigValue(reflect.ValueOf(cfg).Elem(), "")
+}
+
+func interpolateProviderConfigValue(v reflect.Value, path string) error {
+	if !v.IsValid() {
+		return nil
+	}
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil
+		}
+		return interpolateProviderConfigValue(v.Elem(), path)
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldInfo := t.Field(i)
+			if fieldInfo.PkgPath != "" {
+				continue
+			}
+			fieldPath := joinProviderConfigPath(path, providerConfigFieldName(fieldInfo))
+			if err := interpolateProviderConfigValue(field, fieldPath); err != nil {
+				return err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := interpolateProviderConfigValue(v.Index(i), fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String || v.Type().Elem().Kind() != reflect.String {
+			return nil
+		}
+		for _, key := range v.MapKeys() {
+			value := v.MapIndex(key)
+			interpolated, err := interpolateProviderConfigString(value.String(), joinProviderConfigPath(path, key.String()))
+			if err != nil {
+				return err
+			}
+			v.SetMapIndex(key, reflect.ValueOf(interpolated))
+		}
+	case reflect.String:
+		if !v.CanSet() {
+			return nil
+		}
+		interpolated, err := interpolateProviderConfigString(v.String(), path)
+		if err != nil {
+			return err
+		}
+		v.SetString(interpolated)
+	}
+	return nil
+}
+
+func providerConfigFieldName(field reflect.StructField) string {
+	for _, tagName := range []string{"json", "yaml"} {
+		if tag := strings.TrimSpace(field.Tag.Get(tagName)); tag != "" {
+			name := strings.Split(tag, ",")[0]
+			if name != "" && name != "-" {
+				return name
+			}
+		}
+	}
+	return field.Name
+}
+
+func joinProviderConfigPath(parent, child string) string {
+	child = strings.TrimSpace(child)
+	if parent == "" {
+		return child
+	}
+	if child == "" {
+		return parent
+	}
+	return parent + "." + child
+}
+
+func interpolateProviderConfigString(value, fieldPath string) (string, error) {
+	if value == "" || !strings.Contains(value, "${env:") {
+		return value, nil
+	}
+	var b strings.Builder
+	for i := 0; i < len(value); {
+		if strings.HasPrefix(value[i:], `\${env:`) {
+			b.WriteString(`\${env:`)
+			i += len(`\${env:`)
+			continue
+		}
+		if !strings.HasPrefix(value[i:], `${env:`) {
+			b.WriteByte(value[i])
+			i++
+			continue
+		}
+		end := strings.IndexByte(value[i:], '}')
+		if end < 0 {
+			b.WriteByte(value[i])
+			i++
+			continue
+		}
+		end += i
+		name := strings.TrimSpace(value[i+len(`${env:`) : end])
+		if name == "" {
+			b.WriteString(value[i : end+1])
+			i = end + 1
+			continue
+		}
+		envValue, ok := os.LookupEnv(name)
+		if !ok {
+			return "", fmt.Errorf("field %q references undefined env var %s", fieldPath, name)
+		}
+		b.WriteString(envValue)
+		i = end + 1
+	}
+	return b.String(), nil
 }
 
 func (c ProvidersConfig) UsesCopilot() bool {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -1188,3 +1188,96 @@ func BenchmarkDefaultProviderSetup(b *testing.B) {
 		benchmarkProviderSetupSink = handler.providerSetup()
 	}
 }
+
+func TestLoadProvidersConfigFileInterpolatesEnvStrings(t *testing.T) {
+	t.Setenv("VEKIL_TEST_BASE_URL", "https://env.example.com/openai/v1")
+	t.Setenv("VEKIL_TEST_API_KEY", "env-key")
+	t.Setenv("VEKIL_TEST_HEADER", "header-value")
+
+	providersPath := filepath.Join(t.TempDir(), "providers.yaml")
+	body := []byte(`providers:
+  - id: azure-openai
+    type: azure-openai
+    default: true
+    base_url: ${env:VEKIL_TEST_BASE_URL}
+    api_key: ${env:VEKIL_TEST_API_KEY}
+    extra_headers:
+      X-Test-Header: prefix-${env:VEKIL_TEST_HEADER}
+    models:
+      - public_id: gpt-5.4
+        deployment: ${env:VEKIL_TEST_DEPLOYMENT}
+        endpoints:
+          - /responses
+`)
+	t.Setenv("VEKIL_TEST_DEPLOYMENT", "gpt-5.4-env")
+	if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := LoadProvidersConfigFile(providersPath)
+	if err != nil {
+		t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+	}
+	provider := cfg.Providers[0]
+	if provider.BaseURL != "https://env.example.com/openai/v1" {
+		t.Fatalf("BaseURL = %q", provider.BaseURL)
+	}
+	if provider.APIKey != "env-key" {
+		t.Fatalf("APIKey = %q", provider.APIKey)
+	}
+	if provider.ExtraHeaders["X-Test-Header"] != "prefix-header-value" {
+		t.Fatalf("extra header = %q", provider.ExtraHeaders["X-Test-Header"])
+	}
+	if provider.Models[0].Deployment != "gpt-5.4-env" {
+		t.Fatalf("deployment = %q", provider.Models[0].Deployment)
+	}
+}
+
+func TestLoadProvidersConfigFileEnvInterpolationMissingEnv(t *testing.T) {
+	providersPath := filepath.Join(t.TempDir(), "providers.json")
+	body := []byte(`{"providers":[{"id":"azure","type":"azure-openai","base_url":"${env:MISSING_VEKIL_BASE_URL}"}]}`)
+	if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := LoadProvidersConfigFile(providersPath)
+	if err == nil {
+		t.Fatal("LoadProvidersConfigFile() error = nil, want missing env error")
+	}
+	if !strings.Contains(err.Error(), `field "providers[0].base_url" references undefined env var MISSING_VEKIL_BASE_URL`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestLoadProvidersConfigFileEnvInterpolationEscapedAndNonStringNoop(t *testing.T) {
+	t.Setenv("VEKIL_TEST_DEFAULT", "false")
+	providersPath := filepath.Join(t.TempDir(), "providers.yaml")
+	body := []byte(`providers:
+  - id: literal
+    type: openai-compatible
+    default: false
+    base_url: \${env:VEKIL_TEST_BASE_URL}
+    api_key: ${env:VEKIL_TEST_API_KEY}
+    models:
+      - public_id: m
+        context_window: 12345
+`)
+	t.Setenv("VEKIL_TEST_API_KEY", "key")
+	if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := LoadProvidersConfigFile(providersPath)
+	if err != nil {
+		t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+	}
+	if cfg.Providers[0].BaseURL != `\${env:VEKIL_TEST_BASE_URL}` {
+		t.Fatalf("escaped base_url = %q", cfg.Providers[0].BaseURL)
+	}
+	if cfg.Providers[0].APIKey != "key" {
+		t.Fatalf("api_key = %q", cfg.Providers[0].APIKey)
+	}
+	if cfg.Providers[0].Models[0].ContextWindow == nil || *cfg.Providers[0].Models[0].ContextWindow != 12345 {
+		t.Fatalf("context_window = %v, want 12345", cfg.Providers[0].Models[0].ContextWindow)
+	}
+}

--- a/scripts/live-cli-smoke.sh
+++ b/scripts/live-cli-smoke.sh
@@ -166,6 +166,27 @@ read_normalized_output() {
   awk 'NF { gsub(/\r/, "", $0); printf "%s", $0 }' "$1"
 }
 
+read_gemini_normalized_output() {
+  local output_file="$1"
+  local actual
+  actual="$(read_normalized_output "${output_file}")"
+
+  # Newer Gemini CLI builds may still emit JSON-shaped chunks even with
+  # `-o text`, e.g. {"output":"LEFT"}|{"output":"RIGHT"}. Normalize that
+  # wrapper before exact matching so the smoke tests keep validating proxy
+  # translation rather than a CLI presentation detail.
+  if [[ "${actual}" == *'{"output"'* ]]; then
+    local parsed
+    parsed="$(printf '%s' "${actual}" | jq -Rr 'split("|") | map((fromjson? // {}) | .output? // empty) | select(length > 0) | join("|")' 2>/dev/null || true)"
+    if [[ -n "${parsed}" ]]; then
+      printf '%s' "${parsed}"
+      return
+    fi
+  fi
+
+  printf '%s' "${actual}"
+}
+
 start_proxy() {
   [[ -x "${PROXY_BIN}" ]] || die "proxy binary not found or not executable: ${PROXY_BIN}"
 
@@ -322,7 +343,7 @@ EOF
       > "${output_file}"
   )
 
-  actual="$(read_normalized_output "${output_file}")"
+  actual="$(read_gemini_normalized_output "${output_file}")"
   assert_exact_output "gemini" "${expected}" "${actual}"
   printf '%s' "${actual}" > "${output_file}"
 }


### PR DESCRIPTION
## Summary

- Add `${env:VAR_NAME}` interpolation for provider config string fields after JSON/YAML decoding.
- Support interpolation in nested provider/model fields and string maps such as `extra_headers`.
- Fail startup loudly when an env reference is missing, including the field path and variable name.
- Preserve escaped `\${env:VAR_NAME}` expressions as literals.
- Document interpolation in `docs/configuration.md` with Azure and Copilot examples.

Fixes #80

## Validation

- `git diff --check`
- `make test`
- `make lint`
- `golangci-lint run ./...`
- `make build`
- `go test ./proxy -run 'TestLoadProvidersConfigFileEnvInterpolation|TestLoadProvidersConfigFileInterpolatesEnvStrings' -count=1`
- `autoreview` clean

## CI smoke follow-up

While closing out this PR, the credentialed Live Copilot smoke exposed that newer Gemini CLI builds can emit JSON-shaped text even with `-o text`. This PR now includes a narrow `scripts/live-cli-smoke.sh` normalization so the smoke continues asserting the proxied content rather than failing on that CLI presentation wrapper.

