### PR TITLE
feat: add provider endpoint load balancing

### DIFF
--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -122,7 +122,7 @@ JSON configs use the same snake_case field names as YAML.
 
 ### Multi-Endpoint Load Balancing
 
-A provider can declare `endpoints: [...]` instead of a single `base_url`/key pair. Vekil picks a healthy endpoint for each upstream attempt, retries retryable failures (`429`, `5xx`, and transient transport errors) against another healthy endpoint of the same provider, and quarantines endpoints whose error budget is exhausted. Single-endpoint provider configs continue to behave as before.
+A provider can declare `endpoints: [...]` instead of a single `base_url`/key pair. Vekil picks a healthy endpoint for each upstream attempt, records retryable failures (`429`, `5xx`, and transient transport errors), and quarantines endpoints whose error budget is exhausted so later attempts can move to remaining healthy endpoints. Single-endpoint provider configs continue to behave as before.
 
 Selector strategies:
 

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -122,7 +122,7 @@ JSON configs use the same snake_case field names as YAML.
 
 ### Multi-Endpoint Load Balancing
 
-A provider can declare `endpoints: [...]` instead of a single `base_url`/key pair. Vekil picks a healthy endpoint for each upstream attempt, records retryable failures (`429`, `5xx`, and transient transport errors), and quarantines endpoints whose error budget is exhausted so later attempts can move to remaining healthy endpoints. Single-endpoint provider configs continue to behave as before.
+A provider can declare `endpoints: [...]` instead of a single `base_url`/key pair. Vekil picks a healthy endpoint for each upstream attempt and records retryable failures (`429`, `5xx`, and transient transport errors). Any retryable failure temporarily deprioritizes that endpoint for the configured `cooldown` window so immediate retries can move to remaining healthy endpoints; exhausting the error budget also quarantines the endpoint and resets the rolling failure counter. Single-endpoint provider configs continue to behave like ordinary retries when there is nowhere else to fail over.
 
 Selector strategies:
 

--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -120,6 +120,67 @@ providers:
 
 JSON configs use the same snake_case field names as YAML.
 
+### Multi-Endpoint Load Balancing
+
+A provider can declare `endpoints: [...]` instead of a single `base_url`/key pair. Vekil picks a healthy endpoint for each upstream attempt, retries retryable failures (`429`, `5xx`, and transient transport errors) against another healthy endpoint of the same provider, and quarantines endpoints whose error budget is exhausted. Single-endpoint provider configs continue to behave as before.
+
+Selector strategies:
+
+- `round_robin` (default) rotates across healthy endpoints.
+- `weighted` repeats endpoints by `weight` before rotating.
+- `least_latency` prefers endpoints with the lowest successful-request EWMA, probing never-used endpoints first.
+
+Endpoint health defaults to `error_budget: "10/m"` and `cooldown: 30s`. The error budget syntax is `N/{ms,s,m,h}`; for example, `2/s`, `10/m`, or `1500/h`.
+
+Azure three-region example:
+
+```yaml
+providers:
+  - id: azure-openai
+    type: azure-openai
+    default: true
+    selector: weighted
+    api_version: 2025-04-01-preview
+    endpoints:
+      - name: eastus
+        base_url: https://eastus-resource.openai.azure.com
+        api_key_env: AZURE_EASTUS_KEY
+        weight: 2
+        health:
+          error_budget: "10/m"
+          cooldown: 30s
+      - name: westus
+        base_url: https://westus-resource.openai.azure.com
+        api_key_env: AZURE_WESTUS_KEY
+        weight: 1
+      - name: centralus
+        base_url: https://centralus-resource.openai.azure.com
+        api_key_env: AZURE_CENTRALUS_KEY
+        weight: 1
+    models:
+      - public_id: gpt-5.4
+        deployment: gpt-5.4
+        endpoints:
+          - /chat/completions
+```
+
+Copilot two-account example:
+
+```yaml
+providers:
+  - id: copilot
+    type: copilot
+    default: true
+    selector: round_robin
+    endpoints:
+      - name: alice
+        api_key_env: COPILOT_ALICE_TOKEN
+      - name: bob
+        api_key_env: COPILOT_BOB_TOKEN
+```
+
+For Copilot endpoints, `api_key`/`api_key_env` override the default local Copilot token for that endpoint. If an endpoint omits a key, Vekil falls back to the normal local Copilot authentication flow.
+
 ### Generic Provider Behavior
 
 OpenAI-compatible providers route `POST /v1/chat/completions` to `chat_completions_path`. Anthropic `POST /v1/messages` requests for these models are translated through the existing OpenAI Chat Completions adapter. `POST /v1/responses` is never inferred; add `/responses` to a model only after validating the upstream model and path.
@@ -143,6 +204,13 @@ Anthropic-compatible providers directly forward Anthropic `POST /v1/messages` to
 | `messages_path` | `anthropic-compatible` | Upstream path for public `POST /v1/messages`. Defaults to `/v1/messages`. |
 | `models_path` | generic providers | Upstream path for dynamic model discovery and readiness probes. Defaults to `/models`. |
 | `model_discovery` | generic providers | `static`, `openai`, `ollama`, or `openrouter-tools`. |
+| `selector` | providers with `endpoints` | Endpoint selector: `round_robin`, `weighted`, or `least_latency`. Defaults to `round_robin`. |
+| `endpoints[].name` | providers with `endpoints` | Stable endpoint label for logs and health tracking. Auto-fills to `endpoint-N` if omitted. |
+| `endpoints[].base_url` | providers with `endpoints` | Endpoint-specific upstream origin. Defaults to provider `base_url`; Copilot defaults to the built-in Copilot API URL. |
+| `endpoints[].api_key`, `endpoints[].api_key_env` | providers with `endpoints` | Endpoint-specific credential. Defaults to provider-level key for API-key providers. |
+| `endpoints[].weight` | `weighted` selector | Relative endpoint weight; `0` behaves like `1`. |
+| `endpoints[].health.error_budget` | providers with `endpoints` | Retryable failure budget before quarantine, formatted as `N/{ms,s,m,h}`. Defaults to `10/m`. |
+| `endpoints[].health.cooldown` | providers with `endpoints` | Quarantine duration before the endpoint is eligible again. Defaults to `30s`. |
 | `models[].endpoints` | all static models | Public endpoint allowlist. This remains the source of truth for what Vekil advertises and routes. |
 
 ### Generic Provider Cookbook

--- a/proxy/endpoint_health.go
+++ b/proxy/endpoint_health.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type endpointHealthConfig struct {
+	errorBudget endpointErrorBudget
+	cooldown    time.Duration
+}
+
+type endpointErrorBudget struct {
+	Limit  int
+	Window time.Duration
+}
+
+func defaultEndpointHealthConfig() endpointHealthConfig {
+	return endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 10, Window: time.Minute}, cooldown: 30 * time.Second}
+}
+
+func parseEndpointErrorBudget(raw string) (endpointErrorBudget, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultEndpointHealthConfig().errorBudget, nil
+	}
+	parts := strings.Split(raw, "/")
+	if len(parts) != 2 {
+		return endpointErrorBudget{}, fmt.Errorf("invalid error_budget %q: expected N/{ms,s,m,h}", raw)
+	}
+	limit, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || limit <= 0 {
+		return endpointErrorBudget{}, fmt.Errorf("invalid error_budget %q: count must be positive", raw)
+	}
+	var window time.Duration
+	switch strings.TrimSpace(parts[1]) {
+	case "ms":
+		window = time.Millisecond
+	case "s":
+		window = time.Second
+	case "m":
+		window = time.Minute
+	case "h":
+		window = time.Hour
+	default:
+		return endpointErrorBudget{}, fmt.Errorf("invalid error_budget %q: unit must be one of ms,s,m,h", raw)
+	}
+	return endpointErrorBudget{Limit: limit, Window: window}, nil
+}
+
+type endpointHealthTracker struct {
+	mu               sync.Mutex
+	cfg              endpointHealthConfig
+	failures         []time.Time
+	quarantinedUntil time.Time
+	latencyEWMA      time.Duration
+}
+
+func newEndpointHealthTracker(cfg endpointHealthConfig) *endpointHealthTracker {
+	if cfg.errorBudget.Limit <= 0 || cfg.errorBudget.Window <= 0 {
+		cfg.errorBudget = defaultEndpointHealthConfig().errorBudget
+	}
+	if cfg.cooldown <= 0 {
+		cfg.cooldown = defaultEndpointHealthConfig().cooldown
+	}
+	return &endpointHealthTracker{cfg: cfg}
+}
+
+func (h *endpointHealthTracker) healthy(now time.Time) bool {
+	if h == nil {
+		return true
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.quarantinedUntil.IsZero() || !now.Before(h.quarantinedUntil)
+}
+
+func (h *endpointHealthTracker) latency() time.Duration {
+	if h == nil {
+		return 0
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.latencyEWMA
+}
+
+func (h *endpointHealthTracker) recordSuccess(latency time.Duration) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.failures = nil
+	h.quarantinedUntil = time.Time{}
+	if latency <= 0 {
+		return
+	}
+	if h.latencyEWMA <= 0 {
+		h.latencyEWMA = latency
+		return
+	}
+	h.latencyEWMA = (h.latencyEWMA*7 + latency*3) / 10
+}
+
+func (h *endpointHealthTracker) recordFailure(now time.Time) bool {
+	if h == nil {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	cutoff := now.Add(-h.cfg.errorBudget.Window)
+	kept := h.failures[:0]
+	for _, failure := range h.failures {
+		if failure.After(cutoff) {
+			kept = append(kept, failure)
+		}
+	}
+	h.failures = append(kept, now)
+	if len(h.failures) >= h.cfg.errorBudget.Limit {
+		h.quarantinedUntil = now.Add(h.cfg.cooldown)
+		h.failures = nil
+		return true
+	}
+	return false
+}

--- a/proxy/endpoint_health.go
+++ b/proxy/endpoint_health.go
@@ -123,9 +123,10 @@ func (h *endpointHealthTracker) recordFailure(now time.Time) bool {
 		}
 	}
 	h.failures = append(kept, now)
-	if h.latencyEWMA == 0 {
-		h.latencyEWMA = time.Hour
-	}
+	// Deprioritize failed endpoints for least-latency selection immediately, not
+	// only after quarantine, so retries can move to healthy siblings within the
+	// same request even when the error budget is larger than the retry count.
+	h.latencyEWMA = time.Hour
 	if len(h.failures) >= h.cfg.errorBudget.Limit {
 		h.quarantinedUntil = now.Add(h.cfg.cooldown)
 		h.failures = nil

--- a/proxy/endpoint_health.go
+++ b/proxy/endpoint_health.go
@@ -76,7 +76,22 @@ func (h *endpointHealthTracker) healthy(now time.Time) bool {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return h.quarantinedUntil.IsZero() || !now.Before(h.quarantinedUntil)
+	if !h.quarantinedUntil.IsZero() {
+		if now.Before(h.quarantinedUntil) {
+			return false
+		}
+		h.quarantinedUntil = time.Time{}
+	}
+	if !h.deprioritizedUntil.IsZero() {
+		if now.Before(h.deprioritizedUntil) {
+			return false
+		}
+		h.deprioritizedUntil = time.Time{}
+		if h.latencyEWMA >= time.Hour {
+			h.latencyEWMA = 0
+		}
+	}
+	return true
 }
 
 func (h *endpointHealthTracker) latency() time.Duration {

--- a/proxy/endpoint_health.go
+++ b/proxy/endpoint_health.go
@@ -162,3 +162,24 @@ func (h *endpointHealthTracker) recordFailure(now time.Time) bool {
 	}
 	return false
 }
+
+func (h *endpointHealthTracker) usableIgnoringPenalty(now time.Time) bool {
+	if h == nil {
+		return true
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.quarantinedUntil.IsZero() && now.Before(h.quarantinedUntil) {
+		return false
+	}
+	if !h.quarantinedUntil.IsZero() && !now.Before(h.quarantinedUntil) {
+		h.quarantinedUntil = time.Time{}
+	}
+	if !h.deprioritizedUntil.IsZero() && !now.Before(h.deprioritizedUntil) {
+		h.deprioritizedUntil = time.Time{}
+		if h.latencyEWMA >= time.Hour {
+			h.latencyEWMA = 0
+		}
+	}
+	return true
+}

--- a/proxy/endpoint_health.go
+++ b/proxy/endpoint_health.go
@@ -52,11 +52,12 @@ func parseEndpointErrorBudget(raw string) (endpointErrorBudget, error) {
 }
 
 type endpointHealthTracker struct {
-	mu               sync.Mutex
-	cfg              endpointHealthConfig
-	failures         []time.Time
-	quarantinedUntil time.Time
-	latencyEWMA      time.Duration
+	mu                 sync.Mutex
+	cfg                endpointHealthConfig
+	failures           []time.Time
+	quarantinedUntil   time.Time
+	deprioritizedUntil time.Time
+	latencyEWMA        time.Duration
 }
 
 func newEndpointHealthTracker(cfg endpointHealthConfig) *endpointHealthTracker {
@@ -84,6 +85,12 @@ func (h *endpointHealthTracker) latency() time.Duration {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if !h.deprioritizedUntil.IsZero() && !time.Now().Before(h.deprioritizedUntil) {
+		h.deprioritizedUntil = time.Time{}
+		if h.latencyEWMA >= time.Hour {
+			h.latencyEWMA = 0
+		}
+	}
 	return h.latencyEWMA
 }
 
@@ -98,6 +105,10 @@ func (h *endpointHealthTracker) recordSuccess(latency time.Duration) {
 			return
 		}
 		h.quarantinedUntil = time.Time{}
+		h.deprioritizedUntil = time.Time{}
+		if h.latencyEWMA >= time.Hour {
+			h.latencyEWMA = 0
+		}
 	}
 	if latency <= 0 {
 		return
@@ -127,8 +138,10 @@ func (h *endpointHealthTracker) recordFailure(now time.Time) bool {
 	// only after quarantine, so retries can move to healthy siblings within the
 	// same request even when the error budget is larger than the retry count.
 	h.latencyEWMA = time.Hour
+	h.deprioritizedUntil = now.Add(h.cfg.cooldown)
 	if len(h.failures) >= h.cfg.errorBudget.Limit {
 		h.quarantinedUntil = now.Add(h.cfg.cooldown)
+		h.deprioritizedUntil = h.quarantinedUntil
 		h.failures = nil
 		return true
 	}

--- a/proxy/endpoint_health.go
+++ b/proxy/endpoint_health.go
@@ -93,12 +93,16 @@ func (h *endpointHealthTracker) recordSuccess(latency time.Duration) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.failures = nil
-	h.quarantinedUntil = time.Time{}
+	if !h.quarantinedUntil.IsZero() {
+		if time.Now().Before(h.quarantinedUntil) {
+			return
+		}
+		h.quarantinedUntil = time.Time{}
+	}
 	if latency <= 0 {
 		return
 	}
-	if h.latencyEWMA <= 0 {
+	if h.latencyEWMA <= 0 || h.latencyEWMA > time.Minute {
 		h.latencyEWMA = latency
 		return
 	}
@@ -119,6 +123,9 @@ func (h *endpointHealthTracker) recordFailure(now time.Time) bool {
 		}
 	}
 	h.failures = append(kept, now)
+	if h.latencyEWMA == 0 {
+		h.latencyEWMA = time.Hour
+	}
 	if len(h.failures) >= h.cfg.errorBudget.Limit {
 		h.quarantinedUntil = now.Add(h.cfg.cooldown)
 		h.failures = nil

--- a/proxy/endpoint_health_test.go
+++ b/proxy/endpoint_health_test.go
@@ -56,3 +56,16 @@ func TestEndpointHealthSuccessDoesNotClearActiveQuarantine(t *testing.T) {
 		t.Fatal("success while cooldown is active should not clear quarantine")
 	}
 }
+
+func TestEndpointHealthFailurePenaltyExpires(t *testing.T) {
+	tracker := newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 10, Window: time.Minute}, cooldown: time.Millisecond})
+	now := time.Now()
+	tracker.recordFailure(now)
+	if got := tracker.latency(); got < time.Hour {
+		t.Fatalf("latency immediately after failure = %v, want penalty", got)
+	}
+	time.Sleep(2 * time.Millisecond)
+	if got := tracker.latency(); got != 0 {
+		t.Fatalf("latency after penalty expiry = %v, want reset probe latency", got)
+	}
+}

--- a/proxy/endpoint_health_test.go
+++ b/proxy/endpoint_health_test.go
@@ -69,3 +69,19 @@ func TestEndpointHealthFailurePenaltyExpires(t *testing.T) {
 		t.Fatalf("latency after penalty expiry = %v, want reset probe latency", got)
 	}
 }
+
+func TestEndpointHealthHealthyClearsExpiredFailurePenalty(t *testing.T) {
+	tracker := newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 10, Window: time.Minute}, cooldown: time.Millisecond})
+	now := time.Now()
+	tracker.recordFailure(now)
+	if tracker.healthy(now) {
+		t.Fatal("endpoint should be temporarily unhealthy immediately after failure")
+	}
+	time.Sleep(2 * time.Millisecond)
+	if !tracker.healthy(time.Now()) {
+		t.Fatal("endpoint should be healthy after penalty expires")
+	}
+	if got := tracker.latency(); got != 0 {
+		t.Fatalf("latency after healthy() cleared penalty = %v, want 0", got)
+	}
+}

--- a/proxy/endpoint_health_test.go
+++ b/proxy/endpoint_health_test.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseEndpointErrorBudget(t *testing.T) {
+	budget, err := parseEndpointErrorBudget("10/m")
+	if err != nil {
+		t.Fatalf("parseEndpointErrorBudget() error = %v", err)
+	}
+	if budget.Limit != 10 || budget.Window != time.Minute {
+		t.Fatalf("budget = %#v, want 10/m", budget)
+	}
+	if _, err := parseEndpointErrorBudget("0/m"); err == nil {
+		t.Fatal("parseEndpointErrorBudget(0/m) error = nil, want error")
+	}
+	if _, err := parseEndpointErrorBudget("10/day"); err == nil {
+		t.Fatal("parseEndpointErrorBudget(10/day) error = nil, want error")
+	}
+}
+
+func TestEndpointHealthQuarantineAndRelease(t *testing.T) {
+	tracker := newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 2, Window: time.Minute}, cooldown: time.Second})
+	now := time.Unix(100, 0)
+	if !tracker.healthy(now) {
+		t.Fatal("new endpoint should be healthy")
+	}
+	if quarantined := tracker.recordFailure(now); quarantined {
+		t.Fatal("first failure should not quarantine")
+	}
+	if quarantined := tracker.recordFailure(now.Add(100 * time.Millisecond)); !quarantined {
+		t.Fatal("second failure should quarantine")
+	}
+	if tracker.healthy(now.Add(500 * time.Millisecond)) {
+		t.Fatal("endpoint should be quarantined during cooldown")
+	}
+	if !tracker.healthy(now.Add(2 * time.Second)) {
+		t.Fatal("endpoint should become healthy after cooldown")
+	}
+	tracker.recordSuccess(100 * time.Millisecond)
+	if got := tracker.latency(); got != 100*time.Millisecond {
+		t.Fatalf("latency = %v, want 100ms", got)
+	}
+}

--- a/proxy/endpoint_health_test.go
+++ b/proxy/endpoint_health_test.go
@@ -44,3 +44,15 @@ func TestEndpointHealthQuarantineAndRelease(t *testing.T) {
 		t.Fatalf("latency = %v, want 100ms", got)
 	}
 }
+
+func TestEndpointHealthSuccessDoesNotClearActiveQuarantine(t *testing.T) {
+	tracker := newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 1, Window: time.Minute}, cooldown: time.Hour})
+	now := time.Now()
+	if quarantined := tracker.recordFailure(now); !quarantined {
+		t.Fatal("failure should quarantine")
+	}
+	tracker.recordSuccess(10 * time.Millisecond)
+	if tracker.healthy(now.Add(time.Second)) {
+		t.Fatal("success while cooldown is active should not clear quarantine")
+	}
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -802,7 +802,7 @@ func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *pr
 
 	switch provider.kind {
 	case providerTypeCopilot:
-		if providerHasEndpointCredentials(provider) {
+		if len(provider.endpoints) > 0 {
 			req, err := h.newProviderJSONRequest(contextWithNonInteractiveAuth(ctx), provider, http.MethodGet, "/models", nil, nil, "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create provider %q probe request: %w", provider.id, err)

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -801,6 +801,13 @@ func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *pr
 
 	switch provider.kind {
 	case providerTypeCopilot:
+		if providerHasEndpointCredentials(provider) {
+			req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to create provider %q probe request: %w", provider.id, err)
+			}
+			return req, nil
+		}
 		token, err := h.auth.GetTokenNonInteractive(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get token for provider %q: %w", provider.id, err)

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -759,12 +759,13 @@ func (h *ProxyHandler) checkProviderReady(ctx context.Context, provider *provide
 		return nil
 	}
 
-	req, err := h.newProviderProbeRequest(ctx, provider)
-	if err != nil {
-		return err
-	}
-
-	resp, err := h.client.Do(req)
+	resp, err := h.doWithRetry(func() (*http.Request, error) {
+		req, err := h.newProviderProbeRequest(ctx, provider)
+		if err != nil {
+			return nil, err
+		}
+		return req, nil
+	})
 	if err != nil {
 		return fmt.Errorf("provider %q upstream probe failed: %w", provider.id, err)
 	}
@@ -802,7 +803,7 @@ func (h *ProxyHandler) newProviderProbeRequest(ctx context.Context, provider *pr
 	switch provider.kind {
 	case providerTypeCopilot:
 		if providerHasEndpointCredentials(provider) {
-			req, err := h.newProviderJSONRequest(ctx, provider, http.MethodGet, "/models", nil, nil, "")
+			req, err := h.newProviderJSONRequest(contextWithNonInteractiveAuth(ctx), provider, http.MethodGet, "/models", nil, nil, "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create provider %q probe request: %w", provider.id, err)
 			}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -238,7 +238,7 @@ func TestHandleReadyz(t *testing.T) {
 		if result["status"] != "not_ready" {
 			t.Fatalf("expected status not_ready, got %q", result["status"])
 		}
-		if !strings.Contains(result["error"], "upstream probe returned 503") {
+		if !strings.Contains(result["error"], "upstream probe failed") {
 			t.Fatalf("unexpected error message: %q", result["error"])
 		}
 	})

--- a/proxy/provider_endpoints_test.go
+++ b/proxy/provider_endpoints_test.go
@@ -210,3 +210,171 @@ func TestCopilotEndpointOverridesToken(t *testing.T) {
 		}
 	}
 }
+
+func TestProviderEndpointKeysDefaultToBearerAuth(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:      "multi",
+		Type:    "openai-compatible",
+		Default: true,
+		Endpoints: []ProviderEndpointConfig{{
+			Name:    "east",
+			BaseURL: "https://east.example.test/v1",
+			APIKey:  "east-key",
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-test", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["multi"]
+	if provider.authType != providerAuthTypeBearer {
+		t.Fatalf("authType = %q, want bearer", provider.authType)
+	}
+	req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, []byte(`{"model":"gpt-test"}`), nil, "")
+	if err != nil {
+		t.Fatalf("newProviderJSONRequest() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer east-key" {
+		t.Fatalf("Authorization = %q, want endpoint bearer", got)
+	}
+}
+
+func TestAzureEndpointOnlyOpenAIV1DoesNotRequireAPIVersion(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:      "azure",
+		Type:    "azure-openai",
+		Default: true,
+		Endpoints: []ProviderEndpointConfig{{
+			Name:    "east",
+			BaseURL: "https://east.openai.azure.com/openai/v1",
+			APIKey:  "east-key",
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-deployment", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["azure"]
+	req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, []byte(`{"model":"gpt-public"}`), nil, "", provider.staticModels["gpt-public"])
+	if err != nil {
+		t.Fatalf("newProviderJSONRequest() error = %v", err)
+	}
+	if got := req.URL.String(); got != "https://east.openai.azure.com/openai/v1/chat/completions" {
+		t.Fatalf("URL = %q, want Azure v1 chat path", got)
+	}
+	body, _ := io.ReadAll(req.Body)
+	if got := extractRequestModel(body); got != "gpt-deployment" {
+		t.Fatalf("body model = %q, want deployment rewrite", got)
+	}
+}
+
+func TestAzureMixedEndpointShapesRewritePerSelectedEndpoint(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:         "azure",
+		Type:       "azure-openai",
+		Default:    true,
+		APIVersion: "2025-04-01-preview",
+		Endpoints: []ProviderEndpointConfig{
+			{Name: "classic", BaseURL: "https://classic.openai.azure.com", APIKey: "classic-key"},
+			{Name: "v1", BaseURL: "https://v1.openai.azure.com/openai/v1", APIKey: "v1-key"},
+		},
+		Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-deployment", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["azure"]
+	owner := provider.staticModels["gpt-public"]
+	classicReq, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, []byte(`{"model":"gpt-public"}`), nil, "", owner)
+	if err != nil {
+		t.Fatalf("classic newProviderJSONRequest() error = %v", err)
+	}
+	classicBody, _ := io.ReadAll(classicReq.Body)
+	if got := extractRequestModel(classicBody); got != "gpt-public" {
+		t.Fatalf("classic body model = %q, want public model", got)
+	}
+	if !strings.Contains(classicReq.URL.String(), "/deployments/gpt-deployment/chat/completions") {
+		t.Fatalf("classic URL = %q, want deployment path", classicReq.URL.String())
+	}
+	v1Req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, []byte(`{"model":"gpt-public"}`), nil, "", owner)
+	if err != nil {
+		t.Fatalf("v1 newProviderJSONRequest() error = %v", err)
+	}
+	v1Body, _ := io.ReadAll(v1Req.Body)
+	if got := extractRequestModel(v1Body); got != "gpt-deployment" {
+		t.Fatalf("v1 body model = %q, want deployment rewrite", got)
+	}
+	if got := v1Req.URL.String(); got != "https://v1.openai.azure.com/openai/v1/chat/completions" {
+		t.Fatalf("v1 URL = %q", got)
+	}
+}
+
+func TestCopilotReadyzProbeUsesEndpointToken(t *testing.T) {
+	handler := &ProxyHandler{auth: auth.NewTestAuthenticator("default-token"), copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:        "copilot",
+		Type:      "copilot",
+		Default:   true,
+		Endpoints: []ProviderEndpointConfig{{Name: "alice", APIKey: "alice-token"}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	req, err := handler.newProviderProbeRequest(context.Background(), providers["copilot"])
+	if err != nil {
+		t.Fatalf("newProviderProbeRequest() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer alice-token" {
+		t.Fatalf("Authorization = %q, want endpoint token", got)
+	}
+}
+
+func TestLeastLatencyRotatesAfterRetryableFailure(t *testing.T) {
+	var eastHits atomic.Int32
+	east := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		eastHits.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer east.Close()
+	var westHits atomic.Int32
+	west := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		westHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer west.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID:       "multi",
+			Type:     "openai-compatible",
+			Default:  true,
+			AuthType: "none",
+			Selector: "least_latency",
+			Endpoints: []ProviderEndpointConfig{
+				{Name: "east", BaseURL: east.URL},
+				{Name: "west", BaseURL: west.URL},
+			},
+			Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-upstream", Endpoints: []string{providerEndpointChatCompletions}}},
+		}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 2
+	handler.retryBaseDelay = time.Millisecond
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-public","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if eastHits.Load() != 1 || westHits.Load() != 1 {
+		t.Fatalf("hits east/west = %d/%d, want one retry failover to west", eastHits.Load(), westHits.Load())
+	}
+}

--- a/proxy/provider_endpoints_test.go
+++ b/proxy/provider_endpoints_test.go
@@ -467,3 +467,52 @@ func TestCopilotReadyzUsesNonInteractiveAuthForUnkeyedEndpoint(t *testing.T) {
 		t.Fatalf("Authorization = %q, want non-interactive default token", got)
 	}
 }
+
+func TestLeastLatencyRotatesAfterPreviouslyFastEndpointFails(t *testing.T) {
+	var eastHits atomic.Int32
+	east := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		eastHits.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer east.Close()
+	var westHits atomic.Int32
+	west := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		westHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer west.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID:       "multi",
+			Type:     "openai-compatible",
+			Default:  true,
+			AuthType: "none",
+			Selector: "least_latency",
+			Endpoints: []ProviderEndpointConfig{
+				{Name: "east", BaseURL: east.URL},
+				{Name: "west", BaseURL: west.URL},
+			},
+			Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-upstream", Endpoints: []string{providerEndpointChatCompletions}}},
+		}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 2
+	handler.retryBaseDelay = time.Millisecond
+	provider := handler.providerSetup().providerByID("multi")
+	provider.endpointByName["east"].health.recordSuccess(time.Millisecond)
+	provider.endpointByName["west"].health.recordSuccess(20 * time.Millisecond)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-public","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if eastHits.Load() != 1 || westHits.Load() != 1 {
+		t.Fatalf("hits east/west = %d/%d, want failover from previously-fast east to west", eastHits.Load(), westHits.Load())
+	}
+}

--- a/proxy/provider_endpoints_test.go
+++ b/proxy/provider_endpoints_test.go
@@ -516,3 +516,90 @@ func TestLeastLatencyRotatesAfterPreviouslyFastEndpointFails(t *testing.T) {
 		t.Fatalf("hits east/west = %d/%d, want failover from previously-fast east to west", eastHits.Load(), westHits.Load())
 	}
 }
+
+func TestAzureIdentityRejectsEndpointAPIKeys(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test", azureIdentityTokenSourceFactory: (&recordingAzureIdentityFactory{}).factory}
+	_, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:       "azure",
+		Type:     "azure-openai",
+		Default:  true,
+		AuthMode: "azure_identity",
+		BaseURL:  "https://example.openai.azure.com/openai/v1",
+		Endpoints: []ProviderEndpointConfig{{
+			Name:   "east",
+			APIKey: "should-not-be-used",
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-deployment", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("buildProviders() error = %v, want endpoint key rejection", err)
+	}
+}
+
+func TestOpenAICodexEndpointsUseDefaultBaseURL(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:             "codex",
+		Type:           "openai-codex",
+		Default:        true,
+		ModelDiscovery: "static",
+		Endpoints: []ProviderEndpointConfig{{
+			Name: "default",
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-5.5", Endpoints: []string{providerEndpointResponses}}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	if got := providers["codex"].endpoints[0].endpoint.BaseURL; got != defaultOpenAICodexBaseURL {
+		t.Fatalf("codex endpoint baseURL = %q, want default", got)
+	}
+}
+
+func TestEndpointHealthDeprioritizationMakesEndpointTemporarilyUnhealthy(t *testing.T) {
+	tracker := newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 10, Window: time.Minute}, cooldown: time.Millisecond})
+	now := time.Now()
+	tracker.recordSuccess(time.Millisecond)
+	tracker.recordFailure(now)
+	if tracker.healthy(now) {
+		t.Fatal("endpoint should be temporarily unhealthy during failure penalty")
+	}
+	time.Sleep(2 * time.Millisecond)
+	if !tracker.healthy(time.Now()) {
+		t.Fatal("endpoint should recover after failure penalty")
+	}
+}
+
+func TestEndpointHealthCountsPlain500Failure(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID:        "multi",
+			Type:      "openai-compatible",
+			Default:   true,
+			AuthType:  "none",
+			Endpoints: []ProviderEndpointConfig{{Name: "east", BaseURL: upstream.URL, Health: ProviderEndpointHealthConfig{ErrorBudget: "1/m", Cooldown: "1h"}}},
+			Models:    []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-upstream", Endpoints: []string{providerEndpointChatCompletions}}},
+		}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-public","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	provider := handler.providerSetup().providerByID("multi")
+	if provider.endpointByName["east"].health.healthy(time.Now()) {
+		t.Fatal("plain 500 should count against health and quarantine endpoint")
+	}
+}

--- a/proxy/provider_endpoints_test.go
+++ b/proxy/provider_endpoints_test.go
@@ -1,0 +1,212 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
+)
+
+func TestProviderEndpointsWeightedSelectionAndEndpointKeys(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:       "multi",
+		Type:     "openai-compatible",
+		Default:  true,
+		Selector: "weighted",
+		AuthType: "bearer",
+		Endpoints: []ProviderEndpointConfig{
+			{Name: "east", BaseURL: "https://east.example.test/v1", APIKey: "east-key", Weight: 2},
+			{Name: "west", BaseURL: "https://west.example.test/v1", APIKey: "west-key", Weight: 1},
+		},
+		Models: []ProviderModelConfig{{PublicID: "gpt-test", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["multi"]
+	if provider == nil || len(provider.endpoints) != 2 || provider.selectorName != "weighted" {
+		t.Fatalf("provider endpoints = %#v selector=%q, want two weighted endpoints", provider, provider.selectorName)
+	}
+
+	var gotURLs []string
+	var gotAuth []string
+	for range 3 {
+		req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, []byte(`{"model":"gpt-test"}`), nil, "")
+		if err != nil {
+			t.Fatalf("newProviderJSONRequest() error = %v", err)
+		}
+		gotURLs = append(gotURLs, req.URL.String())
+		gotAuth = append(gotAuth, req.Header.Get("Authorization"))
+	}
+	wantURLs := []string{
+		"https://east.example.test/v1/chat/completions",
+		"https://east.example.test/v1/chat/completions",
+		"https://west.example.test/v1/chat/completions",
+	}
+	for i := range wantURLs {
+		if gotURLs[i] != wantURLs[i] {
+			t.Fatalf("request URLs = %v, want %v", gotURLs, wantURLs)
+		}
+	}
+	wantAuth := []string{"Bearer east-key", "Bearer east-key", "Bearer west-key"}
+	for i := range wantAuth {
+		if gotAuth[i] != wantAuth[i] {
+			t.Fatalf("auth headers = %v, want %v", gotAuth, wantAuth)
+		}
+	}
+}
+
+func TestProviderEndpointHealthSkipsQuarantinedEndpoint(t *testing.T) {
+	var eastHits atomic.Int32
+	east := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		eastHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer east.Close()
+
+	var westHits atomic.Int32
+	west := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		westHits.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if got := strings.Trim(string(payload["model"]), `"`); got != "gpt-upstream" {
+			t.Fatalf("upstream model = %q, want gpt-upstream", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer west.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID:       "multi",
+			Type:     "openai-compatible",
+			Default:  true,
+			AuthType: "none",
+			Endpoints: []ProviderEndpointConfig{
+				{Name: "east", BaseURL: east.URL, Health: ProviderEndpointHealthConfig{ErrorBudget: "1/m", Cooldown: "1h"}},
+				{Name: "west", BaseURL: west.URL, Health: ProviderEndpointHealthConfig{ErrorBudget: "1/m", Cooldown: "1h"}},
+			},
+			Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-upstream", Endpoints: []string{providerEndpointChatCompletions}}},
+		}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 2
+	handler.retryBaseDelay = time.Millisecond
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-public","messages":[{"role":"user","content":"hi"}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.HandleOpenAIChatCompletions(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, body = %s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	if got := eastHits.Load(); got != 1 {
+		t.Fatalf("east hits = %d, want exactly one quarantining hit", got)
+	}
+	if got := westHits.Load(); got != 2 {
+		t.Fatalf("west hits = %d, want both successful requests", got)
+	}
+}
+
+func TestProviderEndpointsYAMLConfig(t *testing.T) {
+	providersPath := t.TempDir() + "/providers.yaml"
+	body := []byte(`providers:
+  - id: azure
+    type: azure-openai
+    default: true
+    selector: least_latency
+    api_version: 2025-04-01-preview
+    endpoints:
+      - name: east
+        base_url: https://east.openai.azure.com
+        api_key: east-key
+        weight: 2
+        health:
+          error_budget: "2/s"
+          cooldown: 5s
+      - name: west
+        base_url: https://west.openai.azure.com
+        api_key: west-key
+    models:
+      - public_id: gpt-test
+        deployment: gpt-test
+        endpoints: [/chat/completions]
+`)
+	if err := os.WriteFile(providersPath, body, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	cfg, err := LoadProvidersConfigFile(providersPath)
+	if err != nil {
+		t.Fatalf("LoadProvidersConfigFile() error = %v", err)
+	}
+	if got := cfg.Providers[0].Selector; got != "least_latency" {
+		t.Fatalf("selector = %q, want least_latency", got)
+	}
+	if got := len(cfg.Providers[0].Endpoints); got != 2 {
+		t.Fatalf("endpoints = %d, want 2", got)
+	}
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(cfg)
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["azure"]
+	if provider == nil || len(provider.endpoints) != 2 || provider.selectorName != "least_latency" {
+		t.Fatalf("provider endpoints = %#v selector=%q", provider, provider.selectorName)
+	}
+}
+
+func TestCopilotEndpointOverridesToken(t *testing.T) {
+	handler := &ProxyHandler{auth: auth.NewTestAuthenticator("default-token"), copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:       "copilot",
+		Type:     "copilot",
+		Default:  true,
+		Selector: "round_robin",
+		Endpoints: []ProviderEndpointConfig{
+			{Name: "alice", APIKey: "alice-token"},
+			{Name: "bob", APIKey: "bob-token"},
+		},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["copilot"]
+	var got []string
+	for range 2 {
+		req, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodGet, "/models", nil, nil, "")
+		if err != nil {
+			t.Fatalf("newProviderJSONRequest() error = %v", err)
+		}
+		got = append(got, req.Header.Get("Authorization"))
+	}
+	want := []string{"Bearer alice-token", "Bearer bob-token"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Authorization headers = %v, want %v", got, want)
+		}
+	}
+}

--- a/proxy/provider_endpoints_test.go
+++ b/proxy/provider_endpoints_test.go
@@ -181,7 +181,7 @@ func TestProviderEndpointsYAMLConfig(t *testing.T) {
 }
 
 func TestCopilotEndpointOverridesToken(t *testing.T) {
-	handler := &ProxyHandler{auth: auth.NewTestAuthenticator("default-token"), copilotURL: "https://copilot.example.test"}
+	handler := &ProxyHandler{auth: auth.NewTestAuthenticator("default-token"), client: http.DefaultClient, copilotURL: "https://copilot.example.test"}
 	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
 		ID:       "copilot",
 		Type:     "copilot",
@@ -601,5 +601,80 @@ func TestEndpointHealthCountsPlain500Failure(t *testing.T) {
 	provider := handler.providerSetup().providerByID("multi")
 	if provider.endpointByName["east"].health.healthy(time.Now()) {
 		t.Fatal("plain 500 should count against health and quarantine endpoint")
+	}
+}
+
+func TestEndpointSelectionFallsBackToOnlyPenalizedEndpoint(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:       "single",
+		Type:     "openai-compatible",
+		Default:  true,
+		AuthType: "none",
+		Endpoints: []ProviderEndpointConfig{{
+			Name:    "only",
+			BaseURL: "https://only.example.test/v1",
+			Health:  ProviderEndpointHealthConfig{ErrorBudget: "10/m", Cooldown: "1h"},
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-upstream", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["single"]
+	provider.endpointByName["only"].health.recordFailure(time.Now())
+	endpoint, err := provider.pickEndpoint()
+	if err != nil {
+		t.Fatalf("pickEndpoint() error = %v, want last-resort penalized endpoint", err)
+	}
+	if endpoint.endpoint.Name != "only" {
+		t.Fatalf("endpoint = %q, want only", endpoint.endpoint.Name)
+	}
+}
+
+func TestCopilotReadyzUsesEndpointBaseURLWithoutEndpointToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer default-token" {
+			t.Fatalf("Authorization = %q, want default token", got)
+		}
+		if got := r.URL.Path; got != "/models" {
+			t.Fatalf("path = %q, want /models", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer upstream.Close()
+	handler := &ProxyHandler{auth: auth.NewTestAuthenticator("default-token"), client: http.DefaultClient, copilotURL: "https://copilot.example.test"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:      "copilot",
+		Type:    "copilot",
+		Default: true,
+		Endpoints: []ProviderEndpointConfig{{
+			Name:    "custom",
+			BaseURL: upstream.URL,
+		}},
+	}}})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	if err := handler.checkProviderReady(context.Background(), providers["copilot"]); err != nil {
+		t.Fatalf("checkProviderReady() error = %v", err)
+	}
+}
+
+func TestOpenAICodexRejectsEndpointAPIKeys(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	_, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:      "codex",
+		Type:    "openai-codex",
+		Default: true,
+		Endpoints: []ProviderEndpointConfig{{
+			Name:   "bad-key",
+			APIKey: "ignored",
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-5.5", Endpoints: []string{providerEndpointResponses}}},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "does not support api_key") {
+		t.Fatalf("buildProviders() error = %v, want Codex endpoint key rejection", err)
 	}
 }

--- a/proxy/provider_endpoints_test.go
+++ b/proxy/provider_endpoints_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
+	"github.com/sozercan/vekil/proxy/selector"
 )
 
 func TestProviderEndpointsWeightedSelectionAndEndpointKeys(t *testing.T) {
@@ -376,5 +377,93 @@ func TestLeastLatencyRotatesAfterRetryableFailure(t *testing.T) {
 	}
 	if eastHits.Load() != 1 || westHits.Load() != 1 {
 		t.Fatalf("hits east/west = %d/%d, want one retry failover to west", eastHits.Load(), westHits.Load())
+	}
+}
+
+func TestAzureEndpointOverrideRequiresAPIVersionWhenNotOpenAIV1(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	_, _, _, err := handler.buildProviders(ProvidersConfig{Providers: []ProviderConfig{{
+		ID:      "azure",
+		Type:    "azure-openai",
+		Default: true,
+		BaseURL: "https://default.openai.azure.com/openai/v1",
+		Endpoints: []ProviderEndpointConfig{{
+			Name:    "classic",
+			BaseURL: "https://classic.openai.azure.com",
+			APIKey:  "classic-key",
+		}},
+		Models: []ProviderModelConfig{{PublicID: "gpt-public", Deployment: "gpt-deployment", Endpoints: []string{providerEndpointChatCompletions}}},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "api_version is required") {
+		t.Fatalf("buildProviders() error = %v, want api_version validation error", err)
+	}
+}
+
+func TestReadyzRetriesEndpointProbeToHealthySibling(t *testing.T) {
+	var eastHits atomic.Int32
+	east := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		eastHits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer east.Close()
+	var westHits atomic.Int32
+	west := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		westHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer west.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID:             "dynamic",
+			Type:           "openai-compatible",
+			Default:        true,
+			AuthType:       "none",
+			ModelDiscovery: "openai",
+			Selector:       "least_latency",
+			Endpoints: []ProviderEndpointConfig{
+				{Name: "east", BaseURL: east.URL},
+				{Name: "west", BaseURL: west.URL},
+			},
+		}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 2
+	handler.retryBaseDelay = time.Millisecond
+	w := httptest.NewRecorder()
+	handler.HandleReadyz(w, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("readyz status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if eastHits.Load() != 1 || westHits.Load() != 1 {
+		t.Fatalf("probe hits east/west = %d/%d, want failover 1/1", eastHits.Load(), westHits.Load())
+	}
+}
+
+func TestCopilotReadyzUsesNonInteractiveAuthForUnkeyedEndpoint(t *testing.T) {
+	handler := &ProxyHandler{auth: auth.NewTestAuthenticator("default-token"), copilotURL: "https://copilot.example.test"}
+	provider := &providerRuntime{
+		id:             "copilot",
+		kind:           providerTypeCopilot,
+		baseURL:        "https://copilot.example.test",
+		paths:          providerEndpointPolicyFor(providerTypeCopilot).defaultEndpointPaths(),
+		staticModels:   map[string]providerModel{},
+		endpointByName: map[string]*providerEndpointRuntime{},
+		selector:       selector.NewRoundRobin(),
+	}
+	provider.endpoints = []*providerEndpointRuntime{
+		{endpoint: selector.Endpoint{Name: "unkeyed", BaseURL: "https://copilot.example.test", Healthy: true}, health: newEndpointHealthTracker(defaultEndpointHealthConfig())},
+	}
+	provider.endpointByName["unkeyed"] = provider.endpoints[0]
+	req, err := handler.newProviderProbeRequest(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("newProviderProbeRequest() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer default-token" {
+		t.Fatalf("Authorization = %q, want non-interactive default token", got)
 	}
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -762,7 +762,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 	}
 
 	endpointCfg := cfg
-	if kind == providerTypeCopilot && strings.TrimSpace(endpointCfg.BaseURL) == "" {
+	if (kind == providerTypeCopilot || kind == providerTypeOpenAICodex) && strings.TrimSpace(endpointCfg.BaseURL) == "" {
 		endpointCfg.BaseURL = runtime.baseURL
 	}
 	endpoints, endpointByName, endpointSelector, selectorName, err := buildProviderEndpointRuntimes(id, kind, endpointCfg)
@@ -2394,6 +2394,9 @@ func buildProviderEndpointRuntimes(providerID string, kind providerType, cfg Pro
 		}
 		if err := validateEndpointBaseURL(providerID, name, kind, baseURL); err != nil {
 			return nil, nil, nil, "", err
+		}
+		if kind == providerTypeAzureOpenAI && providerAuthMode(strings.TrimSpace(cfg.AuthMode)) == providerAuthModeAzureIdentity && (strings.TrimSpace(raw.APIKey) != "" || strings.TrimSpace(raw.APIKeyEnv) != "") {
+			return nil, nil, nil, "", fmt.Errorf("provider %q endpoint %q auth_mode %q cannot be combined with api_key or api_key_env", providerID, name, providerAuthModeAzureIdentity)
 		}
 		apiKey := strings.TrimSpace(raw.APIKey)
 		if apiKey == "" && strings.TrimSpace(raw.APIKeyEnv) != "" {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -2492,7 +2492,23 @@ func (p *providerRuntime) pickEndpoint() (*providerEndpointRuntime, error) {
 	}
 	selected, err := p.selector.Pick(views)
 	if err != nil {
-		return nil, &providerRequestError{statusCode: http.StatusServiceUnavailable, err: fmt.Errorf("provider %q has no healthy endpoints", p.id)}
+		fallbackViews := make([]*selector.Endpoint, 0, len(p.endpoints))
+		for _, endpoint := range p.endpoints {
+			if endpoint == nil || (endpoint.health != nil && !endpoint.health.usableIgnoringPenalty(now)) {
+				continue
+			}
+			view := endpoint.endpoint
+			view.Healthy = true
+			view.LatencyEWMA = endpoint.health.latency()
+			fallbackViews = append(fallbackViews, &view)
+		}
+		if len(fallbackViews) == 0 {
+			return nil, &providerRequestError{statusCode: http.StatusServiceUnavailable, err: fmt.Errorf("provider %q has no healthy endpoints", p.id)}
+		}
+		selected, err = p.selector.Pick(fallbackViews)
+		if err != nil {
+			return nil, &providerRequestError{statusCode: http.StatusServiceUnavailable, err: fmt.Errorf("provider %q has no healthy endpoints", p.id)}
+		}
 	}
 	endpoint := p.endpointByName[selected.Name]
 	if endpoint == nil {
@@ -2513,6 +2529,10 @@ func validateProviderEndpointAuth(provider *providerRuntime) error {
 		case providerTypeAzureOpenAI:
 			if provider.azureAuthMode() == providerAuthModeAPIKey && strings.TrimSpace(endpoint.apiKey) == "" {
 				return fmt.Errorf("provider %q endpoint %q must set api_key or api_key_env", provider.id, endpoint.endpoint.Name)
+			}
+		case providerTypeOpenAICodex:
+			if strings.TrimSpace(endpoint.apiKey) != "" {
+				return fmt.Errorf("provider %q endpoint %q does not support api_key or api_key_env; Codex uses CODEX_HOME/auth.json", provider.id, endpoint.endpoint.Name)
 			}
 		case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
 			if provider.authType != providerAuthTypeNone && strings.TrimSpace(endpoint.apiKey) == "" {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -12,7 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/sozercan/vekil/proxy/selector"
 	"gopkg.in/yaml.v3"
 )
 
@@ -92,7 +94,25 @@ type ProviderConfig struct {
 	ModelsPath          string                      `json:"models_path,omitempty" yaml:"models_path,omitempty"`
 	ModelDiscovery      string                      `json:"model_discovery,omitempty" yaml:"model_discovery,omitempty"`
 	Headers             CopilotHeaderProfilesConfig `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Selector            string                      `json:"selector,omitempty" yaml:"selector,omitempty"`
+	Endpoints           []ProviderEndpointConfig    `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 	Models              []ProviderModelConfig       `json:"models,omitempty" yaml:"models,omitempty"`
+}
+
+// ProviderEndpointConfig configures one upstream endpoint/key under a provider.
+type ProviderEndpointConfig struct {
+	Name      string                       `json:"name" yaml:"name"`
+	BaseURL   string                       `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	APIKey    string                       `json:"api_key,omitempty" yaml:"api_key,omitempty"`
+	APIKeyEnv string                       `json:"api_key_env,omitempty" yaml:"api_key_env,omitempty"`
+	Weight    uint                         `json:"weight,omitempty" yaml:"weight,omitempty"`
+	Health    ProviderEndpointHealthConfig `json:"health,omitempty" yaml:"health,omitempty"`
+}
+
+// ProviderEndpointHealthConfig controls endpoint quarantine after retryable failures.
+type ProviderEndpointHealthConfig struct {
+	ErrorBudget string `json:"error_budget,omitempty" yaml:"error_budget,omitempty"`
+	Cooldown    string `json:"cooldown,omitempty" yaml:"cooldown,omitempty"`
 }
 
 // ProviderModelConfig maps a public model ID exposed by this proxy to the
@@ -134,6 +154,16 @@ type providerRuntime struct {
 	staticOrder    []string
 	codexAuth      *openAICodexAuth
 	headerProfiles CopilotHeaderProfilesConfig
+	endpoints      []*providerEndpointRuntime
+	endpointByName map[string]*providerEndpointRuntime
+	selectorName   string
+	selector       selector.Selector
+}
+
+type providerEndpointRuntime struct {
+	endpoint selector.Endpoint
+	apiKey   string
+	health   *endpointHealthTracker
 }
 
 type providerEndpointPaths struct {
@@ -608,20 +638,24 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		runtime.headerProfiles = cfg.Headers
 	case providerTypeAzureOpenAI:
 		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+		baseKind := azureBaseURLKindInvalid
 		if baseURL == "" {
-			return nil, fmt.Errorf("provider %q must set base_url", id)
-		}
-		baseKind := classifyAzureBaseURL(baseURL)
-		switch baseKind {
-		case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI, azureBaseURLKindResourceRoot:
-		case azureBaseURLKindModels:
-			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: Microsoft Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", id, baseURL)
-		default:
-			return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected an absolute URL whose path ends in /openai/v1 or /openai, or is the Azure OpenAI resource root, with no query string or fragment", id, baseURL)
+			if len(cfg.Endpoints) == 0 {
+				return nil, fmt.Errorf("provider %q must set base_url", id)
+			}
+		} else {
+			baseKind = classifyAzureBaseURL(baseURL)
+			switch baseKind {
+			case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI, azureBaseURLKindResourceRoot:
+			case azureBaseURLKindModels:
+				return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: Microsoft Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", id, baseURL)
+			default:
+				return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: expected an absolute URL whose path ends in /openai/v1 or /openai, or is the Azure OpenAI resource root, with no query string or fragment", id, baseURL)
+			}
 		}
 		runtime.baseURL = baseURL
 		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
-		if runtime.apiVersion == "" && baseKind != azureBaseURLKindOpenAIV1 {
+		if runtime.apiVersion == "" && (baseURL == "" || baseKind != azureBaseURLKindOpenAIV1) {
 			return nil, fmt.Errorf("provider %q api_version is required for Azure base_url %q unless the path ends in /openai/v1", id, baseURL)
 		}
 
@@ -639,7 +673,7 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 			if runtime.apiKey == "" && strings.TrimSpace(cfg.APIKeyEnv) != "" {
 				runtime.apiKey = strings.TrimSpace(os.Getenv(strings.TrimSpace(cfg.APIKeyEnv)))
 			}
-			if runtime.apiKey == "" {
+			if runtime.apiKey == "" && len(cfg.Endpoints) == 0 {
 				return nil, fmt.Errorf("provider %q must set api_key or api_key_env", id)
 			}
 		case providerAuthModeAzureIdentity:
@@ -686,9 +720,10 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
 		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
 		if baseURL == "" {
-			return nil, fmt.Errorf("provider %q must set base_url", id)
-		}
-		if err := validateGenericProviderBaseURL(id, string(kind), baseURL); err != nil {
+			if len(cfg.Endpoints) == 0 {
+				return nil, fmt.Errorf("provider %q must set base_url", id)
+			}
+		} else if err := validateGenericProviderBaseURL(id, string(kind), baseURL); err != nil {
 			return nil, err
 		}
 		paths, err := configuredProviderEndpointPaths(kind, cfg)
@@ -723,6 +758,22 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		if err := addStaticProviderModels(runtime, cfg.Models, runtime.defaultStaticModelEndpoints()); err != nil {
 			return nil, err
 		}
+	}
+
+	endpointCfg := cfg
+	if kind == providerTypeCopilot && strings.TrimSpace(endpointCfg.BaseURL) == "" {
+		endpointCfg.BaseURL = runtime.baseURL
+	}
+	endpoints, endpointByName, endpointSelector, selectorName, err := buildProviderEndpointRuntimes(id, kind, endpointCfg)
+	if err != nil {
+		return nil, err
+	}
+	runtime.endpoints = endpoints
+	runtime.endpointByName = endpointByName
+	runtime.selector = endpointSelector
+	runtime.selectorName = selectorName
+	if err := validateProviderEndpointAuth(runtime); err != nil {
+		return nil, err
 	}
 
 	return runtime, nil
@@ -806,7 +857,7 @@ func configuredGenericProviderAuth(cfg ProviderConfig) (providerAuthType, string
 	case providerAuthTypeNone:
 		return authType, "", "", apiKey, nil
 	case providerAuthTypeBearer:
-		if apiKey == "" {
+		if apiKey == "" && len(cfg.Endpoints) == 0 {
 			return "", "", "", "", fmt.Errorf("auth_type bearer requires api_key or api_key_env")
 		}
 		if authHeader == "" {
@@ -816,7 +867,7 @@ func configuredGenericProviderAuth(cfg ProviderConfig) (providerAuthType, string
 			authPrefix = "Bearer"
 		}
 	case providerAuthTypeAPIKeyHeader:
-		if apiKey == "" {
+		if apiKey == "" && len(cfg.Endpoints) == 0 {
 			return "", "", "", "", fmt.Errorf("auth_type api-key-header requires api_key or api_key_env")
 		}
 		if authHeader == "" {
@@ -1193,11 +1244,18 @@ func rewriteRequestModelForProvider(body []byte, upstreamModel string) ([]byte, 
 }
 
 func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string, extraQuery string, owners ...providerModel) (string, error) {
+	return h.providerRequestURLForEndpoint(provider, nil, path, extraQuery, owners...)
+}
+
+func (h *ProxyHandler) providerRequestURLForEndpoint(provider *providerRuntime, endpoint *providerEndpointRuntime, path string, extraQuery string, owners ...providerModel) (string, error) {
 	if provider == nil {
 		return "", fmt.Errorf("provider is required")
 	}
 
 	baseURL := strings.TrimRight(provider.baseURL, "/")
+	if endpoint != nil && strings.TrimSpace(endpoint.endpoint.BaseURL) != "" {
+		baseURL = strings.TrimRight(strings.TrimSpace(endpoint.endpoint.BaseURL), "/")
+	}
 	upstreamPath := provider.upstreamPath(path)
 	if upstreamPath == "" {
 		return "", fmt.Errorf("provider %q has no upstream path configured for %s", provider.id, path)
@@ -1244,7 +1302,11 @@ func providerUsesAzureClassicDeploymentPath(provider *providerRuntime, endpoint 
 	if provider == nil || provider.kind != providerTypeAzureOpenAI || endpoint != providerEndpointChatCompletions {
 		return false
 	}
-	baseKind := classifyAzureBaseURL(provider.baseURL)
+	baseURL := provider.baseURL
+	if baseURL == "" && len(provider.endpoints) > 0 && provider.endpoints[0] != nil {
+		baseURL = provider.endpoints[0].endpoint.BaseURL
+	}
+	baseKind := classifyAzureBaseURL(baseURL)
 	return baseKind == azureBaseURLKindLegacyOpenAI || baseKind == azureBaseURLKindResourceRoot
 }
 
@@ -1346,25 +1408,29 @@ func appendRawQuery(rawURL, rawQuery string) string {
 	return rawURL + separator + rawQuery
 }
 
-func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *providerRuntime, endpoint string) error {
+func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *providerRuntime, routeEndpoint string, selectedEndpoint *providerEndpointRuntime) error {
 	if provider == nil {
 		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
 	}
 
 	switch provider.kind {
 	case providerTypeCopilot:
-		token, err := h.auth.GetToken(req.Context())
-		if err != nil {
-			return &providerRequestError{statusCode: http.StatusInternalServerError, err: err}
+		token := providerAPIKey(provider, selectedEndpoint)
+		if token == "" {
+			var err error
+			token, err = h.auth.GetToken(req.Context())
+			if err != nil {
+				return &providerRequestError{statusCode: http.StatusInternalServerError, err: err}
+			}
 		}
-		h.setCopilotHeadersForProvider(req, token, provider, endpoint)
+		h.setCopilotHeadersForProvider(req, token, provider, routeEndpoint)
 	case providerTypeAzureOpenAI:
 		clearCopilotHeaders(req.Header)
 		mergeHeaderValues(req.Header, provider.extraHeaders)
 		req.Header.Del("api-key")
 		switch provider.azureAuthMode() {
 		case providerAuthModeAPIKey:
-			req.Header.Set("api-key", provider.apiKey)
+			req.Header.Set("api-key", providerAPIKey(provider, selectedEndpoint))
 		case providerAuthModeAzureIdentity:
 			if provider.azureToken == nil {
 				return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no Azure identity token source configured", provider.id)}
@@ -1398,7 +1464,7 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
 		clearCopilotHeaders(req.Header)
 		mergeHeaderValues(req.Header, provider.extraHeaders)
-		if err := applyGenericProviderAuth(req, provider); err != nil {
+		if err := applyGenericProviderAuth(req, provider, selectedEndpoint); err != nil {
 			return err
 		}
 		if req.Method != http.MethodGet {
@@ -1410,19 +1476,19 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 	return nil
 }
 
-func applyGenericProviderAuth(req *http.Request, provider *providerRuntime) error {
+func applyGenericProviderAuth(req *http.Request, provider *providerRuntime, endpoint *providerEndpointRuntime) error {
 	switch provider.authType {
 	case providerAuthTypeNone, "":
 		return nil
 	case providerAuthTypeBearer, providerAuthTypeAPIKeyHeader:
-		if strings.TrimSpace(provider.apiKey) == "" {
+		if providerAPIKey(provider, endpoint) == "" {
 			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no API key configured", provider.id)}
 		}
 		header := strings.TrimSpace(provider.authHeader)
 		if header == "" {
 			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no auth header configured", provider.id)}
 		}
-		value := provider.apiKey
+		value := providerAPIKey(provider, endpoint)
 		if prefix := strings.TrimSpace(provider.authPrefix); prefix != "" {
 			value = prefix + " " + value
 		}
@@ -1434,10 +1500,15 @@ func applyGenericProviderAuth(req *http.Request, provider *providerRuntime) erro
 }
 
 func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, owners ...providerModel) (*http.Request, error) {
-	fullURL, err := h.providerRequestURL(provider, path, extraQuery, owners...)
+	selectedEndpoint, err := provider.pickEndpoint()
 	if err != nil {
 		return nil, err
 	}
+	fullURL, err := h.providerRequestURLForEndpoint(provider, selectedEndpoint, path, extraQuery, owners...)
+	if err != nil {
+		return nil, err
+	}
+	ctx = contextWithProviderEndpoint(ctx, selectedEndpoint)
 
 	var bodyReader io.Reader
 	if len(body) > 0 {
@@ -1451,7 +1522,7 @@ func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *pro
 	if len(extraHeaders) > 0 {
 		mergeHeaderValues(req.Header, extraHeaders)
 	}
-	if err := h.applyProviderHeaders(req, provider, path); err != nil {
+	if err := h.applyProviderHeaders(req, provider, path, selectedEndpoint); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -2268,4 +2339,196 @@ func mergeProviderModelRaw(raw json.RawMessage, supportedEndpoints []string) jso
 		return append(json.RawMessage(nil), raw...)
 	}
 	return merged
+}
+
+func buildProviderEndpointRuntimes(providerID string, kind providerType, cfg ProviderConfig) ([]*providerEndpointRuntime, map[string]*providerEndpointRuntime, selector.Selector, string, error) {
+	if len(cfg.Endpoints) == 0 {
+		return nil, nil, nil, "", nil
+	}
+	selectorName := strings.TrimSpace(cfg.Selector)
+	if selectorName == "" {
+		selectorName = "round_robin"
+	}
+	selected, err := newProviderEndpointSelector(selectorName)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("provider %q: %w", providerID, err)
+	}
+	endpoints := make([]*providerEndpointRuntime, 0, len(cfg.Endpoints))
+	byName := make(map[string]*providerEndpointRuntime, len(cfg.Endpoints))
+	for i, raw := range cfg.Endpoints {
+		name := strings.TrimSpace(raw.Name)
+		if name == "" {
+			name = fmt.Sprintf("endpoint-%d", i+1)
+		}
+		if _, exists := byName[name]; exists {
+			return nil, nil, nil, "", fmt.Errorf("provider %q has duplicate endpoint name %q", providerID, name)
+		}
+		baseURL := strings.TrimRight(strings.TrimSpace(raw.BaseURL), "/")
+		if baseURL == "" {
+			baseURL = strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+		}
+		if baseURL == "" {
+			return nil, nil, nil, "", fmt.Errorf("provider %q endpoint %q must set base_url", providerID, name)
+		}
+		if err := validateEndpointBaseURL(providerID, name, kind, baseURL); err != nil {
+			return nil, nil, nil, "", err
+		}
+		apiKey := strings.TrimSpace(raw.APIKey)
+		if apiKey == "" && strings.TrimSpace(raw.APIKeyEnv) != "" {
+			apiKey = strings.TrimSpace(os.Getenv(strings.TrimSpace(raw.APIKeyEnv)))
+			if apiKey == "" {
+				return nil, nil, nil, "", fmt.Errorf("provider %q endpoint %q api_key_env %q is not set or is empty", providerID, name, strings.TrimSpace(raw.APIKeyEnv))
+			}
+		}
+		if apiKey == "" {
+			apiKey = strings.TrimSpace(cfg.APIKey)
+			if apiKey == "" && strings.TrimSpace(cfg.APIKeyEnv) != "" {
+				apiKey = strings.TrimSpace(os.Getenv(strings.TrimSpace(cfg.APIKeyEnv)))
+			}
+		}
+		healthCfg, err := buildEndpointHealthConfig(raw.Health)
+		if err != nil {
+			return nil, nil, nil, "", fmt.Errorf("provider %q endpoint %q: %w", providerID, name, err)
+		}
+		runtime := &providerEndpointRuntime{
+			endpoint: selector.Endpoint{Name: name, BaseURL: baseURL, Key: apiKey, Weight: raw.Weight, Healthy: true},
+			apiKey:   apiKey,
+			health:   newEndpointHealthTracker(healthCfg),
+		}
+		endpoints = append(endpoints, runtime)
+		byName[name] = runtime
+	}
+	return endpoints, byName, selected, selectorName, nil
+}
+
+func validateEndpointBaseURL(providerID, endpointName string, kind providerType, baseURL string) error {
+	switch kind {
+	case providerTypeAzureOpenAI:
+		baseKind := classifyAzureBaseURL(baseURL)
+		switch baseKind {
+		case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI, azureBaseURLKindResourceRoot:
+			return nil
+		case azureBaseURLKindModels:
+			return fmt.Errorf("provider %q endpoint %q has unsupported Azure base_url %q: Microsoft Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", providerID, endpointName, baseURL)
+		default:
+			return fmt.Errorf("provider %q endpoint %q has unsupported Azure base_url %q: expected an absolute URL whose path ends in /openai/v1 or /openai, or is the Azure OpenAI resource root, with no query string or fragment", providerID, endpointName, baseURL)
+		}
+	case providerTypeOpenAICompatible, providerTypeAnthropicCompatible, providerTypeOpenAICodex:
+		return validateGenericProviderBaseURL(providerID, string(kind), baseURL)
+	default:
+		return nil
+	}
+}
+
+func buildEndpointHealthConfig(raw ProviderEndpointHealthConfig) (endpointHealthConfig, error) {
+	cfg := defaultEndpointHealthConfig()
+	budget, err := parseEndpointErrorBudget(raw.ErrorBudget)
+	if err != nil {
+		return endpointHealthConfig{}, err
+	}
+	cfg.errorBudget = budget
+	if strings.TrimSpace(raw.Cooldown) != "" {
+		cooldown, err := time.ParseDuration(strings.TrimSpace(raw.Cooldown))
+		if err != nil || cooldown <= 0 {
+			return endpointHealthConfig{}, fmt.Errorf("invalid cooldown %q: expected positive duration", raw.Cooldown)
+		}
+		cfg.cooldown = cooldown
+	}
+	return cfg, nil
+}
+
+func newProviderEndpointSelector(name string) (selector.Selector, error) {
+	switch strings.TrimSpace(name) {
+	case "", "round_robin", "round-robin":
+		return selector.NewRoundRobin(), nil
+	case "weighted":
+		return selector.NewWeighted(), nil
+	case "least_latency", "least-latency":
+		return selector.NewLeastLatency(), nil
+	default:
+		return nil, fmt.Errorf("unsupported selector %q", name)
+	}
+}
+
+func (p *providerRuntime) pickEndpoint() (*providerEndpointRuntime, error) {
+	if p == nil || len(p.endpoints) == 0 {
+		return nil, nil
+	}
+	views := make([]*selector.Endpoint, 0, len(p.endpoints))
+	now := time.Now()
+	for _, endpoint := range p.endpoints {
+		if endpoint == nil {
+			continue
+		}
+		view := endpoint.endpoint
+		view.Healthy = endpoint.health == nil || endpoint.health.healthy(now)
+		view.LatencyEWMA = endpoint.health.latency()
+		views = append(views, &view)
+	}
+	selected, err := p.selector.Pick(views)
+	if err != nil {
+		return nil, &providerRequestError{statusCode: http.StatusServiceUnavailable, err: fmt.Errorf("provider %q has no healthy endpoints", p.id)}
+	}
+	endpoint := p.endpointByName[selected.Name]
+	if endpoint == nil {
+		return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q selected unknown endpoint %q", p.id, selected.Name)}
+	}
+	return endpoint, nil
+}
+
+func validateProviderEndpointAuth(provider *providerRuntime) error {
+	if provider == nil || len(provider.endpoints) == 0 {
+		return nil
+	}
+	for _, endpoint := range provider.endpoints {
+		if endpoint == nil {
+			continue
+		}
+		switch provider.kind {
+		case providerTypeAzureOpenAI:
+			if provider.azureAuthMode() == providerAuthModeAPIKey && strings.TrimSpace(endpoint.apiKey) == "" {
+				return fmt.Errorf("provider %q endpoint %q must set api_key or api_key_env", provider.id, endpoint.endpoint.Name)
+			}
+		case providerTypeOpenAICompatible, providerTypeAnthropicCompatible:
+			if provider.authType != providerAuthTypeNone && strings.TrimSpace(endpoint.apiKey) == "" {
+				return fmt.Errorf("provider %q endpoint %q must set api_key or api_key_env", provider.id, endpoint.endpoint.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func providerAPIKey(provider *providerRuntime, endpoint *providerEndpointRuntime) string {
+	if endpoint != nil && strings.TrimSpace(endpoint.apiKey) != "" {
+		return strings.TrimSpace(endpoint.apiKey)
+	}
+	if provider == nil {
+		return ""
+	}
+	return strings.TrimSpace(provider.apiKey)
+}
+
+type providerEndpointContextKey struct{}
+
+func contextWithProviderEndpoint(ctx context.Context, endpoint *providerEndpointRuntime) context.Context {
+	if endpoint == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, providerEndpointContextKey{}, endpoint)
+}
+
+func providerEndpointFromContext(ctx context.Context) *providerEndpointRuntime {
+	if ctx == nil {
+		return nil
+	}
+	endpoint, _ := ctx.Value(providerEndpointContextKey{}).(*providerEndpointRuntime)
+	return endpoint
+}
+
+func providerEndpointNameFromContext(ctx context.Context) string {
+	endpoint := providerEndpointFromContext(ctx)
+	if endpoint == nil {
+		return ""
+	}
+	return endpoint.endpoint.Name
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -638,14 +638,12 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		runtime.headerProfiles = cfg.Headers
 	case providerTypeAzureOpenAI:
 		baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
-		baseKind := azureBaseURLKindInvalid
 		if baseURL == "" {
 			if len(cfg.Endpoints) == 0 {
 				return nil, fmt.Errorf("provider %q must set base_url", id)
 			}
 		} else {
-			baseKind = classifyAzureBaseURL(baseURL)
-			switch baseKind {
+			switch baseKind := classifyAzureBaseURL(baseURL); baseKind {
 			case azureBaseURLKindOpenAIV1, azureBaseURLKindLegacyOpenAI, azureBaseURLKindResourceRoot:
 			case azureBaseURLKindModels:
 				return nil, fmt.Errorf("provider %q has unsupported Azure base_url %q: Microsoft Foundry /models inference endpoints are not supported; use the OpenAI-compatible endpoint ending in /openai/v1 instead", id, baseURL)

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -2604,18 +2604,6 @@ func azureEndpointConfigsAllOpenAIV1WithDefault(defaultBaseURL string, endpoints
 	return true
 }
 
-func providerHasEndpointCredentials(provider *providerRuntime) bool {
-	if provider == nil {
-		return false
-	}
-	for _, endpoint := range provider.endpoints {
-		if endpoint != nil && strings.TrimSpace(endpoint.apiKey) != "" {
-			return true
-		}
-	}
-	return false
-}
-
 type nonInteractiveAuthContextKey struct{}
 
 func contextWithNonInteractiveAuth(ctx context.Context) context.Context {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -655,8 +655,14 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		}
 		runtime.baseURL = baseURL
 		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
-		if runtime.apiVersion == "" && (baseURL == "" || baseKind != azureBaseURLKindOpenAIV1) {
-			return nil, fmt.Errorf("provider %q api_version is required for Azure base_url %q unless the path ends in /openai/v1", id, baseURL)
+		if runtime.apiVersion == "" {
+			if baseURL != "" {
+				if baseKind != azureBaseURLKindOpenAIV1 {
+					return nil, fmt.Errorf("provider %q api_version is required for Azure base_url %q unless the path ends in /openai/v1", id, baseURL)
+				}
+			} else if !azureEndpointConfigsAllOpenAIV1(cfg.Endpoints) {
+				return nil, fmt.Errorf("provider %q api_version is required unless every endpoint base_url ends in /openai/v1", id)
+			}
 		}
 
 		authMode := providerAuthMode(strings.TrimSpace(cfg.AuthMode))
@@ -843,7 +849,7 @@ func configuredGenericProviderAuth(cfg ProviderConfig) (providerAuthType, string
 
 	authType := providerAuthType(strings.TrimSpace(cfg.AuthType))
 	if authType == "" {
-		if apiKey == "" {
+		if apiKey == "" && !providerConfigHasEndpointCredentials(cfg) {
 			authType = providerAuthTypeNone
 		} else {
 			authType = providerAuthTypeBearer
@@ -1299,11 +1305,17 @@ func azureClassicOpenAIBaseURL(baseURL string, baseKind azureBaseURLKind) string
 }
 
 func providerUsesAzureClassicDeploymentPath(provider *providerRuntime, endpoint string) bool {
+	return providerUsesAzureClassicDeploymentPathForEndpoint(provider, nil, endpoint)
+}
+
+func providerUsesAzureClassicDeploymentPathForEndpoint(provider *providerRuntime, selectedEndpoint *providerEndpointRuntime, endpoint string) bool {
 	if provider == nil || provider.kind != providerTypeAzureOpenAI || endpoint != providerEndpointChatCompletions {
 		return false
 	}
 	baseURL := provider.baseURL
-	if baseURL == "" && len(provider.endpoints) > 0 && provider.endpoints[0] != nil {
+	if selectedEndpoint != nil && strings.TrimSpace(selectedEndpoint.endpoint.BaseURL) != "" {
+		baseURL = selectedEndpoint.endpoint.BaseURL
+	} else if baseURL == "" && len(provider.endpoints) > 0 && provider.endpoints[0] != nil {
 		baseURL = provider.endpoints[0].endpoint.BaseURL
 	}
 	baseKind := classifyAzureBaseURL(baseURL)
@@ -1509,6 +1521,17 @@ func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *pro
 		return nil, err
 	}
 	ctx = contextWithProviderEndpoint(ctx, selectedEndpoint)
+
+	if len(body) > 0 && provider != nil && provider.kind == providerTypeAzureOpenAI && len(provider.endpoints) > 0 && len(owners) > 0 {
+		owner := owners[0]
+		if !providerUsesAzureClassicDeploymentPathForEndpoint(provider, selectedEndpoint, path) {
+			var rewriteErr error
+			body, _, rewriteErr = rewriteRequestModelForProvider(body, owner.upstreamModel)
+			if rewriteErr != nil {
+				return nil, &providerRequestError{statusCode: http.StatusBadRequest, err: rewriteErr}
+			}
+		}
+	}
 
 	var bodyReader io.Reader
 	if len(body) > 0 {
@@ -2531,4 +2554,38 @@ func providerEndpointNameFromContext(ctx context.Context) string {
 		return ""
 	}
 	return endpoint.endpoint.Name
+}
+
+func providerConfigHasEndpointCredentials(cfg ProviderConfig) bool {
+	for _, endpoint := range cfg.Endpoints {
+		if strings.TrimSpace(endpoint.APIKey) != "" || strings.TrimSpace(endpoint.APIKeyEnv) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func azureEndpointConfigsAllOpenAIV1(endpoints []ProviderEndpointConfig) bool {
+	if len(endpoints) == 0 {
+		return false
+	}
+	for _, endpoint := range endpoints {
+		baseURL := strings.TrimRight(strings.TrimSpace(endpoint.BaseURL), "/")
+		if baseURL == "" || classifyAzureBaseURL(baseURL) != azureBaseURLKindOpenAIV1 {
+			return false
+		}
+	}
+	return true
+}
+
+func providerHasEndpointCredentials(provider *providerRuntime) bool {
+	if provider == nil {
+		return false
+	}
+	for _, endpoint := range provider.endpoints {
+		if endpoint != nil && strings.TrimSpace(endpoint.apiKey) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -1519,7 +1519,7 @@ func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *pro
 	if err != nil {
 		return nil, err
 	}
-	ctx = contextWithProviderEndpoint(ctx, selectedEndpoint)
+	ctx = contextWithProviderEndpoint(ctx, selectedEndpoint, len(provider.endpoints))
 
 	if len(body) > 0 && provider != nil && provider.kind == providerTypeAzureOpenAI && len(provider.endpoints) > 0 && len(owners) > 0 {
 		owner := owners[0]
@@ -2554,12 +2554,17 @@ func providerAPIKey(provider *providerRuntime, endpoint *providerEndpointRuntime
 }
 
 type providerEndpointContextKey struct{}
+type providerEndpointCountContextKey struct{}
 
-func contextWithProviderEndpoint(ctx context.Context, endpoint *providerEndpointRuntime) context.Context {
+func contextWithProviderEndpoint(ctx context.Context, endpoint *providerEndpointRuntime, count int) context.Context {
 	if endpoint == nil {
 		return ctx
 	}
-	return context.WithValue(ctx, providerEndpointContextKey{}, endpoint)
+	ctx = context.WithValue(ctx, providerEndpointContextKey{}, endpoint)
+	if count > 0 {
+		ctx = context.WithValue(ctx, providerEndpointCountContextKey{}, count)
+	}
+	return ctx
 }
 
 func providerEndpointFromContext(ctx context.Context) *providerEndpointRuntime {
@@ -2568,6 +2573,14 @@ func providerEndpointFromContext(ctx context.Context) *providerEndpointRuntime {
 	}
 	endpoint, _ := ctx.Value(providerEndpointContextKey{}).(*providerEndpointRuntime)
 	return endpoint
+}
+
+func providerEndpointCountFromContext(ctx context.Context) int {
+	if ctx == nil {
+		return 0
+	}
+	count, _ := ctx.Value(providerEndpointCountContextKey{}).(int)
+	return count
 }
 
 func providerEndpointNameFromContext(ctx context.Context) string {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -655,14 +655,11 @@ func buildProviderRuntime(cfg ProviderConfig, defaultCopilotURL string, azureIde
 		}
 		runtime.baseURL = baseURL
 		runtime.apiVersion = strings.TrimSpace(cfg.APIVersion)
-		if runtime.apiVersion == "" {
-			if baseURL != "" {
-				if baseKind != azureBaseURLKindOpenAIV1 {
-					return nil, fmt.Errorf("provider %q api_version is required for Azure base_url %q unless the path ends in /openai/v1", id, baseURL)
-				}
-			} else if !azureEndpointConfigsAllOpenAIV1(cfg.Endpoints) {
-				return nil, fmt.Errorf("provider %q api_version is required unless every endpoint base_url ends in /openai/v1", id)
+		if runtime.apiVersion == "" && !azureEndpointConfigsAllOpenAIV1WithDefault(baseURL, cfg.Endpoints) {
+			if baseURL != "" && len(cfg.Endpoints) == 0 {
+				return nil, fmt.Errorf("provider %q api_version is required for Azure base_url %q unless the path ends in /openai/v1", id, baseURL)
 			}
+			return nil, fmt.Errorf("provider %q api_version is required unless every effective endpoint base_url ends in /openai/v1", id)
 		}
 
 		authMode := providerAuthMode(strings.TrimSpace(cfg.AuthMode))
@@ -1430,7 +1427,11 @@ func (h *ProxyHandler) applyProviderHeaders(req *http.Request, provider *provide
 		token := providerAPIKey(provider, selectedEndpoint)
 		if token == "" {
 			var err error
-			token, err = h.auth.GetToken(req.Context())
+			if nonInteractiveAuthFromContext(req.Context()) {
+				token, err = h.auth.GetTokenNonInteractive(req.Context())
+			} else {
+				token, err = h.auth.GetToken(req.Context())
+			}
 			if err != nil {
 				return &providerRequestError{statusCode: http.StatusInternalServerError, err: err}
 			}
@@ -2565,12 +2566,16 @@ func providerConfigHasEndpointCredentials(cfg ProviderConfig) bool {
 	return false
 }
 
-func azureEndpointConfigsAllOpenAIV1(endpoints []ProviderEndpointConfig) bool {
+func azureEndpointConfigsAllOpenAIV1WithDefault(defaultBaseURL string, endpoints []ProviderEndpointConfig) bool {
+	defaultBaseURL = strings.TrimRight(strings.TrimSpace(defaultBaseURL), "/")
 	if len(endpoints) == 0 {
-		return false
+		return defaultBaseURL != "" && classifyAzureBaseURL(defaultBaseURL) == azureBaseURLKindOpenAIV1
 	}
 	for _, endpoint := range endpoints {
 		baseURL := strings.TrimRight(strings.TrimSpace(endpoint.BaseURL), "/")
+		if baseURL == "" {
+			baseURL = defaultBaseURL
+		}
 		if baseURL == "" || classifyAzureBaseURL(baseURL) != azureBaseURLKindOpenAIV1 {
 			return false
 		}
@@ -2588,4 +2593,18 @@ func providerHasEndpointCredentials(provider *providerRuntime) bool {
 		}
 	}
 	return false
+}
+
+type nonInteractiveAuthContextKey struct{}
+
+func contextWithNonInteractiveAuth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, nonInteractiveAuthContextKey{}, true)
+}
+
+func nonInteractiveAuthFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(nonInteractiveAuthContextKey{}).(bool)
+	return v
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -2414,7 +2414,7 @@ func buildProviderEndpointRuntimes(providerID string, kind providerType, cfg Pro
 			return nil, nil, nil, "", fmt.Errorf("provider %q endpoint %q: %w", providerID, name, err)
 		}
 		runtime := &providerEndpointRuntime{
-			endpoint: selector.Endpoint{Name: name, BaseURL: baseURL, Key: apiKey, Weight: raw.Weight, Healthy: true},
+			endpoint: selector.Endpoint{Name: name, BaseURL: baseURL, Weight: raw.Weight, Healthy: true},
 			apiKey:   apiKey,
 			health:   newEndpointHealthTracker(healthCfg),
 		}

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -152,6 +152,8 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		if !retryable(resp.StatusCode) {
 			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 				recordEndpointSuccess(attemptEndpoint, time.Since(attemptStart))
+			} else if resp.StatusCode >= http.StatusInternalServerError {
+				recordEndpointFailure(attemptEndpoint, time.Now())
 			}
 			return resp, nil
 		}

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -130,12 +130,15 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			return nil, err
 		}
 
+		attemptEndpoint := providerEndpointFromContext(req.Context())
+		attemptStart := time.Now()
 		resp, err := h.client.Do(req)
 		if err != nil {
 			lastErr = err
 			if permanentTransportError(err) {
 				return nil, err
 			}
+			recordEndpointFailure(attemptEndpoint, time.Now())
 			if attempt < maxRetries-1 {
 				delay := backoff(retryDelay, attempt)
 				h.logRetryAttempt(req.Context(), attempt, 0, "", delay, err)
@@ -147,8 +150,12 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		}
 
 		if !retryable(resp.StatusCode) {
+			if resp.StatusCode < http.StatusInternalServerError && resp.StatusCode != http.StatusTooManyRequests {
+				recordEndpointSuccess(attemptEndpoint, time.Since(attemptStart))
+			}
 			return resp, nil
 		}
+		recordEndpointFailure(attemptEndpoint, time.Now())
 
 		retryAfterHeader := resp.Header.Get("Retry-After")
 		upstreamErr := &upstreamError{
@@ -199,6 +206,9 @@ func (h *ProxyHandler) logRetryAttempt(ctx context.Context, attempt int, status 
 	}
 	if retryAfter != "" {
 		fields = append(fields, logger.F("retry_after", retryAfter))
+	}
+	if endpoint := providerEndpointNameFromContext(ctx); endpoint != "" {
+		fields = append(fields, logger.F("endpoint", endpoint))
 	}
 	if err != nil {
 		fields = append(fields, logger.Err(err))
@@ -287,4 +297,18 @@ func drainRetryableUpstreamErrorBody(body io.ReadCloser) {
 		_ = timer.Stop()
 		closeBody()
 	}()
+}
+
+func recordEndpointFailure(endpoint *providerEndpointRuntime, now time.Time) {
+	if endpoint == nil || endpoint.health == nil {
+		return
+	}
+	endpoint.health.recordFailure(now)
+}
+
+func recordEndpointSuccess(endpoint *providerEndpointRuntime, latency time.Duration) {
+	if endpoint == nil || endpoint.health == nil {
+		return
+	}
+	endpoint.health.recordSuccess(latency)
 }

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -135,6 +135,9 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		resp, err := h.client.Do(req)
 		if err != nil {
 			lastErr = err
+			if req.Context().Err() != nil {
+				return nil, err
+			}
 			if permanentTransportError(err) {
 				return nil, err
 			}
@@ -151,8 +154,10 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 
 		if !retryable(resp.StatusCode) {
 			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
-				recordEndpointSuccess(attemptEndpoint, time.Since(attemptStart))
-			} else if resp.StatusCode >= http.StatusInternalServerError {
+				if !responseLooksStreaming(resp) {
+					recordEndpointSuccess(attemptEndpoint, time.Since(attemptStart))
+				}
+			} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode >= http.StatusInternalServerError {
 				recordEndpointFailure(attemptEndpoint, time.Now())
 			}
 			return resp, nil
@@ -171,8 +176,10 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			// Drain and close body before retry to allow connection reuse.
 			drainAndClose(resp.Body)
 			delay := backoff(retryDelay, attempt)
-			if ra, ok := parseRetryAfter(retryAfterHeader); ok && ra > delay {
-				delay = ra
+			if providerEndpointCountFromContext(req.Context()) <= 1 {
+				if ra, ok := parseRetryAfter(retryAfterHeader); ok && ra > delay {
+					delay = ra
+				}
 			}
 			h.logRetryAttempt(req.Context(), attempt, resp.StatusCode, retryAfterHeader, delay, nil)
 			if ctxErr := sleepWithContext(req.Context(), delay); ctxErr != nil {
@@ -313,4 +320,12 @@ func recordEndpointSuccess(endpoint *providerEndpointRuntime, latency time.Durat
 		return
 	}
 	endpoint.health.recordSuccess(latency)
+}
+
+func responseLooksStreaming(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	return strings.Contains(contentType, "text/event-stream")
 }

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -150,7 +150,7 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		}
 
 		if !retryable(resp.StatusCode) {
-			if resp.StatusCode < http.StatusInternalServerError && resp.StatusCode != http.StatusTooManyRequests {
+			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 				recordEndpointSuccess(attemptEndpoint, time.Since(attemptStart))
 			}
 			return resp, nil

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
+	"github.com/sozercan/vekil/proxy/selector"
 )
 
 func TestDoWithRetry_SuccessOnFirstTry(t *testing.T) {
@@ -450,5 +451,89 @@ func TestBackoffGuardsZeroBaseAndLargeAttempt(t *testing.T) {
 	}
 	if got := backoff(time.Second, 1000); got < maxRetryBackoff || got >= maxRetryBackoff+maxRetryBackoff/4 {
 		t.Fatalf("backoff(time.Second, 1000) = %v, want capped delay plus bounded jitter", got)
+	}
+}
+
+func TestDoWithRetry_DoesNotPenalizeCanceledRequest(t *testing.T) {
+	endpoint := &providerEndpointRuntime{endpoint: selector.Endpoint{Name: "east", Healthy: true}, health: newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 1, Window: time.Minute}, cooldown: time.Hour})}
+	h := &ProxyHandler{client: http.DefaultClient, log: logger.New(logger.LevelError), retryBaseDelay: time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := h.doWithRetry(func() (*http.Request, error) {
+		req, reqErr := http.NewRequestWithContext(contextWithProviderEndpoint(ctx, endpoint, 2), http.MethodGet, "http://127.0.0.1:1", nil)
+		return req, reqErr
+	})
+	if err == nil {
+		t.Fatal("doWithRetry() error = nil, want canceled request error")
+	}
+	if !endpoint.health.healthy(time.Now()) {
+		t.Fatal("canceled request should not penalize endpoint health")
+	}
+}
+
+func TestDoWithRetry_BypassesRetryAfterForMultiEndpointFailover(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	endpoint := &providerEndpointRuntime{endpoint: selector.Endpoint{Name: "east", Healthy: true}, health: newEndpointHealthTracker(defaultEndpointHealthConfig())}
+	h := &ProxyHandler{client: server.Client(), log: logger.New(logger.LevelError), retryBaseDelay: time.Millisecond}
+	start := time.Now()
+	resp, err := h.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequestWithContext(contextWithProviderEndpoint(context.Background(), endpoint, 2), http.MethodGet, server.URL, nil)
+	})
+	if err != nil {
+		t.Fatalf("doWithRetry() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if time.Since(start) > time.Second {
+		t.Fatalf("retry slept too long despite alternate endpoints: %v", time.Since(start))
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2", calls.Load())
+	}
+}
+
+func TestDoWithRetry_PenalizesAuthFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) }))
+	defer server.Close()
+	endpoint := &providerEndpointRuntime{endpoint: selector.Endpoint{Name: "bad-key", Healthy: true}, health: newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 1, Window: time.Minute}, cooldown: time.Hour})}
+	h := &ProxyHandler{client: server.Client(), log: logger.New(logger.LevelError)}
+	resp, err := h.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequestWithContext(contextWithProviderEndpoint(context.Background(), endpoint, 2), http.MethodGet, server.URL, nil)
+	})
+	if err != nil {
+		t.Fatalf("doWithRetry() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if endpoint.health.healthy(time.Now()) {
+		t.Fatal("401 endpoint should be penalized")
+	}
+}
+
+func TestDoWithRetry_DoesNotRecordStreamingHeaderAsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: hi\n\n"))
+	}))
+	defer server.Close()
+	endpoint := &providerEndpointRuntime{endpoint: selector.Endpoint{Name: "stream", Healthy: true}, health: newEndpointHealthTracker(defaultEndpointHealthConfig())}
+	h := &ProxyHandler{client: server.Client(), log: logger.New(logger.LevelError)}
+	resp, err := h.doWithRetry(func() (*http.Request, error) {
+		return http.NewRequestWithContext(contextWithProviderEndpoint(context.Background(), endpoint, 2), http.MethodGet, server.URL, nil)
+	})
+	if err != nil {
+		t.Fatalf("doWithRetry() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := endpoint.health.latency(); got != 0 {
+		t.Fatalf("streaming header recorded latency = %v, want 0 until body completes", got)
 	}
 }

--- a/proxy/selector/selector.go
+++ b/proxy/selector/selector.go
@@ -1,0 +1,106 @@
+package selector
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// Endpoint is the selection-time view of one configured upstream endpoint.
+type Endpoint struct {
+	Name        string
+	BaseURL     string
+	Key         string
+	Weight      uint
+	Healthy     bool
+	LatencyEWMA time.Duration
+}
+
+// Selector picks one endpoint from the currently configured candidates.
+type Selector interface {
+	Pick(endpoints []*Endpoint) (*Endpoint, error)
+}
+
+var ErrNoHealthyEndpoints = errors.New("no healthy endpoints")
+
+type RoundRobin struct {
+	mu   sync.Mutex
+	next int
+}
+
+func NewRoundRobin() *RoundRobin { return &RoundRobin{} }
+
+func (s *RoundRobin) Pick(endpoints []*Endpoint) (*Endpoint, error) {
+	healthy := healthyEndpoints(endpoints)
+	if len(healthy) == 0 {
+		return nil, ErrNoHealthyEndpoints
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.next % len(healthy)
+	s.next = (s.next + 1) % len(healthy)
+	return healthy[idx], nil
+}
+
+type Weighted struct {
+	mu   sync.Mutex
+	next int
+}
+
+func NewWeighted() *Weighted { return &Weighted{} }
+
+func (s *Weighted) Pick(endpoints []*Endpoint) (*Endpoint, error) {
+	healthy := healthyEndpoints(endpoints)
+	if len(healthy) == 0 {
+		return nil, ErrNoHealthyEndpoints
+	}
+	weighted := make([]*Endpoint, 0, len(healthy))
+	for _, endpoint := range healthy {
+		weight := endpoint.Weight
+		if weight == 0 {
+			weight = 1
+		}
+		for range weight {
+			weighted = append(weighted, endpoint)
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.next % len(weighted)
+	s.next = (s.next + 1) % len(weighted)
+	return weighted[idx], nil
+}
+
+type LeastLatency struct{}
+
+func NewLeastLatency() *LeastLatency { return &LeastLatency{} }
+
+func (s *LeastLatency) Pick(endpoints []*Endpoint) (*Endpoint, error) {
+	healthy := healthyEndpoints(endpoints)
+	if len(healthy) == 0 {
+		return nil, ErrNoHealthyEndpoints
+	}
+	best := healthy[0]
+	for _, candidate := range healthy[1:] {
+		switch {
+		case best.LatencyEWMA == 0 && candidate.LatencyEWMA != 0:
+			// Keep never-used endpoints ahead of known-latency endpoints so they get probes.
+			continue
+		case candidate.LatencyEWMA == 0:
+			best = candidate
+		case candidate.LatencyEWMA < best.LatencyEWMA:
+			best = candidate
+		}
+	}
+	return best, nil
+}
+
+func healthyEndpoints(endpoints []*Endpoint) []*Endpoint {
+	healthy := make([]*Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint != nil && endpoint.Healthy {
+			healthy = append(healthy, endpoint)
+		}
+	}
+	return healthy
+}

--- a/proxy/selector/selector.go
+++ b/proxy/selector/selector.go
@@ -44,7 +44,7 @@ func (s *RoundRobin) Pick(endpoints []*Endpoint) (*Endpoint, error) {
 
 type Weighted struct {
 	mu   sync.Mutex
-	next int
+	next uint64
 }
 
 func NewWeighted() *Weighted { return &Weighted{} }
@@ -54,21 +54,30 @@ func (s *Weighted) Pick(endpoints []*Endpoint) (*Endpoint, error) {
 	if len(healthy) == 0 {
 		return nil, ErrNoHealthyEndpoints
 	}
-	weighted := make([]*Endpoint, 0, len(healthy))
+	var total uint64
 	for _, endpoint := range healthy {
-		weight := endpoint.Weight
+		weight := uint64(endpoint.Weight)
 		if weight == 0 {
 			weight = 1
 		}
-		for range weight {
-			weighted = append(weighted, endpoint)
-		}
+		total += weight
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	idx := s.next % len(weighted)
-	s.next = (s.next + 1) % len(weighted)
-	return weighted[idx], nil
+	pick := s.next % total
+	s.next = (s.next + 1) % total
+	s.mu.Unlock()
+	var cumulative uint64
+	for _, endpoint := range healthy {
+		weight := uint64(endpoint.Weight)
+		if weight == 0 {
+			weight = 1
+		}
+		cumulative += weight
+		if pick < cumulative {
+			return endpoint, nil
+		}
+	}
+	return healthy[len(healthy)-1], nil
 }
 
 type LeastLatency struct{}
@@ -83,8 +92,10 @@ func (s *LeastLatency) Pick(endpoints []*Endpoint) (*Endpoint, error) {
 	best := healthy[0]
 	for _, candidate := range healthy[1:] {
 		switch {
-		case best.LatencyEWMA == 0 && candidate.LatencyEWMA != 0:
-			// Keep never-used endpoints ahead of known-latency endpoints so they get probes.
+		case best.LatencyEWMA == 0:
+			// Keep the earliest never-used endpoint ahead of known-latency endpoints
+			// and other never-used endpoints so retries can deprioritize it after a
+			// failure via the endpoint health tracker.
 			continue
 		case candidate.LatencyEWMA == 0:
 			best = candidate

--- a/proxy/selector/selector.go
+++ b/proxy/selector/selector.go
@@ -10,7 +10,6 @@ import (
 type Endpoint struct {
 	Name        string
 	BaseURL     string
-	Key         string
 	Weight      uint
 	Healthy     bool
 	LatencyEWMA time.Duration

--- a/proxy/selector/selector_test.go
+++ b/proxy/selector/selector_test.go
@@ -1,0 +1,67 @@
+package selector
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRoundRobinSkipsUnhealthy(t *testing.T) {
+	endpoints := []*Endpoint{{Name: "a", Healthy: true}, {Name: "b", Healthy: false}, {Name: "c", Healthy: true}}
+	sel := NewRoundRobin()
+	var got []string
+	for range 4 {
+		ep, err := sel.Pick(endpoints)
+		if err != nil {
+			t.Fatalf("Pick() error = %v", err)
+		}
+		got = append(got, ep.Name)
+	}
+	want := []string{"a", "c", "a", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round robin = %v, want %v", got, want)
+	}
+}
+
+func TestWeightedRoundRobin(t *testing.T) {
+	endpoints := []*Endpoint{{Name: "east", Healthy: true, Weight: 2}, {Name: "west", Healthy: true, Weight: 1}}
+	sel := NewWeighted()
+	var got []string
+	for range 6 {
+		ep, err := sel.Pick(endpoints)
+		if err != nil {
+			t.Fatalf("Pick() error = %v", err)
+		}
+		got = append(got, ep.Name)
+	}
+	want := []string{"east", "east", "west", "east", "east", "west"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("weighted = %v, want %v", got, want)
+	}
+}
+
+func TestLeastLatencyPrefersUnusedThenFastest(t *testing.T) {
+	sel := NewLeastLatency()
+	ep, err := sel.Pick([]*Endpoint{{Name: "slow", Healthy: true, LatencyEWMA: 200 * time.Millisecond}, {Name: "fresh", Healthy: true}})
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if ep.Name != "fresh" {
+		t.Fatalf("first pick = %q, want fresh", ep.Name)
+	}
+	ep, err = sel.Pick([]*Endpoint{{Name: "slow", Healthy: true, LatencyEWMA: 200 * time.Millisecond}, {Name: "fast", Healthy: true, LatencyEWMA: 50 * time.Millisecond}})
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if ep.Name != "fast" {
+		t.Fatalf("second pick = %q, want fast", ep.Name)
+	}
+}
+
+func TestNoHealthyEndpoints(t *testing.T) {
+	_, err := NewRoundRobin().Pick([]*Endpoint{{Name: "a", Healthy: false}})
+	if !errors.Is(err, ErrNoHealthyEndpoints) {
+		t.Fatalf("Pick() error = %v, want ErrNoHealthyEndpoints", err)
+	}
+}

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -168,11 +168,13 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 	}
 
 	rewrittenBody := body
-	if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
-		var err error
-		rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)
-		if err != nil {
-			return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+	if !(provider.kind == providerTypeAzureOpenAI && len(provider.endpoints) > 0) {
+		if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
+			var err error
+			rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)
+			if err != nil {
+				return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+			}
 		}
 	}
 	rewrittenBody = applyProviderModelRequestPolicy(rewrittenBody, owner)

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -168,7 +168,7 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 	}
 
 	rewrittenBody := body
-	if !(provider.kind == providerTypeAzureOpenAI && len(provider.endpoints) > 0) {
+	if provider.kind != providerTypeAzureOpenAI || len(provider.endpoints) == 0 {
 		if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
 			var err error
 			rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)

--- a/scripts/live-cli-smoke.sh
+++ b/scripts/live-cli-smoke.sh
@@ -177,7 +177,7 @@ read_gemini_normalized_output() {
   # translation rather than a CLI presentation detail.
   if [[ "${actual}" == *'{"output"'* ]]; then
     local parsed
-    parsed="$(printf '%s' "${actual}" | jq -Rr '((fromjson? // {}) | .output? // empty) as $single | if $single != "" then $single else split("|") | map((fromjson? // {}) | .output? // empty) | select(length > 0) | join("|") end' 2>/dev/null || true)"
+    parsed="$(printf '%s' "${actual}" | jq -Rr '(try (fromjson | .output // "") catch "") as $single | if $single != "" then $single else split("|") | map(try (fromjson | .output // "") catch "") | map(select(length > 0)) | join("|") end' 2>/dev/null || true)"
     if [[ -n "${parsed}" ]]; then
       printf '%s' "${parsed}"
       return

--- a/scripts/live-cli-smoke.sh
+++ b/scripts/live-cli-smoke.sh
@@ -166,6 +166,27 @@ read_normalized_output() {
   awk 'NF { gsub(/\r/, "", $0); printf "%s", $0 }' "$1"
 }
 
+read_gemini_normalized_output() {
+  local output_file="$1"
+  local actual
+  actual="$(read_normalized_output "${output_file}")"
+
+  # Newer Gemini CLI builds may still emit JSON-shaped chunks even with
+  # `-o text`, e.g. {"output":"LEFT"}|{"output":"RIGHT"}. Normalize that
+  # wrapper before exact matching so the smoke tests keep validating proxy
+  # translation rather than a CLI presentation detail.
+  if [[ "${actual}" == *'{"output"'* ]]; then
+    local parsed
+    parsed="$(printf '%s' "${actual}" | jq -Rr 'split("|") | map((fromjson? // {}) | .output? // empty) | select(length > 0) | join("|")' 2>/dev/null || true)"
+    if [[ -n "${parsed}" ]]; then
+      printf '%s' "${parsed}"
+      return
+    fi
+  fi
+
+  printf '%s' "${actual}"
+}
+
 start_proxy() {
   [[ -x "${PROXY_BIN}" ]] || die "proxy binary not found or not executable: ${PROXY_BIN}"
 
@@ -322,7 +343,7 @@ EOF
       > "${output_file}"
   )
 
-  actual="$(read_normalized_output "${output_file}")"
+  actual="$(read_gemini_normalized_output "${output_file}")"
   assert_exact_output "gemini" "${expected}" "${actual}"
   printf '%s' "${actual}" > "${output_file}"
 }

--- a/scripts/live-cli-smoke.sh
+++ b/scripts/live-cli-smoke.sh
@@ -177,7 +177,7 @@ read_gemini_normalized_output() {
   # translation rather than a CLI presentation detail.
   if [[ "${actual}" == *'{"output"'* ]]; then
     local parsed
-    parsed="$(printf '%s' "${actual}" | jq -Rr 'split("|") | map((fromjson? // {}) | .output? // empty) | select(length > 0) | join("|")' 2>/dev/null || true)"
+    parsed="$(printf '%s' "${actual}" | jq -Rr '((fromjson? // {}) | .output? // empty) as $single | if $single != "" then $single else split("|") | map((fromjson? // {}) | .output? // empty) | select(length > 0) | join("|") end' 2>/dev/null || true)"
     if [[ -n "${parsed}" ]]; then
       printf '%s' "${parsed}"
       return


### PR DESCRIPTION
## Summary

Adds multi-endpoint provider routing for issue #76.

- adds provider-level `selector` plus `endpoints` config fields
- supports `round_robin`, `weighted`, and `least_latency` endpoint selectors
- adds endpoint health/error-budget parsing and quarantine behavior
- picks a healthy endpoint on every upstream retry attempt, with endpoint-specific base URLs and credentials
- supports endpoint-specific Copilot tokens for multi-account rotation
- documents Azure three-region and Copilot two-account examples

## Validation

- `make test`
- `make lint`
- `bash -n scripts/*.sh`
- `make build`
- built local image `vekil:issue76`
- loaded and deployed `vekil:issue76` to the current kind cluster as `vekil-system/vekil-issue76`
- verified `/healthz`, `/readyz`, and `/v1/models`
- verified an in-cluster chat request failed over from a mock `east` endpoint returning 429 to a mock `west` endpoint returning 200

## Notes

This covers in-provider endpoint/key selection and health tracking. Cross-provider fallback chains remain separate work for issue #78.

## CI smoke follow-up

While closing out this PR, the credentialed Live Copilot smoke exposed that newer Gemini CLI builds can emit JSON-shaped text even with `-o text`. This PR includes the same narrow `scripts/live-cli-smoke.sh` normalization used on PR #243 so the smoke continues asserting proxied content instead of failing on that CLI presentation wrapper.

Fixes #76
