### PR TITLE
feat: add token cost accounting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ Vekil supports two runtime patterns:
 | `--host` | `HOST` | `127.0.0.1` | Listen host |
 | `--token-dir` | `TOKEN_DIR` | `~/.config/vekil` | Token storage directory |
 | `--providers-config` | `PROVIDERS_CONFIG` | unset | Path to JSON or YAML provider configuration for explicit provider routing |
+| `--prices` | `PRICES_CONFIG` | unset | Path to JSON price overrides merged onto the embedded default token-cost table |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, or `error` |
 | `--streaming-upstream-timeout` | `STREAMING_UPSTREAM_TIMEOUT` | `1h0m0s` | Timeout for streaming upstream inference requests |
 
@@ -49,6 +50,24 @@ Use `--providers-config` or `PROVIDERS_CONFIG` when you need explicit ownership 
 - See [Provider API Keys](provider-api-keys.md) for provider console links and key-to-config mapping.
 - See [Tool Optimizers](tool-optimizers.md) for the optional `tool_optimizers` block that can live alongside `providers` in the same config file.
 - Set the optional top-level `insight_model` key to a public model ID the config serves to enable the dashboard's AI insights button. See [Traffic Dashboard](dashboard.md#ai-insights-optional).
+
+
+## Price Configs
+
+Vekil ships an embedded best-effort USD price table for common public model IDs and uses it only for estimates in logs and Prometheus metrics. Token counters are emitted for every model, but `vekil_cost_usd_total{provider,public_model}` is emitted only when a price entry exists.
+
+Use `--prices` or `PRICES_CONFIG` to merge a JSON override file onto the embedded defaults:
+
+```json
+{
+  "models": {
+    "gpt-5.4": {"input_per_1k": 0.01, "output_per_1k": 0.03},
+    "my-public-model": {"input_per_1k": 0.002, "output_per_1k": 0.008}
+  }
+}
+```
+
+A flat object keyed by public model ID is also accepted. Values are USD per 1,000 prompt/input tokens and USD per 1,000 completion/output tokens. Prices are estimates and should be reviewed against provider pricing pages before financial reporting or billing automation.
 
 ## Responses WebSocket Bridge
 

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ type serveFlags struct {
 	host                            *string
 	tokenDir                        *string
 	providersConfigPath             *string
+	pricesPath                      *string
 	logLevel                        *string
 	metrics                         *bool
 	noMetrics                       *bool
@@ -243,6 +244,7 @@ func registerServeFlags(fs *flag.FlagSet) serveFlags {
 		host:                            fs.String("host", getEnv("HOST", "127.0.0.1"), "Listen host"),
 		tokenDir:                        fs.String("token-dir", getEnv("TOKEN_DIR", ""), "Token storage directory (default: ~/.config/vekil)"),
 		providersConfigPath:             fs.String("providers-config", getEnv("PROVIDERS_CONFIG", ""), "Path to JSON or YAML provider configuration"),
+		pricesPath:                      fs.String("prices", getEnv("PRICES_CONFIG", ""), "Path to JSON model price override file"),
 		logLevel:                        fs.String("log-level", getEnv("LOG_LEVEL", "info"), "Log level"),
 		metrics:                         fs.Bool("metrics", getEnvBool("METRICS", true), "Expose Prometheus metrics at /metrics"),
 		noMetrics:                       fs.Bool("no-metrics", getEnvBool("NO_METRICS", false), "Disable Prometheus metrics endpoint"),
@@ -400,6 +402,10 @@ func runServe() {
 	if err != nil {
 		log.Fatal("failed to load providers config", logger.Err(err))
 	}
+	priceCatalog, err := proxy.LoadPriceCatalogFile(*serve.pricesPath)
+	if err != nil {
+		log.Fatal("failed to load prices config", logger.Err(err))
+	}
 
 	srv, err := server.New(
 		authenticator,
@@ -416,6 +422,7 @@ func runServe() {
 		server.WithProxyOptions(
 			proxy.WithProvidersConfig(providersCfg),
 			proxy.WithDeferredDynamicProviderModelValidation(providersCfg.UsesCopilot()),
+			proxy.WithPriceCatalog(priceCatalog),
 		),
 	)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -189,6 +189,16 @@ func TestServeFlagsMetricsEnabled(t *testing.T) {
 	}
 }
 
+func TestServeFlagsPricesPath(t *testing.T) {
+	t.Setenv("PRICES_CONFIG", "/env/prices.json")
+	if got := *parseServeFlagsForTest(t).pricesPath; got != "/env/prices.json" {
+		t.Fatalf("pricesPath from env = %q", got)
+	}
+	if got := *parseServeFlagsForTest(t, "--prices", "/cli/prices.json").pricesPath; got != "/cli/prices.json" {
+		t.Fatalf("pricesPath from CLI = %q", got)
+	}
+}
+
 func TestServeFlagsResponsesWebSocketDisabledByDefault(t *testing.T) {
 	serve := parseServeFlagsForTest(t)
 	cfg := serve.responsesWebSocketConfig()

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -262,6 +262,7 @@ type ProxyHandler struct {
 	models                           modelsCache
 	geminiCounts                     geminiCountTokensCache
 	stats                            *statsCollector
+	prices                           *priceCatalog
 	insightGate                      *insightGate
 	insightGateOnce                  sync.Once
 }
@@ -343,6 +344,13 @@ func WithCopilotHeaderConfig(cfg CopilotHeaderConfig) Option {
 func WithProvidersConfig(cfg ProvidersConfig) Option {
 	return func(h *ProxyHandler) {
 		h.providersConfig = cfg
+	}
+}
+
+// WithPriceCatalog overrides the default token cost estimates used for logs and metrics.
+func WithPriceCatalog(catalog *priceCatalog) Option {
+	return func(h *ProxyHandler) {
+		h.prices = catalog
 	}
 }
 
@@ -477,6 +485,7 @@ func NewProxyHandler(a *auth.Authenticator, log *logger.Logger, opts ...Option) 
 		streamingUpstreamTimeout:        streamingUpstreamTimeout,
 		log:                             log,
 		stats:                           newStatsCollector(),
+		prices:                          defaultPriceCatalog(),
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -55,6 +55,8 @@ func (h *ProxyHandler) HandleMetrics(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintln(w, "# TYPE vekil_tokens_cached_total counter")
 	_, _ = fmt.Fprintln(w, "# HELP vekil_tokens_reasoning_total Total reasoning completion tokens by provider and public model.")
 	_, _ = fmt.Fprintln(w, "# TYPE vekil_tokens_reasoning_total counter")
+	_, _ = fmt.Fprintln(w, "# HELP vekil_cost_usd_total Estimated upstream cost in USD by provider and public model.")
+	_, _ = fmt.Fprintln(w, "# TYPE vekil_cost_usd_total counter")
 	for _, row := range snap.TokenMetrics {
 		labels := map[string]string{"provider": row.Provider, "public_model": row.Model, "direction": "prompt"}
 		componentLabels := map[string]string{"provider": row.Provider, "public_model": row.Model}
@@ -63,6 +65,9 @@ func (h *ProxyHandler) HandleMetrics(w http.ResponseWriter, r *http.Request) {
 		writePromIntMetric(w, "vekil_tokens_reported_total", componentLabels, row.TotalTokens)
 		writePromIntMetric(w, "vekil_tokens_cached_total", componentLabels, row.CachedTokens)
 		writePromIntMetric(w, "vekil_tokens_reasoning_total", componentLabels, row.ReasoningTokens)
+		if row.CostUSD > 0 {
+			writePromFloatMetric(w, "vekil_cost_usd_total", componentLabels, row.CostUSD)
+		}
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP vekil_retries_total Total upstream retry attempts.")

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -209,3 +209,58 @@ func TestHandleMetricsExportsAllRetryReasonCounters(t *testing.T) {
 		t.Fatalf("metrics body missing non-top retry reason %q:\n%s", want, body)
 	}
 }
+
+func TestHandleMetricsExportsEstimatedCost(t *testing.T) {
+	h := &ProxyHandler{stats: newStatsCollector(), prices: newPriceCatalog(map[string]PriceEntry{
+		"priced-model": {InputPer1K: 0.01, OutputPer1K: 0.02},
+	})}
+	s := newStatsRequestSummary("priced-model", "openai", "openai", 1000, 500, 1500)
+	h.RecordRequest(s, http.StatusOK, "test-agent", time.Millisecond)
+
+	w := httptest.NewRecorder()
+	h.HandleMetrics(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := w.Body.String()
+	want := `vekil_cost_usd_total{provider="openai",public_model="priced-model"} 0.02`
+	if !strings.Contains(body, want) {
+		t.Fatalf("metrics body missing %q:\n%s", want, body)
+	}
+	fields := s.LoggerFields()
+	found := false
+	for _, field := range fields {
+		if field.Key == "cost_usd" && field.Value == 0.02 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("LoggerFields missing cost_usd=0.02: %#v", fields)
+	}
+}
+
+func TestHandleMetricsOmitsCostForUnpricedModel(t *testing.T) {
+	h := &ProxyHandler{stats: newStatsCollector(), prices: newPriceCatalog(nil)}
+	s := newStatsRequestSummary("unpriced", "openai", "openai", 1000, 500, 1500)
+	h.RecordRequest(s, http.StatusOK, "test-agent", time.Millisecond)
+
+	w := httptest.NewRecorder()
+	h.HandleMetrics(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := w.Body.String()
+	if strings.Contains(body, `vekil_cost_usd_total{`) {
+		t.Fatalf("unpriced model should not emit cost metric:\n%s", body)
+	}
+}
+
+func TestRecordRequestCostUsesRawModelBeforeStatsTruncation(t *testing.T) {
+	longModel := strings.Repeat("model-", 20)
+	h := &ProxyHandler{stats: newStatsCollector(), prices: newPriceCatalog(map[string]PriceEntry{
+		longModel: {InputPer1K: 0.01, OutputPer1K: 0.02},
+	})}
+	s := newStatsRequestSummary(longModel, "openai", "openai", 1000, 500, 1500)
+	h.RecordRequest(s, http.StatusOK, "test-agent", time.Millisecond)
+	fields := s.LoggerFields()
+	for _, field := range fields {
+		if field.Key == "cost_usd" && field.Value == 0.02 {
+			return
+		}
+	}
+	t.Fatalf("LoggerFields missing cost for long raw model: %#v", fields)
+}

--- a/proxy/prices.go
+++ b/proxy/prices.go
@@ -1,0 +1,115 @@
+package proxy
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+//go:embed prices.json
+var defaultPricesFS embed.FS
+
+type PriceEntry struct {
+	InputPer1K  float64 `json:"input_per_1k"`
+	OutputPer1K float64 `json:"output_per_1k"`
+}
+
+type priceCatalog struct {
+	models map[string]PriceEntry
+}
+
+func defaultPriceCatalog() *priceCatalog {
+	body, err := defaultPricesFS.ReadFile("prices.json")
+	if err != nil {
+		return &priceCatalog{models: map[string]PriceEntry{}}
+	}
+	catalog, err := decodePriceCatalog(body)
+	if err != nil {
+		return &priceCatalog{models: map[string]PriceEntry{}}
+	}
+	return catalog
+}
+
+func LoadPriceCatalogFile(path string) (*priceCatalog, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return defaultPriceCatalog(), nil
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read prices %q: %w", path, err)
+	}
+	override, err := decodePriceCatalog(body)
+	if err != nil {
+		return nil, fmt.Errorf("decode prices %q: %w", path, err)
+	}
+	merged := defaultPriceCatalog()
+	if merged.models == nil {
+		merged.models = make(map[string]PriceEntry, len(override.models))
+	}
+	for model, price := range override.models {
+		merged.models[model] = price
+	}
+	return merged, nil
+}
+
+func decodePriceCatalog(body []byte) (*priceCatalog, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(body, &top); err != nil {
+		return nil, err
+	}
+	if rawModels, ok := top["models"]; ok {
+		var models map[string]PriceEntry
+		if err := json.Unmarshal(rawModels, &models); err != nil {
+			return nil, fmt.Errorf("decode models: %w", err)
+		}
+		return newPriceCatalog(models), nil
+	}
+	var flat map[string]PriceEntry
+	if err := json.Unmarshal(body, &flat); err != nil {
+		return nil, err
+	}
+	return newPriceCatalog(flat), nil
+}
+
+func newPriceCatalog(models map[string]PriceEntry) *priceCatalog {
+	out := make(map[string]PriceEntry, len(models))
+	for model, price := range models {
+		model = strings.TrimSpace(model)
+		if model == "" || price.InputPer1K < 0 || price.OutputPer1K < 0 {
+			continue
+		}
+		out[model] = price
+	}
+	return &priceCatalog{models: out}
+}
+
+func (c *priceCatalog) estimate(model string, promptTokens, completionTokens int) (float64, bool) {
+	if c == nil || len(c.models) == 0 || (promptTokens == 0 && completionTokens == 0) {
+		return 0, false
+	}
+	price, ok := c.lookup(model)
+	if !ok {
+		return 0, false
+	}
+	cost := float64(promptTokens)/1000*price.InputPer1K + float64(completionTokens)/1000*price.OutputPer1K
+	return cost, true
+}
+
+func (c *priceCatalog) lookup(model string) (PriceEntry, bool) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return PriceEntry{}, false
+	}
+	if price, ok := c.models[model]; ok {
+		return price, true
+	}
+	if normalized := NormalizeModelName(model); normalized != model {
+		if price, ok := c.models[normalized]; ok {
+			return price, true
+		}
+	}
+	return PriceEntry{}, false
+}

--- a/proxy/prices.json
+++ b/proxy/prices.json
@@ -1,0 +1,20 @@
+{
+  "gpt-5.5": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.4": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.4-pro": {"input_per_1k": 0.015, "output_per_1k": 0.060},
+  "gpt-5.3-codex": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.2": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.2-codex": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.1": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.1-codex": {"input_per_1k": 0.010, "output_per_1k": 0.030},
+  "gpt-5.1-codex-max": {"input_per_1k": 0.015, "output_per_1k": 0.060},
+  "gpt-5.1-codex-mini": {"input_per_1k": 0.001, "output_per_1k": 0.004},
+  "gpt-5-mini": {"input_per_1k": 0.001, "output_per_1k": 0.004},
+  "claude-sonnet-4": {"input_per_1k": 0.003, "output_per_1k": 0.015},
+  "claude-sonnet-4.5": {"input_per_1k": 0.003, "output_per_1k": 0.015},
+  "claude-sonnet-4.6": {"input_per_1k": 0.003, "output_per_1k": 0.015},
+  "claude-opus-4.6": {"input_per_1k": 0.015, "output_per_1k": 0.075},
+  "gemini-2.5-pro": {"input_per_1k": 0.00125, "output_per_1k": 0.010},
+  "gemini-2.5-flash": {"input_per_1k": 0.0003, "output_per_1k": 0.0025},
+  "gemini-3.1-pro-preview": {"input_per_1k": 0.00125, "output_per_1k": 0.010}
+}

--- a/proxy/prices_test.go
+++ b/proxy/prices_test.go
@@ -1,0 +1,67 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPriceCatalogEstimate(t *testing.T) {
+	catalog := newPriceCatalog(map[string]PriceEntry{
+		"model-a": {InputPer1K: 0.01, OutputPer1K: 0.03},
+	})
+	got, ok := catalog.estimate("model-a", 2000, 500)
+	if !ok {
+		t.Fatal("estimate ok = false, want true")
+	}
+	want := 0.035
+	if got != want {
+		t.Fatalf("estimate = %v, want %v", got, want)
+	}
+	if _, ok := catalog.estimate("missing", 2000, 500); ok {
+		t.Fatal("missing model should not produce a cost")
+	}
+}
+
+func TestLoadPriceCatalogFileMergesOverrides(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prices.json")
+	if err := os.WriteFile(path, []byte(`{"models":{"gpt-5.4":{"input_per_1k":1,"output_per_1k":2},"custom":{"input_per_1k":3,"output_per_1k":4}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	catalog, err := LoadPriceCatalogFile(path)
+	if err != nil {
+		t.Fatalf("LoadPriceCatalogFile() error = %v", err)
+	}
+	if got, ok := catalog.lookup("gpt-5.4"); !ok || got.InputPer1K != 1 || got.OutputPer1K != 2 {
+		t.Fatalf("override gpt-5.4 = %+v, ok=%v", got, ok)
+	}
+	if got, ok := catalog.lookup("custom"); !ok || got.InputPer1K != 3 || got.OutputPer1K != 4 {
+		t.Fatalf("custom = %+v, ok=%v", got, ok)
+	}
+	if _, ok := catalog.lookup("claude-sonnet-4.6"); !ok {
+		t.Fatal("default catalog entry should remain after merge")
+	}
+}
+
+func TestLoadPriceCatalogFileRejectsInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prices.json")
+	if err := os.WriteFile(path, []byte(`{not json`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	_, err := LoadPriceCatalogFile(path)
+	if err == nil || !strings.Contains(err.Error(), "decode prices") {
+		t.Fatalf("LoadPriceCatalogFile() error = %v, want decode error", err)
+	}
+}
+
+func TestLoadPriceCatalogFileRejectsMalformedWrappedEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prices.json")
+	if err := os.WriteFile(path, []byte(`{"models":{"bad":{"input_per_1k":"oops","output_per_1k":2}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	_, err := LoadPriceCatalogFile(path)
+	if err == nil || !strings.Contains(err.Error(), "decode models") {
+		t.Fatalf("LoadPriceCatalogFile() error = %v, want decode models error", err)
+	}
+}

--- a/proxy/request_summary.go
+++ b/proxy/request_summary.go
@@ -29,6 +29,7 @@ type RequestSummary struct {
 	totalTokens       *int
 	cachedTokens      *int
 	reasoningTokens   *int
+	costUSD           *float64
 	// extraPromptTokens / extraCompletionTokens accumulate out-of-band token
 	// spend that is separate from the turn's own reported usage — e.g. an
 	// internal /responses compaction call made while serving a 413 oversized-
@@ -260,6 +261,33 @@ func observeInternalResponsesUsage(ctx context.Context, usage responsesUsage) {
 	}
 }
 
+func (s *RequestSummary) costInputs() (model string, promptTokens, completionTokens int) {
+	if s == nil {
+		return "", 0, 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	model = strings.TrimSpace(s.model)
+	if s.promptTokens != nil {
+		promptTokens = *s.promptTokens
+	}
+	if s.completionTokens != nil {
+		completionTokens = *s.completionTokens
+	}
+	promptTokens += s.extraPromptTokens
+	completionTokens += s.extraCompletionTokens
+	return model, promptTokens, completionTokens
+}
+
+func (s *RequestSummary) setCostUSD(cost float64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.costUSD = &cost
+}
+
 // LoggerFields returns the structured fields populated for this request.
 func (s *RequestSummary) LoggerFields() []logger.Field {
 	if s == nil {
@@ -295,6 +323,9 @@ func (s *RequestSummary) LoggerFields() []logger.Field {
 	}
 	if s.totalTokens != nil {
 		fields = append(fields, logger.F("total_tokens", *s.totalTokens))
+	}
+	if s.costUSD != nil {
+		fields = append(fields, logger.F("cost_usd", *s.costUSD))
 	}
 	return fields
 }

--- a/proxy/responses_usage_test.go
+++ b/proxy/responses_usage_test.go
@@ -76,7 +76,7 @@ func TestRecordResponsesTurn(t *testing.T) {
 	u.InputTokensDetails.CachedTokens = 20
 	u.OutputTokensDetails.ReasoningTokens = 10
 
-	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", 200, u)
+	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", 200, u, 0)
 
 	snap := c.snapshot()
 	if snap.Totals.Requests != 1 {
@@ -103,7 +103,7 @@ func TestRecordResponsesTurn(t *testing.T) {
 	}
 	// A zero-usage turn is still counted as a request (matching the HTTP path),
 	// just with zero tokens.
-	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", 200, responsesUsage{})
+	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", 200, responsesUsage{}, 0)
 	after := c.snapshot()
 	if after.Totals.Requests != 2 {
 		t.Fatalf("zero-usage turn should still be counted: got %d requests want 2", after.Totals.Requests)
@@ -118,7 +118,7 @@ func TestRecordResponsesTurn(t *testing.T) {
 // recorded, and lands in the error counts so the dashboard reflects it.
 func TestRecordResponsesTurnCountsFailures(t *testing.T) {
 	c := newStatsCollector()
-	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", http.StatusBadGateway, responsesUsage{})
+	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", http.StatusBadGateway, responsesUsage{}, 0)
 
 	snap := c.snapshot()
 	if snap.Totals.Requests != 1 {
@@ -131,7 +131,7 @@ func TestRecordResponsesTurnCountsFailures(t *testing.T) {
 		t.Fatalf("failed turn should land in 5xx status class: got %+v", snap.Status)
 	}
 	// Default status 0 is treated as a successful (200) turn, not an error.
-	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", 0, responsesUsage{})
+	c.recordResponsesTurn("gpt-5.4-codex", "codex", "openai-codex", "Codex CLI", 0, responsesUsage{}, 0)
 	snap2 := c.snapshot()
 	if snap2.Totals.Errors != 1 {
 		t.Fatalf("status 0 should default to success, errors stayed: got %d want 1", snap2.Totals.Errors)

--- a/proxy/stats.go
+++ b/proxy/stats.go
@@ -45,13 +45,14 @@ const (
 
 // statsTotals is the cumulative session counters.
 type statsTotals struct {
-	Requests         int64 `json:"requests"`
-	Errors           int64 `json:"errors"`
-	PromptTokens     int64 `json:"prompt_tokens"`
-	CompletionTokens int64 `json:"completion_tokens"`
-	TotalTokens      int64 `json:"total_tokens"`
-	CachedTokens     int64 `json:"cached_tokens"`
-	ReasoningTokens  int64 `json:"reasoning_tokens"`
+	Requests         int64   `json:"requests"`
+	Errors           int64   `json:"errors"`
+	PromptTokens     int64   `json:"prompt_tokens"`
+	CompletionTokens int64   `json:"completion_tokens"`
+	TotalTokens      int64   `json:"total_tokens"`
+	CachedTokens     int64   `json:"cached_tokens"`
+	ReasoningTokens  int64   `json:"reasoning_tokens"`
+	CostUSD          float64 `json:"cost_usd,omitempty"`
 	// Latency percentiles in milliseconds over a bounded recent sample.
 	LatencyP50 int64 `json:"latency_p50_ms"`
 	LatencyP95 int64 `json:"latency_p95_ms"`
@@ -105,6 +106,7 @@ type statsTokenMetric struct {
 	TotalTokens      int64
 	CachedTokens     int64
 	ReasoningTokens  int64
+	CostUSD          float64
 }
 
 type statsUpstreamErrorMetric struct {
@@ -206,6 +208,7 @@ type tokenMetricCounter struct {
 	total      int64
 	cached     int64
 	reasoning  int64
+	costUSD    float64
 }
 
 type upstreamErrorMetricCounter struct {
@@ -434,7 +437,7 @@ func (c *statsCollector) record(summary *RequestSummary, status int, userAgent s
 // failed/non-200 turn) so failures show up in error counts and the recent log.
 // Streamed turns carry no latency sample. Every turn is counted as a request
 // even with zero/absent usage, matching the HTTP path.
-func (c *statsCollector) recordResponsesTurn(model, provider, kind, agentLabel string, status int, usage responsesUsage) {
+func (c *statsCollector) recordResponsesTurn(model, provider, kind, agentLabel string, status int, usage responsesUsage, costUSD float64) {
 	total := usage.TotalTokens
 	if total == 0 {
 		total = usage.InputTokens + usage.OutputTokens
@@ -450,6 +453,7 @@ func (c *statsCollector) recordResponsesTurn(model, provider, kind, agentLabel s
 		total:      total,
 		cached:     usage.InputTokensDetails.CachedTokens,
 		reasoning:  usage.OutputTokensDetails.ReasoningTokens,
+		costUSD:    costUSD,
 	}
 	agent := agentLabel
 	if agent == "" {
@@ -491,6 +495,7 @@ func (c *statsCollector) recordLocked(d summaryStats, agent string, status int, 
 	c.totals.TotalTokens += int64(d.total)
 	c.totals.CachedTokens += int64(d.cached)
 	c.totals.ReasoningTokens += int64(d.reasoning)
+	c.totals.CostUSD += d.costUSD
 
 	// Latency: only non-streaming requests carry a meaningful end-to-end
 	// duration. A streamed response (SSE chat, or a GET /v1/responses websocket
@@ -882,6 +887,7 @@ func addTokenMetric(m map[statsProviderModelKey]*tokenMetricCounter, provider, m
 	e.total += int64(d.total)
 	e.cached += int64(d.cached)
 	e.reasoning += int64(d.reasoning)
+	e.costUSD += d.costUSD
 }
 
 func addUpstreamErrorMetric(m map[statsUpstreamErrorMetricKey]*upstreamErrorMetricCounter, provider, model string, code int) {
@@ -1028,6 +1034,7 @@ func tokenMetricRows(m map[statsProviderModelKey]*tokenMetricCounter) []statsTok
 			PromptTokens:     e.prompt,
 			CompletionTokens: e.completion,
 			TotalTokens:      e.total,
+			CostUSD:          e.costUSD,
 			CachedTokens:     e.cached,
 			ReasoningTokens:  e.reasoning,
 		})
@@ -1098,6 +1105,7 @@ type summaryStats struct {
 	prompt     int
 	completion int
 	total      int
+	costUSD    float64
 	cached     int
 	reasoning  int
 }
@@ -1144,6 +1152,9 @@ func readSummaryForStats(summary *RequestSummary) summaryStats {
 	}
 	if summary.reasoningTokens != nil {
 		d.reasoning = *summary.reasoningTokens
+	}
+	if summary.costUSD != nil {
+		d.costUSD = *summary.costUSD
 	}
 	return d
 }
@@ -1379,7 +1390,19 @@ func (h *ProxyHandler) RecordRequest(summary *RequestSummary, status int, userAg
 	if h == nil || h.stats == nil {
 		return
 	}
+	h.applyRequestCost(summary)
 	h.stats.record(summary, status, userAgent, dur)
+}
+
+func (h *ProxyHandler) applyRequestCost(summary *RequestSummary) {
+	if h == nil || summary == nil {
+		return
+	}
+	model, promptTokens, completionTokens := summary.costInputs()
+	cost, ok := h.prices.estimate(model, promptTokens, completionTokens)
+	if ok {
+		summary.setCostUSD(cost)
+	}
 }
 
 // RecordResponsesTurn folds one /v1/responses websocket-bridge turn into the
@@ -1390,7 +1413,11 @@ func (h *ProxyHandler) RecordResponsesTurn(model, provider, kind, agentLabel str
 	if h == nil || h.stats == nil {
 		return
 	}
-	h.stats.recordResponsesTurn(model, provider, kind, agentLabel, status, usage)
+	cost, ok := h.prices.estimate(model, usage.InputTokens, usage.OutputTokens)
+	if !ok {
+		cost = 0
+	}
+	h.stats.recordResponsesTurn(model, provider, kind, agentLabel, status, usage, cost)
 }
 
 // HandleStatsJSON handles GET /stats.json with the current traffic snapshot.


### PR DESCRIPTION
## Summary

- Add embedded token price estimates and `--prices` / `PRICES_CONFIG` JSON overrides.
- Compute estimated `cost_usd` from observed prompt/completion tokens when a public model has a price entry.
- Add `cost_usd` to structured request logs and `vekil_cost_usd_total{provider,public_model}` Prometheus metrics.
- Preserve token metrics for unpriced models while omitting fabricated cost metrics.
- Document the price override schema and caveats.

Fixes #79

## Stacking

This PR is stacked on #241 because issue #79 depends on the Prometheus metrics work from issue #77.

## Validation

- `git diff --check`
- `make test`
- `make lint`
- `golangci-lint run ./...`
- `make build`
- focused price/catalog/metrics tests
- disposable kind smoke via `scripts/k8s-kind-smoke.sh`
- `autoreview` clean
