### PR TITLE
feat: add provider fallback chains

### DIFF
--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -181,6 +181,46 @@ providers:
 
 For Copilot endpoints, `api_key`/`api_key_env` override the default local Copilot token for that endpoint. If an endpoint omits a key, Vekil falls back to the normal local Copilot authentication flow.
 
+
+### Cross-Provider Fallback Chains
+
+`fallbacks` declare ordered provider/model hops for one public model. Vekil tries the first hop normally. If that provider exhausts its in-provider retries with a retryable failure (`429`, `5xx`, or transient transport/timeout errors), Vekil logs a `provider fallback` event and retries the request against the next hop. Client errors such as `400`, `401`, `403`, and `404` short-circuit and are returned unchanged.
+
+```yaml
+providers:
+  - id: azure-east
+    type: azure-openai
+    base_url: https://east.openai.azure.com/openai/v1
+    api_key_env: AZURE_EAST_KEY
+    models:
+      - public_id: gpt-5.4-east
+        deployment: gpt-5.4
+        endpoints: [/chat/completions]
+  - id: azure-west
+    type: azure-openai
+    base_url: https://west.openai.azure.com/openai/v1
+    api_key_env: AZURE_WEST_KEY
+    models:
+      - public_id: gpt-5.4-west
+        deployment: gpt-5.4
+        endpoints: [/chat/completions]
+  - id: copilot
+    type: copilot
+    default: true
+
+fallbacks:
+  - public: gpt-5.4-east
+    chain:
+      - provider: azure-east
+        model: gpt-5.4-east
+      - provider: azure-west
+        model: gpt-5.4-west
+      - provider: copilot
+        model: claude-sonnet-4.5
+```
+
+Fallback chain entries target configured provider models. Keep each hop on an endpoint the provider/model supports; protocol translation across incompatible public endpoints is not inferred.
+
 ### Generic Provider Behavior
 
 OpenAI-compatible providers route `POST /v1/chat/completions` to `chat_completions_path`. Anthropic `POST /v1/messages` requests for these models are translated through the existing OpenAI Chat Completions adapter. `POST /v1/responses` is never inferred; add `/responses` to a model only after validating the upstream model and path.
@@ -204,6 +244,9 @@ Anthropic-compatible providers directly forward Anthropic `POST /v1/messages` to
 | `messages_path` | `anthropic-compatible` | Upstream path for public `POST /v1/messages`. Defaults to `/v1/messages`. |
 | `models_path` | generic providers | Upstream path for dynamic model discovery and readiness probes. Defaults to `/models`. |
 | `model_discovery` | generic providers | `static`, `openai`, `ollama`, or `openrouter-tools`. |
+| `fallbacks[].public` | top-level `fallbacks` | Public model ID whose requests should follow the declared fallback chain. |
+| `fallbacks[].chain[].provider` | top-level `fallbacks` | Provider ID for one fallback hop. |
+| `fallbacks[].chain[].model` | top-level `fallbacks` | Provider model public ID to use at that hop. |
 | `selector` | providers with `endpoints` | Endpoint selector: `round_robin`, `weighted`, or `least_latency`. Defaults to `round_robin`. |
 | `endpoints[].name` | providers with `endpoints` | Stable endpoint label for logs and health tracking. Auto-fills to `endpoint-N` if omitted. |
 | `endpoints[].base_url` | providers with `endpoints` | Endpoint-specific upstream origin. Defaults to provider `base_url`; Copilot defaults to the built-in Copilot API URL. |

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -161,7 +161,10 @@ func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFrom(r.Context(), streaming)
 	defer upstreamCancel()
 
-	resp, err := h.postAnthropicMessages(upstreamCtx, body, anthropicExtraHeadersFromRequest(r))
+	resp, owner, err := h.postAnthropicMessagesTracked(upstreamCtx, body, anthropicExtraHeadersFromRequest(r))
+	if owner.upstreamModel != "" {
+		upstreamModel = owner.upstreamModel
+	}
 	if err != nil {
 		statusCode := upstreamStatusCode(err, http.StatusBadGateway)
 		h.log.Error("upstream request failed", logger.F("endpoint", "anthropic"), logger.Err(err))

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -162,6 +162,7 @@ func (h *ProxyHandler) forwardAnthropicMessagesDirect(w http.ResponseWriter, r *
 	defer upstreamCancel()
 
 	resp, owner, err := h.postAnthropicMessagesTracked(upstreamCtx, body, anthropicExtraHeadersFromRequest(r))
+	h.observeSelectedProvider(upstreamCtx, owner)
 	if owner.upstreamModel != "" {
 		upstreamModel = owner.upstreamModel
 	}

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -479,3 +479,195 @@ func TestChatFallbackAttributesUsageToBackupProvider(t *testing.T) {
 		t.Fatalf("summary provider = %q, want backup", summary.provider)
 	}
 }
+
+func TestFallbackChainsRejectDynamicAliasMissingFromLoadedCatalog(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"unrelated-upstream"}]}`))
+	}))
+	defer primary.Close()
+
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-backup"}]}`))
+	}))
+	defer backup.Close()
+
+	_, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:             "primary",
+					Type:           "openai-compatible",
+					Default:        true,
+					BaseURL:        primary.URL,
+					AuthType:       "none",
+					ModelDiscovery: "openai",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-primary",
+						Deployment: "missing-upstream",
+						Endpoints:  []string{providerEndpointChatCompletions},
+					}},
+				},
+				{ID: "backup", Type: "openai-compatible", BaseURL: backup.URL, AuthType: "none", ModelDiscovery: "openai"},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}},
+		}),
+	)
+	if err == nil || !strings.Contains(err.Error(), "references unknown model") {
+		t.Fatalf("NewProxyHandler() error = %v, want fallback unknown dynamic model", err)
+	}
+}
+
+func TestProviderFallbackExhaustsPrimaryEndpointsBeforeProviderFallbackOn500(t *testing.T) {
+	var eastHits atomic.Int32
+	east := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		eastHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"east down"}}`))
+	}))
+	defer east.Close()
+
+	var westHits atomic.Int32
+	west := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		westHits.Add(1)
+		assertFallbackUpstreamModel(t, r, "primary-upstream")
+		writeFallbackChatOK(w, "west-ok")
+	}))
+	defer west.Close()
+
+	var backupHits atomic.Int32
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:       "primary",
+					Type:     "openai-compatible",
+					Default:  true,
+					AuthType: "none",
+					Endpoints: []ProviderEndpointConfig{
+						{Name: "east", BaseURL: east.URL, Health: ProviderEndpointHealthConfig{ErrorBudget: "1/m", Cooldown: "1h"}},
+						{Name: "west", BaseURL: west.URL, Health: ProviderEndpointHealthConfig{ErrorBudget: "1/m", Cooldown: "1h"}},
+					},
+					Models: []ProviderModelConfig{{PublicID: "gpt-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointChatCompletions}}},
+				},
+				{ID: "backup", Type: "openai-compatible", BaseURL: backup.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointChatCompletions}}}},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 2
+	handler.retryBaseDelay = time.Millisecond
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if eastHits.Load() != 1 || westHits.Load() != 1 || backupHits.Load() != 0 {
+		t.Fatalf("hits east/west/backup = %d/%d/%d, want 1/1/0", eastHits.Load(), westHits.Load(), backupHits.Load())
+	}
+}
+
+func TestFallbackResponseBodySurvivesPrimaryContextTimeout(t *testing.T) {
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(25 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"backup-ok"}}]}`))
+	}))
+	defer backup.Close()
+
+	handler := newFallbackTestHandler(t, "http://127.0.0.1:1", backup.URL)
+	handler.maxRetries = 1
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resp, owner, _, err := handler.postJSONEndpointWithHeadersTracked(ctx, providerEndpointChatCompletions, []byte(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if err != nil {
+		t.Fatalf("postJSONEndpointWithHeadersTracked() error = %v", err)
+	}
+	if owner.providerID != "backup" {
+		t.Fatalf("owner.providerID = %q, want backup", owner.providerID)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll(fallback body) error = %v", err)
+	}
+	if !strings.Contains(string(body), "backup-ok") {
+		t.Fatalf("fallback body = %s, want backup-ok", string(body))
+	}
+}
+
+func TestResponsesStreamNestedModelLineRewrite(t *testing.T) {
+	line := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-backup\",\"model\":\"backup-upstream\"}}\n"
+	rewritten := rewriteResponsesSSEModelLine(line, "gpt-primary")
+	if !strings.Contains(rewritten, `"model":"gpt-primary"`) {
+		t.Fatalf("rewritten line = %q, want nested public model", rewritten)
+	}
+	if strings.Contains(rewritten, "backup-upstream") {
+		t.Fatalf("rewritten line = %q, leaked backup model", rewritten)
+	}
+}
+
+func TestResponsesStreamModelRewriteLeavesOversizedDataLineUnchanged(t *testing.T) {
+	body := "data: {\"model\":\"backup-upstream\",\"payload\":\"" + strings.Repeat("x", responsesFailureTapMaxBuffer) + "\"}\n"
+	readCloser := newResponsesModelRewriteReadCloser(io.NopCloser(strings.NewReader(body)), "gpt-primary")
+	defer readCloser.Close()
+	read, err := io.ReadAll(readCloser)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(read) != body {
+		t.Fatalf("oversized SSE line changed; got len %d want len %d", len(read), len(body))
+	}
+}
+
+func TestResponsesWebSocketStatsUseSelectedFallbackOwner(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-backup","object":"response","status":"completed","model":"backup-upstream","output":[]}`))
+	}))
+	defer backup.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "primary", Type: "openai-compatible", Default: true, BaseURL: primary.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointResponses}}}},
+				{ID: "backup", Type: "openai-compatible", BaseURL: backup.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointResponses}}}},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	session := &responsesWebSocketSession{selectedOwner: providerModel{providerID: "backup"}, userAgent: "codex/1.0"}
+	session.recordTurnStats(handler, "gpt-primary", http.StatusOK, responsesUsage{InputTokens: 2, OutputTokens: 3})
+	snap := handler.stats.snapshot()
+	if len(snap.ByProvider) == 0 || snap.ByProvider[0].Provider != "backup" {
+		t.Fatalf("ByProvider = %#v, want backup attribution", snap.ByProvider)
+	}
+}

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
+	"github.com/sozercan/vekil/models"
 )
 
 func newFallbackTestHandler(t *testing.T, primaryURL, backupURL string) *ProxyHandler {
@@ -182,4 +183,104 @@ func assertFallbackUpstreamModel(t *testing.T, r *http.Request, want string) {
 func writeFallbackChatOK(w http.ResponseWriter, content string) {
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"` + content + `"}}]}`))
+}
+
+func TestProviderFallbackSucceedsOnSecondHopAfter500(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary internal"}}`))
+	}))
+	defer primary.Close()
+	var backupHits atomic.Int32
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		assertFallbackUpstreamModel(t, r, "backup-upstream")
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if backupHits.Load() != 1 {
+		t.Fatalf("backup hits = %d, want 1", backupHits.Load())
+	}
+}
+
+func TestFallbackChainsConfiguredAfterDynamicModelLoading(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-primary"}]}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-backup"}]}`))
+	}))
+	defer backup.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "primary", Type: "openai-compatible", Default: true, BaseURL: primary.URL, AuthType: "none", ModelDiscovery: "openai"},
+				{ID: "backup", Type: "openai-compatible", BaseURL: backup.URL, AuthType: "none", ModelDiscovery: "openai"},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	chain := handler.providerSetup().fallbackChain("gpt-primary")
+	if len(chain) != 2 || chain[0].providerID != "primary" || chain[1].providerID != "backup" {
+		t.Fatalf("fallback chain = %#v, want primary->backup", chain)
+	}
+}
+
+func TestDirectAnthropicFallbackPreservesRequestedResponseModel(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary internal"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"backup-upstream","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer backup.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "primary", Type: "anthropic-compatible", Default: true, BaseURL: primary.URL, AuthType: "none", MessagesPath: "/v1/messages", Models: []ProviderModelConfig{{PublicID: "claude-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointMessages}}}},
+				{ID: "backup", Type: "anthropic-compatible", BaseURL: backup.URL, AuthType: "none", MessagesPath: "/v1/messages", Models: []ProviderModelConfig{{PublicID: "claude-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointMessages}}}},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "claude-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "claude-primary"}, {Provider: "backup", Model: "claude-backup"}}}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 1
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-primary","max_tokens":128,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleAnthropicMessages(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp models.AnthropicResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Model != "claude-primary" {
+		t.Fatalf("response model = %q, want requested claude-primary", resp.Model)
+	}
 }

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -367,5 +369,69 @@ func TestResponsesFallbackPreservesRequestedModel(t *testing.T) {
 	}
 	if got := rawJSONString(payload["model"]); got != "gpt-primary" {
 		t.Fatalf("response model = %q, want requested gpt-primary", got)
+	}
+}
+
+func TestFallbackPublicMustMatchFirstChainEntry(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.test"}
+	_, err := handler.buildConfiguredProviderSetup(context.Background(), ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:       "primary",
+			Type:     "openai-compatible",
+			Default:  true,
+			BaseURL:  "https://primary.example.test/v1",
+			AuthType: "none",
+			Models:   []ProviderModelConfig{{PublicID: "gpt-primary", Endpoints: []string{providerEndpointChatCompletions}}},
+		}},
+		Fallbacks: []ProviderFallbackConfig{{Public: "typo-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must match first chain model") {
+		t.Fatalf("buildConfiguredProviderSetup() error = %v, want public mismatch", err)
+	}
+}
+
+func TestProviderFallbackDoesNotMaskProviderAuthError(t *testing.T) {
+	err := &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider auth failed")}
+	if shouldFallbackToNextProvider(err) {
+		t.Fatal("provider auth/config errors should not trigger fallback")
+	}
+}
+
+func TestResponsesFallbackAttributesUsageToBackupProvider(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary down"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-backup","object":"response","status":"completed","model":"backup-upstream","output":[],"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}`))
+	}))
+	defer backup.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "primary", Type: "openai-compatible", Default: true, BaseURL: primary.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointResponses}}}},
+				{ID: "backup", Type: "openai-compatible", BaseURL: backup.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointResponses}}}},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 1
+	ctx, summary := WithRequestSummary(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-primary","input":"hi"}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleResponses(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if summary.provider != "backup" {
+		t.Fatalf("summary provider = %q, want backup", summary.provider)
 	}
 }

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -326,3 +326,46 @@ func TestProviderFallbackAfterProviderEndpointExhaustion(t *testing.T) {
 		t.Fatalf("backup hits = %d, want 1", backupHits.Load())
 	}
 }
+
+func TestResponsesFallbackPreservesRequestedModel(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary down"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertFallbackUpstreamModel(t, r, "backup-upstream")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-backup","object":"response","status":"completed","model":"backup-upstream","output":[]}`))
+	}))
+	defer backup.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{ID: "primary", Type: "openai-compatible", Default: true, BaseURL: primary.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointResponses}}}},
+				{ID: "backup", Type: "openai-compatible", BaseURL: backup.URL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointResponses}}}},
+			},
+			Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 1
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-primary","input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.HandleResponses(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := rawJSONString(payload["model"]); got != "gpt-primary" {
+		t.Fatalf("response model = %q, want requested gpt-primary", got)
+	}
+}

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sozercan/vekil/auth"
+	"github.com/sozercan/vekil/logger"
+)
+
+func newFallbackTestHandler(t *testing.T, primaryURL, backupURL string) *ProxyHandler {
+	t.Helper()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{
+				{
+					ID:       "primary",
+					Type:     "openai-compatible",
+					Default:  true,
+					BaseURL:  primaryURL,
+					AuthType: "none",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-primary",
+						Deployment: "primary-upstream",
+						Endpoints:  []string{providerEndpointChatCompletions},
+					}},
+				},
+				{
+					ID:       "backup",
+					Type:     "openai-compatible",
+					BaseURL:  backupURL,
+					AuthType: "none",
+					Models: []ProviderModelConfig{{
+						PublicID:   "gpt-backup",
+						Deployment: "backup-upstream",
+						Endpoints:  []string{providerEndpointChatCompletions},
+					}},
+				},
+			},
+			Fallbacks: []ProviderFallbackConfig{{
+				Public: "gpt-primary",
+				Chain: []ProviderFallbackChainEntry{
+					{Provider: "primary", Model: "gpt-primary"},
+					{Provider: "backup", Model: "gpt-backup"},
+				},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 1
+	handler.retryBaseDelay = time.Millisecond
+	return handler
+}
+
+func TestProviderFallbackSucceedsOnFirstHop(t *testing.T) {
+	var primaryHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryHits.Add(1)
+		assertFallbackUpstreamModel(t, r, "primary-upstream")
+		writeFallbackChatOK(w, "primary-ok")
+	}))
+	defer primary.Close()
+	var backupHits atomic.Int32
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if primaryHits.Load() != 1 || backupHits.Load() != 0 {
+		t.Fatalf("hits primary/backup = %d/%d, want 1/0", primaryHits.Load(), backupHits.Load())
+	}
+}
+
+func TestProviderFallbackSucceedsOnSecondHopAfter429(t *testing.T) {
+	var primaryHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryHits.Add(1)
+		assertFallbackUpstreamModel(t, r, "primary-upstream")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer primary.Close()
+	var backupHits atomic.Int32
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		assertFallbackUpstreamModel(t, r, "backup-upstream")
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if primaryHits.Load() != 1 || backupHits.Load() != 1 {
+		t.Fatalf("hits primary/backup = %d/%d, want 1/1", primaryHits.Load(), backupHits.Load())
+	}
+}
+
+func TestProviderFallbackAllHopsFailReturnsLastError(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary limited"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"backup down"}}`))
+	}))
+	defer backup.Close()
+
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "backup down") {
+		t.Fatalf("body = %s, want last upstream error", w.Body.String())
+	}
+}
+
+func TestProviderFallbackClientErrorShortCircuits(t *testing.T) {
+	var backupHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad request"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", w.Code, w.Body.String())
+	}
+	if backupHits.Load() != 0 {
+		t.Fatalf("backup hits = %d, want 0", backupHits.Load())
+	}
+}
+
+func assertFallbackUpstreamModel(t *testing.T, r *http.Request, want string) {
+	t.Helper()
+	body, _ := io.ReadAll(r.Body)
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if got := strings.Trim(string(payload["model"]), `"`); got != want {
+		t.Fatalf("upstream model = %q, want %q", got, want)
+	}
+}
+
+func writeFallbackChatOK(w http.ResponseWriter, content string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"` + content + `"}}]}`))
+}

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sozercan/vekil/auth"
 	"github.com/sozercan/vekil/logger"
 	"github.com/sozercan/vekil/models"
+	"github.com/sozercan/vekil/proxy/selector"
 )
 
 func newFallbackTestHandler(t *testing.T, primaryURL, backupURL string) *ProxyHandler {
@@ -282,5 +283,46 @@ func TestDirectAnthropicFallbackPreservesRequestedResponseModel(t *testing.T) {
 	}
 	if resp.Model != "claude-primary" {
 		t.Fatalf("response model = %q, want requested claude-primary", resp.Model)
+	}
+}
+
+func TestProviderFallbackDoesNotMaskPermanentTransportError(t *testing.T) {
+	backupHits := atomic.Int32{}
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+	handler := newFallbackTestHandler(t, "https://missing.invalid", backup.URL)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if backupHits.Load() != 0 {
+		t.Fatalf("backup hits = %d, want 0 for permanent DNS failure", backupHits.Load())
+	}
+}
+
+func TestProviderFallbackAfterProviderEndpointExhaustion(t *testing.T) {
+	backupHits := atomic.Int32{}
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backupHits.Add(1)
+		writeFallbackChatOK(w, "backup-ok")
+	}))
+	defer backup.Close()
+	handler := newFallbackTestHandler(t, "http://127.0.0.1:1", backup.URL)
+	primary := handler.providerSetup().providerByID("primary")
+	primary.endpoints = []*providerEndpointRuntime{{endpoint: selector.Endpoint{Name: "dead", BaseURL: "http://127.0.0.1:1", Healthy: true}, health: newEndpointHealthTracker(endpointHealthConfig{errorBudget: endpointErrorBudget{Limit: 1, Window: time.Minute}, cooldown: time.Hour})}}
+	primary.endpointByName = map[string]*providerEndpointRuntime{"dead": primary.endpoints[0]}
+	primary.selector = selector.NewRoundRobin()
+	primary.endpointByName["dead"].health.recordFailure(time.Now())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`))
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if backupHits.Load() != 1 {
+		t.Fatalf("backup hits = %d, want 1", backupHits.Load())
 	}
 }

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -435,3 +435,47 @@ func TestResponsesFallbackAttributesUsageToBackupProvider(t *testing.T) {
 		t.Fatalf("summary provider = %q, want backup", summary.provider)
 	}
 }
+
+func TestResponsesStreamModelLineRewrite(t *testing.T) {
+	line := "data: {\"type\":\"response.created\",\"model\":\"backup-upstream\"}\n"
+	rewritten := rewriteResponsesSSEModelLine(line, "gpt-primary")
+	if !strings.Contains(rewritten, `"model":"gpt-primary"`) {
+		t.Fatalf("rewritten line = %q, want public model", rewritten)
+	}
+}
+
+func TestNormalizeResponsesModelResponseLeavesOversizedBodyStreaming(t *testing.T) {
+	body := strings.Repeat("x", usageSniffMaxBuffer+2)
+	resp := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}
+	got := normalizeResponsesModelResponse(resp, "public", "upstream")
+	read, err := io.ReadAll(got.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(read) != body {
+		t.Fatalf("oversized body changed, got len %d want %d", len(read), len(body))
+	}
+}
+
+func TestChatFallbackAttributesUsageToBackupProvider(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`))
+	}))
+	defer backup.Close()
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	ctx, summary := WithRequestSummary(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`)).WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if summary.provider != "backup" {
+		t.Fatalf("summary provider = %q, want backup", summary.provider)
+	}
+}

--- a/proxy/provider_fallback_test.go
+++ b/proxy/provider_fallback_test.go
@@ -671,3 +671,206 @@ func TestResponsesWebSocketStatsUseSelectedFallbackOwner(t *testing.T) {
 		t.Fatalf("ByProvider = %#v, want backup attribution", snap.ByProvider)
 	}
 }
+
+func TestDirectAnthropicFallbackAttributesUsageToBackupProvider(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary down"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"backup-upstream","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":2,"output_tokens":3}}`))
+	}))
+	defer backup.Close()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{
+			{ID: "primary", Type: "anthropic-compatible", Default: true, BaseURL: primary.URL, AuthType: "none", MessagesPath: "/v1/messages", Models: []ProviderModelConfig{{PublicID: "claude-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointMessages}}}},
+			{ID: "backup", Type: "anthropic-compatible", BaseURL: backup.URL, AuthType: "none", MessagesPath: "/v1/messages", Models: []ProviderModelConfig{{PublicID: "claude-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointMessages}}}},
+		}, Fallbacks: []ProviderFallbackConfig{{Public: "claude-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "claude-primary"}, {Provider: "backup", Model: "claude-backup"}}}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 1
+	ctx, summary := WithRequestSummary(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-primary","max_tokens":128,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.HandleAnthropicMessages(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if summary.provider != "backup" {
+		t.Fatalf("summary provider = %q, want backup", summary.provider)
+	}
+}
+
+func TestFailedFallbackErrorAttributesFinalProvider(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"primary limited"}}`))
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"backup down"}}`))
+	}))
+	defer backup.Close()
+	handler := newFallbackTestHandler(t, primary.URL, backup.URL)
+	handler.maxRetries = 1
+	ctx, summary := WithRequestSummary(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-primary","messages":[{"role":"user","content":"hi"}]}`)).WithContext(ctx)
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503, body = %s", w.Code, w.Body.String())
+	}
+	if summary.provider != "backup" {
+		t.Fatalf("summary provider = %q, want backup", summary.provider)
+	}
+}
+
+func TestFallbackChainsRejectDuplicatePublicDeclarations(t *testing.T) {
+	_, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID: "primary", Type: "openai-compatible", Default: true, BaseURL: "https://primary.example.test", AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-primary", Endpoints: []string{providerEndpointChatCompletions}}},
+		}}, Fallbacks: []ProviderFallbackConfig{
+			{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}}},
+			{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}}},
+		}}),
+	)
+	if err == nil || !strings.Contains(err.Error(), "configured more than once") {
+		t.Fatalf("NewProxyHandler() error = %v, want duplicate fallback error", err)
+	}
+}
+
+func TestResponsesProviderFallbackStripsPreviousResponseIDAcrossProviders(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer primary.Close()
+	var backupPayload map[string]json.RawMessage
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&backupPayload); err != nil {
+			t.Fatalf("decode backup body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-backup","object":"response","status":"completed","model":"backup-upstream","output":[]}`))
+	}))
+	defer backup.Close()
+	handler := newResponsesFallbackTestHandler(t, primary.URL, backup.URL)
+	resp, owner, err := handler.postResponsesWithHeadersTracked(context.Background(), []byte(`{"model":"gpt-primary","previous_response_id":"resp-primary","input":"hi"}`), nil)
+	if err != nil {
+		t.Fatalf("postResponsesWithHeadersTracked() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if owner.providerID != "backup" {
+		t.Fatalf("owner.providerID = %q, want backup", owner.providerID)
+	}
+	if _, ok := backupPayload["previous_response_id"]; ok {
+		t.Fatalf("backup payload kept previous_response_id: %s", backupPayload["previous_response_id"])
+	}
+}
+
+func TestResponsesEncryptedContentRetryReturnsFallbackOwner(t *testing.T) {
+	const encryptedToken = "gAAAAABencryptedReasoningPayloadpQ=="
+	var primaryHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch primaryHits.Add(1) {
+		case 1:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, `{"error":{"message":"The encrypted content %s could not be verified. Reason: Encrypted content could not be decrypted or parsed.","code":"invalid_request_body"}}`, encryptedToken)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-backup","object":"response","status":"completed","model":"backup-upstream","output":[]}`))
+	}))
+	defer backup.Close()
+	handler := newResponsesFallbackTestHandler(t, primary.URL, backup.URL)
+	body := []byte(`{"model":"gpt-primary","input":[{"type":"reasoning","encrypted_content":"` + encryptedToken + `"},{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}]}`)
+	resp, owner, err := handler.postResponsesWithHeadersTracked(context.Background(), body, nil)
+	if err != nil {
+		t.Fatalf("postResponsesWithHeadersTracked() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if owner.providerID != "backup" {
+		t.Fatalf("owner.providerID = %q, want backup", owner.providerID)
+	}
+}
+
+func TestResponsesCompactionRetryReturnsFallbackOwner(t *testing.T) {
+	var primaryHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch primaryHits.Add(1) {
+		case 1:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp-summary","object":"response","status":"completed","model":"primary-upstream","output":[{"type":"message","content":[{"type":"output_text","text":"summary"}]}]}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer primary.Close()
+	backup := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-backup","object":"response","status":"completed","model":"backup-upstream","output":[]}`))
+	}))
+	defer backup.Close()
+	handler := newResponsesFallbackTestHandler(t, primary.URL, backup.URL)
+	handler.responsesWS = ResponsesWebSocketConfig{AutoCompactKeepTail: 1}
+	input := []json.RawMessage{json.RawMessage(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"old"}]}`), json.RawMessage(`{"type":"message","role":"user","content":[{"type":"input_text","text":"new"}]}`)}
+	inputRaw, _ := json.Marshal(input)
+	body := []byte(`{"model":"gpt-primary","input":` + string(inputRaw) + `}`)
+	initial := &http.Response{StatusCode: http.StatusRequestEntityTooLarge, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"too large"}}`))}
+	resp, owner, err := handler.maybeRetryCompactedResponsesRequest(context.Background(), context.Background(), body, nil, nil, initial)
+	if err != nil {
+		t.Fatalf("maybeRetryCompactedResponsesRequest() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if owner.providerID != "backup" {
+		t.Fatalf("owner.providerID = %q, want backup", owner.providerID)
+	}
+}
+
+func TestFallbackAfterCanceledStreamingContextUsesStreamingTimeout(t *testing.T) {
+	customTimeout := upstreamTimeout + time.Hour
+	ctx := contextWithUpstreamAttemptTimeout(context.Background(), customTimeout)
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+	attemptCtx, cleanup := context.WithTimeout(context.WithoutCancel(ctx), upstreamAttemptTimeoutFromContext(ctx, upstreamTimeout))
+	defer cleanup()
+	deadline, ok := attemptCtx.Deadline()
+	if !ok {
+		t.Fatal("fallback attempt context has no deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining < upstreamTimeout+30*time.Minute {
+		t.Fatalf("fallback attempt timeout = %s, want preserved streaming/custom timeout greater than upstreamTimeout %s", remaining, upstreamTimeout)
+	}
+}
+
+func newResponsesFallbackTestHandler(t *testing.T, primaryURL, backupURL string) *ProxyHandler {
+	t.Helper()
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelError),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{
+			{ID: "primary", Type: "openai-compatible", Default: true, BaseURL: primaryURL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-primary", Deployment: "primary-upstream", Endpoints: []string{providerEndpointResponses}}}},
+			{ID: "backup", Type: "openai-compatible", BaseURL: backupURL, AuthType: "none", Models: []ProviderModelConfig{{PublicID: "gpt-backup", Deployment: "backup-upstream", Endpoints: []string{providerEndpointResponses}}}},
+		}, Fallbacks: []ProviderFallbackConfig{{Public: "gpt-primary", Chain: []ProviderFallbackChainEntry{{Provider: "primary", Model: "gpt-primary"}, {Provider: "backup", Model: "gpt-backup"}}}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+	handler.maxRetries = 1
+	return handler
+}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -519,6 +519,9 @@ func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx con
 		}
 	}
 
+	if err := setup.configureFallbackChains(cfg.Fallbacks); err != nil {
+		return nil, err
+	}
 	return setup, nil
 }
 
@@ -550,6 +553,9 @@ func (h *ProxyHandler) ValidateDynamicProviderModels(ctx context.Context) error 
 		}
 	}
 
+	if err := setup.configureFallbackChains(h.providersConfig.Fallbacks); err != nil {
+		return err
+	}
 	h.dynamicProviderValidationPending.Store(false)
 	return nil
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -80,9 +80,8 @@ type ProviderFallbackConfig struct {
 
 // ProviderFallbackChainEntry names one provider/model hop in a fallback chain.
 type ProviderFallbackChainEntry struct {
-	Provider                 string `json:"provider" yaml:"provider"`
-	Model                    string `json:"model" yaml:"model"`
-	AllowProtocolTranslation bool   `json:"allow_protocol_translation,omitempty" yaml:"allow_protocol_translation,omitempty"`
+	Provider string `json:"provider" yaml:"provider"`
+	Model    string `json:"model" yaml:"model"`
 }
 
 // ProviderConfig configures one upstream provider instance.
@@ -481,7 +480,7 @@ func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx con
 		hasConfiguredState: true,
 	}
 
-	needsDynamicModelValidation := len(providers) > 1 && hasDynamicProvider(providers)
+	needsDynamicModelValidation := hasDynamicProvider(providers) && (len(providers) > 1 || len(cfg.Fallbacks) > 0)
 
 	if !needsDynamicModelValidation || !validateDynamicModels {
 		for _, providerID := range providerOrder {
@@ -533,7 +532,7 @@ func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx con
 // model-map updates are applied through providerSetup's locked replacement path.
 func (h *ProxyHandler) ValidateDynamicProviderModels(ctx context.Context) error {
 	setup := h.providerSetup()
-	if setup == nil || !setup.hasConfiguredState || len(setup.providers) <= 1 || !hasDynamicProvider(setup.providers) {
+	if setup == nil || !setup.hasConfiguredState || !hasDynamicProvider(setup.providers) || (len(setup.providers) <= 1 && len(h.providersConfig.Fallbacks) == 0) {
 		h.dynamicProviderValidationPending.Store(false)
 		return nil
 	}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -2644,6 +2644,9 @@ func (ps *providerSetup) configureFallbackChains(configs []ProviderFallbackConfi
 		if public == "" {
 			return fmt.Errorf("fallback public model is required")
 		}
+		if _, exists := chains[public]; exists {
+			return fmt.Errorf("fallback %q is configured more than once", public)
+		}
 		if len(cfg.Chain) == 0 {
 			return fmt.Errorf("fallback %q must include at least one chain entry", public)
 		}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -174,9 +174,10 @@ type providerRuntime struct {
 }
 
 type providerEndpointRuntime struct {
-	endpoint selector.Endpoint
-	apiKey   string
-	health   *endpointHealthTracker
+	endpoint                 selector.Endpoint
+	apiKey                   string
+	health                   *endpointHealthTracker
+	retryInternalServerError bool
 }
 
 type providerEndpointPaths struct {
@@ -2444,9 +2445,10 @@ func buildProviderEndpointRuntimes(providerID string, kind providerType, cfg Pro
 			return nil, nil, nil, "", fmt.Errorf("provider %q endpoint %q: %w", providerID, name, err)
 		}
 		runtime := &providerEndpointRuntime{
-			endpoint: selector.Endpoint{Name: name, BaseURL: baseURL, Weight: raw.Weight, Healthy: true},
-			apiKey:   apiKey,
-			health:   newEndpointHealthTracker(healthCfg),
+			endpoint:                 selector.Endpoint{Name: name, BaseURL: baseURL, Weight: raw.Weight, Healthy: true},
+			apiKey:                   apiKey,
+			health:                   newEndpointHealthTracker(healthCfg),
+			retryInternalServerError: len(cfg.Endpoints) > 1,
 		}
 		endpoints = append(endpoints, runtime)
 		byName[name] = runtime
@@ -2677,6 +2679,16 @@ func (ps *providerSetup) lookupProviderModel(providerID, modelID string) (provid
 	provider := ps.providerByID(providerID)
 	if provider == nil {
 		return providerModel{}, false
+	}
+	modelID = strings.TrimSpace(modelID)
+	if providerUsesDynamicModels(provider) {
+		ps.modelsMu.RLock()
+		model, ok := ps.models[modelID]
+		ps.modelsMu.RUnlock()
+		if !ok || model.providerID != providerID {
+			return providerModel{}, false
+		}
+		return model, true
 	}
 	if model, ok := provider.staticModels[modelID]; ok {
 		return model, true

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -458,7 +458,7 @@ func (h *ProxyHandler) initializeProviders() error {
 		return err
 	}
 	h.providersState = setup
-	h.dynamicProviderValidationPending.Store(h.deferDynamicProviderModelRefresh && len(setup.providers) > 1 && hasDynamicProvider(setup.providers))
+	h.dynamicProviderValidationPending.Store(h.deferDynamicProviderModelRefresh && hasDynamicProvider(setup.providers) && (len(setup.providers) > 1 || len(h.providersConfig.Fallbacks) > 0))
 	return nil
 }
 
@@ -489,8 +489,10 @@ func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx con
 				return nil, err
 			}
 		}
-		if err := setup.configureFallbackChains(cfg.Fallbacks); err != nil {
-			return nil, err
+		if validateDynamicModels || !hasDynamicProvider(providers) {
+			if err := setup.configureFallbackChains(cfg.Fallbacks); err != nil {
+				return nil, err
+			}
 		}
 		return setup, nil
 	}
@@ -2660,6 +2662,9 @@ func (ps *providerSetup) configureFallbackChains(configs []ProviderFallbackConfi
 				return fmt.Errorf("fallback %q references unknown model %q on provider %q", public, modelID, providerID)
 			}
 			chain = append(chain, model)
+		}
+		if len(chain) > 0 && chain[0].publicID != public {
+			return fmt.Errorf("fallback %q public key must match first chain model %q", public, chain[0].publicID)
 		}
 		chains[public] = chain
 	}

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -62,13 +62,27 @@ var openAICodexProviderEndpoints = []string{providerEndpointResponses}
 // ProvidersConfig configures optional non-Copilot upstream providers.
 // When empty, the proxy keeps its legacy zero-config Copilot behavior.
 type ProvidersConfig struct {
-	Providers      []ProviderConfig     `json:"providers" yaml:"providers"`
-	ToolOptimizers ToolOptimizersConfig `json:"tool_optimizers,omitempty" yaml:"tool_optimizers,omitempty"`
+	Providers      []ProviderConfig         `json:"providers" yaml:"providers"`
+	Fallbacks      []ProviderFallbackConfig `json:"fallbacks,omitempty" yaml:"fallbacks,omitempty"`
+	ToolOptimizers ToolOptimizersConfig     `json:"tool_optimizers,omitempty" yaml:"tool_optimizers,omitempty"`
 	// InsightModel is the public model ID the dashboard uses to generate
 	// natural-language traffic insights on demand. Empty disables the feature
 	// (the dashboard's "Generate insights" button is hidden). The model must be
 	// one served by the configured providers.
 	InsightModel string `json:"insight_model,omitempty" yaml:"insight_model,omitempty"`
+}
+
+// ProviderFallbackConfig declares an ordered cross-provider fallback chain for one public model.
+type ProviderFallbackConfig struct {
+	Public string                       `json:"public" yaml:"public"`
+	Chain  []ProviderFallbackChainEntry `json:"chain" yaml:"chain"`
+}
+
+// ProviderFallbackChainEntry names one provider/model hop in a fallback chain.
+type ProviderFallbackChainEntry struct {
+	Provider                 string `json:"provider" yaml:"provider"`
+	Model                    string `json:"model" yaml:"model"`
+	AllowProtocolTranslation bool   `json:"allow_protocol_translation,omitempty" yaml:"allow_protocol_translation,omitempty"`
 }
 
 // ProviderConfig configures one upstream provider instance.
@@ -190,6 +204,7 @@ type providerSetup struct {
 	defaultProviderID  string
 	modelsMu           sync.RWMutex
 	models             map[string]providerModel
+	fallbackChains     map[string][]providerModel
 	hasConfiguredState bool
 }
 
@@ -319,6 +334,7 @@ func defaultProviderSetup(h *ProxyHandler) *providerSetup {
 		providerOrder:     []string{"copilot"},
 		defaultProviderID: "copilot",
 		models:            map[string]providerModel{},
+		fallbackChains:    map[string][]providerModel{},
 	}
 }
 
@@ -460,6 +476,7 @@ func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx con
 		providerOrder:      providerOrder,
 		defaultProviderID:  defaultProviderID,
 		models:             make(map[string]providerModel),
+		fallbackChains:     make(map[string][]providerModel),
 		hasConfiguredState: true,
 	}
 
@@ -470,6 +487,9 @@ func (h *ProxyHandler) buildConfiguredProviderSetupWithDynamicValidation(ctx con
 			if err := setup.addStaticProviderModels(providerID); err != nil {
 				return nil, err
 			}
+		}
+		if err := setup.configureFallbackChains(cfg.Fallbacks); err != nil {
+			return nil, err
 		}
 		return setup, nil
 	}
@@ -2588,4 +2608,59 @@ func providerHasEndpointCredentials(provider *providerRuntime) bool {
 		}
 	}
 	return false
+}
+
+func (ps *providerSetup) configureFallbackChains(configs []ProviderFallbackConfig) error {
+	if ps == nil || len(configs) == 0 {
+		return nil
+	}
+	chains := make(map[string][]providerModel, len(configs))
+	for _, cfg := range configs {
+		public := strings.TrimSpace(cfg.Public)
+		if public == "" {
+			return fmt.Errorf("fallback public model is required")
+		}
+		if len(cfg.Chain) == 0 {
+			return fmt.Errorf("fallback %q must include at least one chain entry", public)
+		}
+		chain := make([]providerModel, 0, len(cfg.Chain))
+		for _, entry := range cfg.Chain {
+			providerID := strings.TrimSpace(entry.Provider)
+			modelID := strings.TrimSpace(entry.Model)
+			if providerID == "" || modelID == "" {
+				return fmt.Errorf("fallback %q chain entries must set provider and model", public)
+			}
+			provider := ps.providerByID(providerID)
+			if provider == nil {
+				return fmt.Errorf("fallback %q references unknown provider %q", public, providerID)
+			}
+			model, ok := provider.staticModels[modelID]
+			if !ok {
+				if providerUsesDynamicModels(provider) {
+					model = providerModel{publicID: modelID, upstreamModel: modelID, providerID: providerID, supportedEndpoints: provider.defaultDynamicModelEndpoints()}
+					ok = true
+				}
+			}
+			if !ok {
+				return fmt.Errorf("fallback %q references unknown model %q on provider %q", public, modelID, providerID)
+			}
+			chain = append(chain, model)
+		}
+		chains[public] = chain
+	}
+	ps.fallbackChains = chains
+	return nil
+}
+
+func (ps *providerSetup) fallbackChain(public string) []providerModel {
+	if ps == nil {
+		return nil
+	}
+	chain := ps.fallbackChains[strings.TrimSpace(public)]
+	if len(chain) == 0 {
+		return nil
+	}
+	out := make([]providerModel, len(chain))
+	copy(out, chain)
+	return out
 }

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -204,6 +204,7 @@ type providerSetup struct {
 	defaultProviderID  string
 	modelsMu           sync.RWMutex
 	models             map[string]providerModel
+	fallbackChainsMu   sync.RWMutex
 	fallbackChains     map[string][]providerModel
 	hasConfiguredState bool
 }
@@ -2654,13 +2655,7 @@ func (ps *providerSetup) configureFallbackChains(configs []ProviderFallbackConfi
 			if provider == nil {
 				return fmt.Errorf("fallback %q references unknown provider %q", public, providerID)
 			}
-			model, ok := provider.staticModels[modelID]
-			if !ok {
-				if providerUsesDynamicModels(provider) {
-					model = providerModel{publicID: modelID, upstreamModel: modelID, providerID: providerID, supportedEndpoints: provider.defaultDynamicModelEndpoints()}
-					ok = true
-				}
-			}
+			model, ok := ps.lookupProviderModel(providerID, modelID)
 			if !ok {
 				return fmt.Errorf("fallback %q references unknown model %q on provider %q", public, modelID, providerID)
 			}
@@ -2668,15 +2663,36 @@ func (ps *providerSetup) configureFallbackChains(configs []ProviderFallbackConfi
 		}
 		chains[public] = chain
 	}
+	ps.fallbackChainsMu.Lock()
 	ps.fallbackChains = chains
+	ps.fallbackChainsMu.Unlock()
 	return nil
+}
+
+func (ps *providerSetup) lookupProviderModel(providerID, modelID string) (providerModel, bool) {
+	provider := ps.providerByID(providerID)
+	if provider == nil {
+		return providerModel{}, false
+	}
+	if model, ok := provider.staticModels[modelID]; ok {
+		return model, true
+	}
+	ps.modelsMu.RLock()
+	defer ps.modelsMu.RUnlock()
+	model, ok := ps.models[modelID]
+	if !ok || model.providerID != providerID {
+		return providerModel{}, false
+	}
+	return model, true
 }
 
 func (ps *providerSetup) fallbackChain(public string) []providerModel {
 	if ps == nil {
 		return nil
 	}
+	ps.fallbackChainsMu.RLock()
 	chain := ps.fallbackChains[strings.TrimSpace(public)]
+	ps.fallbackChainsMu.RUnlock()
 	if len(chain) == 0 {
 		return nil
 	}

--- a/proxy/request_summary.go
+++ b/proxy/request_summary.go
@@ -255,3 +255,15 @@ func observeUpstreamHeaders(ctx context.Context, headers http.Header) {
 		summary.setUpstreamRequestID(UpstreamRequestID(headers))
 	}
 }
+
+func (h *ProxyHandler) observeSelectedProvider(ctx context.Context, owner providerModel) {
+	summary := RequestSummaryFromContext(ctx)
+	if summary == nil || strings.TrimSpace(owner.providerID) == "" {
+		return
+	}
+	provider := h.providerSetup().providerByID(owner.providerID)
+	if provider == nil {
+		return
+	}
+	summary.setProvider(provider.id, string(provider.kind))
+}

--- a/proxy/request_summary.go
+++ b/proxy/request_summary.go
@@ -61,6 +61,13 @@ func WithRequestSummary(ctx context.Context) (context.Context, *RequestSummary) 
 
 // RequestSummaryFromContext returns the mutable request summary attached to ctx,
 // if any.
+func contextWithRequestSummary(ctx context.Context, summary *RequestSummary) context.Context {
+	if summary == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, requestSummaryContextKey{}, summary)
+}
+
 func RequestSummaryFromContext(ctx context.Context) *RequestSummary {
 	if ctx == nil {
 		return nil

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -107,6 +107,7 @@ func (h *ProxyHandler) postPreparedResponsesRequest(ctx, observeCtx context.Cont
 	if err != nil {
 		return nil, providerModel{}, err
 	}
+	h.observeSelectedProvider(observeCtx, selectedOwner)
 	resp, err = h.maybeRetryCompactedResponsesRequest(ctx, observeCtx, req.body, req.extraHeaders, req.upstreamHeaders, resp)
 	return resp, selectedOwner, err
 }

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -101,12 +102,13 @@ func responsesRequestStreams(bodyBytes []byte) bool {
 	return partial.Stream != nil && *partial.Stream
 }
 
-func (h *ProxyHandler) postPreparedResponsesRequest(ctx, observeCtx context.Context, req preparedResponsesRequest) (*http.Response, error) {
-	resp, err := h.postResponsesWithHeaders(ctx, req.body, req.upstreamHeaders)
+func (h *ProxyHandler) postPreparedResponsesRequest(ctx, observeCtx context.Context, req preparedResponsesRequest) (*http.Response, providerModel, error) {
+	resp, selectedOwner, err := h.postResponsesWithHeadersTracked(ctx, req.body, req.upstreamHeaders)
 	if err != nil {
-		return nil, err
+		return nil, providerModel{}, err
 	}
-	return h.maybeRetryCompactedResponsesRequest(ctx, observeCtx, req.body, req.extraHeaders, req.upstreamHeaders, resp)
+	resp, err = h.maybeRetryCompactedResponsesRequest(ctx, observeCtx, req.body, req.extraHeaders, req.upstreamHeaders, resp)
+	return resp, selectedOwner, err
 }
 
 func (h *ProxyHandler) writeResponsesUpstreamRequestFailure(w http.ResponseWriter, endpoint string, err error) {
@@ -156,7 +158,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.postPreparedResponsesRequest(upstreamCtx, r.Context(), prepared)
+	resp, selectedOwner, err := h.postPreparedResponsesRequest(upstreamCtx, r.Context(), prepared)
 	if err != nil {
 		h.writeResponsesUpstreamRequestFailure(w, "responses", err)
 		return
@@ -170,7 +172,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeResponsesUpstreamResponse(r.Context(), w, resp, h.toolContexts, prepared.headerToolScope)
+	h.writeResponsesUpstreamResponse(r.Context(), w, normalizeResponsesModelResponse(resp, extractRequestModel(prepared.body), selectedOwner.upstreamModel), h.toolContexts, prepared.headerToolScope)
 }
 
 // compactPrompt is the system instruction used when the upstream does not
@@ -3348,4 +3350,40 @@ func (h *ProxyHandler) pickResponsesCompatibleModel(ctx context.Context, provide
 	}
 
 	return firstAvailable, nil
+}
+
+func normalizeResponsesModelResponse(resp *http.Response, publicModel, upstreamModel string) *http.Response {
+	if resp == nil || resp.Body == nil || resp.StatusCode != http.StatusOK || strings.TrimSpace(publicModel) == "" || strings.TrimSpace(publicModel) == strings.TrimSpace(upstreamModel) {
+		return resp
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp
+	}
+	if rawJSONString(payload["model"]) == "" {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp
+	}
+	raw, err := json.Marshal(publicModel)
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp
+	}
+	payload["model"] = raw
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp
+	}
+	resp.Header.Del("Content-Length")
+	resp.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
+	resp.Body = io.NopCloser(bytes.NewReader(rewritten))
+	return resp
 }

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -3411,24 +3411,33 @@ func newResponsesModelRewriteReadCloser(body io.ReadCloser, publicModel string) 
 	pr, pw := io.Pipe()
 	go func() {
 		defer func() { _ = body.Close() }()
-		reader := bufio.NewReader(body)
+		reader := bufio.NewReaderSize(body, responsesFailureTapMaxBuffer)
 		for {
-			line, err := reader.ReadString('\n')
-			if line != "" {
-				_, writeErr := io.WriteString(pw, rewriteResponsesSSEModelLine(line, publicModel))
-				if writeErr != nil {
+			fragment, err := reader.ReadSlice('\n')
+			if len(fragment) != 0 {
+				line := string(fragment)
+				if err != bufio.ErrBufferFull {
+					line = rewriteResponsesSSEModelLine(line, publicModel)
+				}
+				if _, writeErr := io.WriteString(pw, line); writeErr != nil {
 					_ = pw.CloseWithError(writeErr)
 					return
 				}
 			}
-			if err != nil {
-				if err == io.EOF {
-					_ = pw.Close()
-				} else {
-					_ = pw.CloseWithError(err)
-				}
-				return
+			if err == nil {
+				continue
 			}
+			if err == bufio.ErrBufferFull {
+				// The current SSE line is larger than the rewrite cap. Stream it
+				// through unchanged in bounded chunks until the delimiter appears.
+				continue
+			}
+			if err == io.EOF {
+				_ = pw.Close()
+			} else {
+				_ = pw.CloseWithError(err)
+			}
+			return
 		}
 	}()
 	return pr
@@ -3447,17 +3456,38 @@ func rewriteResponsesSSEModelLine(line, publicModel string) string {
 		return line
 	}
 	var payload map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(jsonPart), &payload); err != nil || rawJSONString(payload["model"]) == "" {
+	if err := json.Unmarshal([]byte(jsonPart), &payload); err != nil {
 		return line
 	}
-	raw, err := json.Marshal(publicModel)
-	if err != nil {
+	if !rewriteResponsesPayloadModels(payload, publicModel) {
 		return line
 	}
-	payload["model"] = raw
 	rewritten, err := json.Marshal(payload)
 	if err != nil {
 		return line
 	}
 	return line[:prefixLen+leading] + string(rewritten) + lineEnding
+}
+
+func rewriteResponsesPayloadModels(payload map[string]json.RawMessage, publicModel string) bool {
+	raw, err := json.Marshal(publicModel)
+	if err != nil {
+		return false
+	}
+	changed := false
+	if rawJSONString(payload["model"]) != "" {
+		payload["model"] = raw
+		changed = true
+	}
+	if rawResponse := payload["response"]; len(rawResponse) != 0 {
+		var response map[string]json.RawMessage
+		if err := json.Unmarshal(rawResponse, &response); err == nil && rawJSONString(response["model"]) != "" {
+			response["model"] = raw
+			if rewritten, err := json.Marshal(response); err == nil {
+				payload["response"] = rewritten
+				changed = true
+			}
+		}
+	}
+	return changed
 }

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -169,6 +170,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 
 	if prepared.streaming && resp.StatusCode == http.StatusOK {
 		model := extractRequestModel(prepared.body)
+		resp = normalizeResponsesStreamModelResponse(resp, model, selectedOwner.upstreamModel)
 		peekAndForwardResponses(h, w, r, resp, upstreamCancel, model, prepared.headerToolScope)
 		return
 	}
@@ -3357,34 +3359,105 @@ func normalizeResponsesModelResponse(resp *http.Response, publicModel, upstreamM
 	if resp == nil || resp.Body == nil || resp.StatusCode != http.StatusOK || strings.TrimSpace(publicModel) == "" || strings.TrimSpace(publicModel) == strings.TrimSpace(upstreamModel) {
 		return resp
 	}
-	body, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	prefix, err := io.ReadAll(io.LimitReader(resp.Body, usageSniffMaxBuffer+1))
 	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.Body = io.NopCloser(bytes.NewReader(prefix))
 		return resp
 	}
+	if len(prefix) > usageSniffMaxBuffer {
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{Reader: io.MultiReader(bytes.NewReader(prefix), resp.Body), Closer: resp.Body}
+		return resp
+	}
+	_ = resp.Body.Close()
 	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(body, &payload); err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(body))
+	if err := json.Unmarshal(prefix, &payload); err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(prefix))
 		return resp
 	}
 	if rawJSONString(payload["model"]) == "" {
-		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.Body = io.NopCloser(bytes.NewReader(prefix))
 		return resp
 	}
 	raw, err := json.Marshal(publicModel)
 	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.Body = io.NopCloser(bytes.NewReader(prefix))
 		return resp
 	}
 	payload["model"] = raw
 	rewritten, err := json.Marshal(payload)
 	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.Body = io.NopCloser(bytes.NewReader(prefix))
 		return resp
 	}
 	resp.Header.Del("Content-Length")
 	resp.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
 	resp.Body = io.NopCloser(bytes.NewReader(rewritten))
 	return resp
+}
+
+func normalizeResponsesStreamModelResponse(resp *http.Response, publicModel, upstreamModel string) *http.Response {
+	if resp == nil || resp.Body == nil || resp.StatusCode != http.StatusOK || strings.TrimSpace(publicModel) == "" || strings.TrimSpace(publicModel) == strings.TrimSpace(upstreamModel) {
+		return resp
+	}
+	resp.Body = newResponsesModelRewriteReadCloser(resp.Body, publicModel)
+	resp.Header.Del("Content-Length")
+	return resp
+}
+
+func newResponsesModelRewriteReadCloser(body io.ReadCloser, publicModel string) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		defer func() { _ = body.Close() }()
+		reader := bufio.NewReader(body)
+		for {
+			line, err := reader.ReadString('\n')
+			if line != "" {
+				_, writeErr := io.WriteString(pw, rewriteResponsesSSEModelLine(line, publicModel))
+				if writeErr != nil {
+					_ = pw.CloseWithError(writeErr)
+					return
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					_ = pw.Close()
+				} else {
+					_ = pw.CloseWithError(err)
+				}
+				return
+			}
+		}
+	}()
+	return pr
+}
+
+func rewriteResponsesSSEModelLine(line, publicModel string) string {
+	trimmed := strings.TrimPrefix(line, "data:")
+	if trimmed == line || len(line) > responsesFailureTapMaxBuffer {
+		return line
+	}
+	prefixLen := len(line) - len(trimmed)
+	leading := len(trimmed) - len(strings.TrimLeft(trimmed, " 	"))
+	jsonPart := strings.TrimRight(trimmed[leading:], "\r\n")
+	lineEnding := line[prefixLen+leading+len(jsonPart):]
+	if jsonPart == "" || jsonPart == "[DONE]" {
+		return line
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(jsonPart), &payload); err != nil || rawJSONString(payload["model"]) == "" {
+		return line
+	}
+	raw, err := json.Marshal(publicModel)
+	if err != nil {
+		return line
+	}
+	payload["model"] = raw
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return line
+	}
+	return line[:prefixLen+leading] + string(rewritten) + lineEnding
 }

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -106,10 +106,15 @@ func responsesRequestStreams(bodyBytes []byte) bool {
 func (h *ProxyHandler) postPreparedResponsesRequest(ctx, observeCtx context.Context, req preparedResponsesRequest) (*http.Response, providerModel, error) {
 	resp, selectedOwner, err := h.postResponsesWithHeadersTracked(ctx, req.body, req.upstreamHeaders)
 	if err != nil {
-		return nil, providerModel{}, err
+		h.observeSelectedProvider(observeCtx, selectedOwner)
+		return nil, selectedOwner, err
 	}
 	h.observeSelectedProvider(observeCtx, selectedOwner)
-	resp, err = h.maybeRetryCompactedResponsesRequest(ctx, observeCtx, req.body, req.extraHeaders, req.upstreamHeaders, resp)
+	resp, retryOwner, err := h.maybeRetryCompactedResponsesRequest(ctx, observeCtx, req.body, req.extraHeaders, req.upstreamHeaders, resp)
+	if retryOwner.providerID != "" {
+		selectedOwner = retryOwner
+		h.observeSelectedProvider(observeCtx, selectedOwner)
+	}
 	return resp, selectedOwner, err
 }
 
@@ -2203,15 +2208,15 @@ func (h *ProxyHandler) postResponsesWithFallbackHeaders(ctx context.Context, bod
 	return resp, err
 }
 
-func (h *ProxyHandler) maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx context.Context, bodyBytes []byte, extraHeaders http.Header, resp *http.Response) (*http.Response, error) {
+func (h *ProxyHandler) maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx context.Context, bodyBytes []byte, extraHeaders http.Header, resp *http.Response) (*http.Response, providerModel, error) {
 	if resp == nil || resp.StatusCode != http.StatusBadRequest {
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 
 	respBodyPrefix, err := io.ReadAll(io.LimitReader(resp.Body, int64(compactUpstreamErrorBodySize)+1))
 	if err != nil {
 		_ = resp.Body.Close()
-		return nil, err
+		return nil, providerModel{}, err
 	}
 	classificationBody := respBodyPrefix
 	if len(classificationBody) > compactUpstreamErrorBodySize {
@@ -2231,24 +2236,24 @@ func (h *ProxyHandler) maybeRetryResponsesWithoutUnverifiableEncryptedContent(ct
 	}
 
 	if !isUnverifiableEncryptedContentError(resp.StatusCode, classificationBody) {
-		return restoreOriginalResp(), nil
+		return restoreOriginalResp(), providerModel{}, nil
 	}
 
 	retryBody, strippedItems := sanitizeResponsesUnverifiableEncryptedContentBody(bodyBytes)
 	if strippedItems == 0 {
-		return restoreOriginalResp(), nil
+		return restoreOriginalResp(), providerModel{}, nil
 	}
 
 	h.log.Info("retrying responses request without unverifiable encrypted content",
 		logger.F("encrypted_items_stripped", strippedItems),
 	)
-	retryResp, retryErr := h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, retryBody, extraHeaders)
+	retryResp, retryOwner, _, retryErr := h.postJSONEndpointWithHeadersTracked(ctx, providerEndpointResponses, retryBody, extraHeaders)
 	if retryErr != nil {
 		h.log.Debug("responses encrypted-content retry request failed", logger.Err(retryErr))
-		return restoreOriginalResp(), nil
+		return restoreOriginalResp(), providerModel{}, nil
 	}
 	_ = resp.Body.Close()
-	return retryResp, nil
+	return retryResp, retryOwner, nil
 }
 
 type prefixedReadCloser struct {
@@ -2517,15 +2522,15 @@ func applyResolvedCompactModel(bodyBytes []byte, budget *compactBudget) []byte {
 	return sanitizeResponsesModelFallbackBody(rewritten)
 }
 
-func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx context.Context, bodyBytes []byte, extraHeaders, upstreamHeaders http.Header, resp *http.Response) (*http.Response, error) {
+func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx context.Context, bodyBytes []byte, extraHeaders, upstreamHeaders http.Header, resp *http.Response) (*http.Response, providerModel, error) {
 	if resp == nil || resp.StatusCode != http.StatusRequestEntityTooLarge {
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 
 	var requestFields map[string]json.RawMessage
 	if err := json.Unmarshal(bodyBytes, &requestFields); err != nil {
 		h.log.Debug("responses 413 compaction skipped", logger.F("reason", "invalid_request_json"), logger.Err(err))
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 
 	var previousResponseID string
@@ -2535,14 +2540,14 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx conte
 	var model string
 	if err := json.Unmarshal(requestFields["model"], &model); err != nil || strings.TrimSpace(model) == "" {
 		h.log.Debug("responses 413 compaction skipped", logger.F("reason", "missing_model"))
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 	model = strings.TrimSpace(model)
 
 	var input []json.RawMessage
 	if err := json.Unmarshal(requestFields["input"], &input); err != nil {
 		h.log.Debug("responses 413 compaction skipped", logger.F("reason", "input_not_array"), logger.Err(err))
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 	if !isLikelyResponsesReplay(input) {
 		h.log.Info("responses 413 compaction skipped",
@@ -2550,25 +2555,25 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx conte
 			logger.F("input_items", len(input)),
 			logger.F("previous_response_id_present", previousResponseID != ""),
 		)
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 
 	configuredKeepTail := h.responsesWebSocketConfig().AutoCompactKeepTail
 	if configuredKeepTail <= 0 {
 		h.log.Debug("responses 413 compaction skipped", logger.F("reason", "keep_tail_disabled"), logger.F("keep_tail", configuredKeepTail))
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 
 	keepTailSchedule := compactedResponsesRetryKeepTailSchedule(len(input), configuredKeepTail)
 	if len(keepTailSchedule) == 0 {
 		h.log.Debug("responses 413 compaction skipped", logger.F("reason", "not_enough_input_items"), logger.F("input_items", len(input)), logger.F("keep_tail", configuredKeepTail))
-		return resp, nil
+		return resp, providerModel{}, nil
 	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		_ = resp.Body.Close()
-		return nil, err
+		return nil, providerModel{}, err
 	}
 	_ = resp.Body.Close()
 	lastResp := cloneHTTPResponseWithBody(resp, respBody)
@@ -2591,13 +2596,13 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx conte
 		summary, err := h.compactResponsesInputWithBudget(ctx, model, input[:prefixLen], extraHeaders, budget)
 		if err != nil {
 			h.log.Debug("responses 413 compaction failed", logger.F("keep_tail", keepTail), logger.Err(err))
-			return lastResp, nil
+			return lastResp, providerModel{}, nil
 		}
 
 		checkpoint, err := proxyCompactionContextRawMessage(summary)
 		if err != nil {
 			h.log.Debug("responses 413 compaction checkpoint build failed", logger.F("keep_tail", keepTail), logger.Err(err))
-			return lastResp, nil
+			return lastResp, providerModel{}, nil
 		}
 
 		compactedInput := make([]json.RawMessage, 0, alignedKeepTail+1)
@@ -2607,14 +2612,14 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx conte
 		compactedInputRaw, err := json.Marshal(compactedInput)
 		if err != nil {
 			h.log.Debug("responses 413 compaction marshal failed", logger.F("keep_tail", keepTail), logger.Err(err))
-			return lastResp, nil
+			return lastResp, providerModel{}, nil
 		}
 		requestFields["input"] = compactedInputRaw
 
 		retryBody, err := json.Marshal(requestFields)
 		if err != nil {
 			h.log.Debug("responses 413 retry body marshal failed", logger.F("keep_tail", keepTail), logger.Err(err))
-			return lastResp, nil
+			return lastResp, providerModel{}, nil
 		}
 
 		fields := []logger.Field{
@@ -2636,19 +2641,19 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx conte
 		}
 		h.log.Info("retrying responses request with compacted history after 413", fields...)
 
-		retryResp, retryErr := h.postResponsesWithHeaders(ctx, retryBody, upstreamHeaders)
+		retryResp, retryOwner, retryErr := h.postResponsesWithHeadersTracked(ctx, retryBody, upstreamHeaders)
 		if retryErr != nil {
 			h.log.Debug("responses 413 retry request failed", logger.F("keep_tail", keepTail), logger.Err(retryErr))
-			return lastResp, nil
+			return lastResp, providerModel{}, nil
 		}
 		if retryResp.StatusCode != http.StatusRequestEntityTooLarge {
-			return retryResp, nil
+			return retryResp, retryOwner, nil
 		}
 
 		retryBodyBytes, truncated, readErr := readBodyWithCap(retryResp.Body, compactUpstreamErrorBodySize)
 		_ = retryResp.Body.Close()
 		if readErr != nil {
-			return nil, readErr
+			return nil, providerModel{}, readErr
 		}
 		lastResp = cloneHTTPResponseWithBody(retryResp, retryBodyBytes)
 		if truncated {
@@ -2680,7 +2685,7 @@ func (h *ProxyHandler) maybeRetryCompactedResponsesRequest(ctx, observeCtx conte
 		logger.F("compact_attempts_used", compactAttempts),
 		logger.F("compact_attempts_max", compactMaxAttempts),
 	)
-	return lastResp, nil
+	return lastResp, providerModel{}, nil
 }
 
 func isLikelyResponsesReplay(input []json.RawMessage) bool {

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -145,6 +145,7 @@ type responsesWebSocketSession struct {
 	historyBytes   int
 	toolContexts   *ToolExecutionContextStore
 	toolScope      string
+	selectedOwner  providerModel
 	done           chan struct{}
 	doneOnce       sync.Once
 	inflightMu     sync.Mutex
@@ -698,7 +699,12 @@ func (s *responsesWebSocketSession) handleCreateRequest(h *ProxyHandler, request
 // completed turn, an error status for a failed one).
 func (s *responsesWebSocketSession) recordTurnStats(h *ProxyHandler, model string, status int, usage responsesUsage) {
 	providerID, providerKind := "", ""
-	if provider, _, _ := h.resolveProviderModel(model, providerEndpointResponses); provider != nil {
+	if s.selectedOwner.providerID != "" {
+		providerID = s.selectedOwner.providerID
+		if provider := h.providerSetup().providerByID(providerID); provider != nil {
+			providerKind = string(provider.kind)
+		}
+	} else if provider, _, _ := h.resolveProviderModel(model, providerEndpointResponses); provider != nil {
 		providerID, providerKind = provider.id, string(provider.kind)
 	}
 	h.RecordResponsesTurn(model, providerID, providerKind, classifyAgent(s.userAgent), status, usage)
@@ -779,7 +785,11 @@ func (s *responsesWebSocketSession) postCreateRequestSegments(h *ProxyHandler, c
 	if compactionResp, handled, _, err := h.maybeBuildResponsesCompactionTriggerResponse(ctx, bodyBytes, headers, true); handled || err != nil {
 		return compactionResp, err
 	}
-	return h.postResponsesWithHeaders(ctx, bodyBytes, headers)
+	resp, owner, err := h.postResponsesWithHeadersTracked(ctx, bodyBytes, headers)
+	if owner.providerID != "" {
+		s.selectedOwner = owner
+	}
+	return resp, err
 }
 
 func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCreateRequest, includeTurnState bool) http.Header {

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -43,6 +43,13 @@ func retryable(statusCode int) bool {
 	return false
 }
 
+func retryableForAttempt(statusCode int, endpoint *providerEndpointRuntime) bool {
+	if retryable(statusCode) {
+		return true
+	}
+	return statusCode == http.StatusInternalServerError && endpoint != nil && endpoint.retryInternalServerError
+}
+
 // backoff returns the delay for the given attempt (0-indexed) with jitter.
 func backoff(base time.Duration, attempt int) time.Duration {
 	if base <= 0 {
@@ -149,7 +156,7 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			continue
 		}
 
-		if !retryable(resp.StatusCode) {
+		if !retryableForAttempt(resp.StatusCode, attemptEndpoint) {
 			if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 				recordEndpointSuccess(attemptEndpoint, time.Since(attemptStart))
 			} else if resp.StatusCode >= http.StatusInternalServerError {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -242,15 +242,18 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 		if i > 0 && ctx.Err() != nil {
 			attemptCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), upstreamTimeout)
 		}
-		if cancel != nil {
-			defer cancel()
-		}
 		attemptProvider := h.providerSetup().providerByID(attemptOwner.providerID)
 		if attemptProvider == nil || !attemptProvider.supportsEndpoint(path) || !providerModelSupportsEndpoint(attemptOwner, path) {
+			if cancel != nil {
+				cancel()
+			}
 			continue
 		}
 		attemptBody, prepErr := prepareProviderRequestBody(attemptProvider, attemptOwner, body, path)
 		if prepErr != nil {
+			if cancel != nil {
+				cancel()
+			}
 			return nil, providerModel{}, nil, prepErr
 		}
 		resp, postErr := h.doWithRetry(func() (*http.Request, error) {
@@ -263,6 +266,13 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 		lastOwner = attemptOwner
 		lastBody = attemptBody
 		if !shouldFallbackResponse(resp, postErr) || i == len(attempts)-1 {
+			if cancel != nil {
+				if resp != nil && resp.Body != nil && postErr == nil {
+					resp.Body = &cancelOnCloseReadCloser{ReadCloser: resp.Body, cancel: cancel}
+				} else {
+					cancel()
+				}
+			}
 			return resp, attemptOwner, attemptBody, postErr
 		}
 		lastErr = postErr
@@ -270,12 +280,29 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 			lastErr = &upstreamError{statusCode: resp.StatusCode, headers: resp.Header.Clone()}
 			drainAndClose(resp.Body)
 		}
+		if cancel != nil {
+			cancel()
+		}
 		h.logProviderFallback(owner.publicID, attemptOwner, attempts[i+1], lastErr)
 	}
 	if lastErr != nil {
 		return nil, lastOwner, lastBody, lastErr
 	}
 	return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no fallback provider available for model %q", owner.publicID)}
+}
+
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelOnCloseReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	if c.cancel != nil {
+		c.cancel()
+		c.cancel = nil
+	}
+	return err
 }
 
 func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*http.Response, error) {
@@ -584,7 +611,7 @@ func shouldFallbackToNextProvider(err error) bool {
 	}
 	var upstreamErr *upstreamError
 	if errors.As(err, &upstreamErr) {
-		return retryable(upstreamErr.statusCode)
+		return retryable(upstreamErr.statusCode) || upstreamErr.statusCode == http.StatusInternalServerError
 	}
 	return true
 }

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -248,11 +248,15 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 		})
 		lastOwner = attemptOwner
 		lastBody = attemptBody
-		if !shouldFallbackToNextProvider(postErr) || i == len(attempts)-1 {
+		if !shouldFallbackResponse(resp, postErr) || i == len(attempts)-1 {
 			return resp, attemptOwner, attemptBody, postErr
 		}
 		lastErr = postErr
-		h.logProviderFallback(owner.publicID, attemptOwner, attempts[i+1], postErr)
+		if lastErr == nil && resp != nil {
+			lastErr = &upstreamError{statusCode: resp.StatusCode, headers: resp.Header.Clone()}
+			drainAndClose(resp.Body)
+		}
+		h.logProviderFallback(owner.publicID, attemptOwner, attempts[i+1], lastErr)
 	}
 	if lastErr != nil {
 		return nil, lastOwner, lastBody, lastErr
@@ -273,7 +277,13 @@ func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte
 }
 
 func (h *ProxyHandler) postAnthropicMessages(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	return h.postJSONEndpointWithHeaders(ctx, providerEndpointMessages, body, extraHeaders)
+	resp, _, err := h.postAnthropicMessagesTracked(ctx, body, extraHeaders)
+	return resp, err
+}
+
+func (h *ProxyHandler) postAnthropicMessagesTracked(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, providerModel, error) {
+	resp, owner, _, err := h.postJSONEndpointWithHeadersTracked(ctx, providerEndpointMessages, body, extraHeaders)
+	return resp, owner, err
 }
 
 func (h *ProxyHandler) postAnthropicMessagesCountTokens(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
@@ -532,6 +542,13 @@ func (h *ProxyHandler) providerFallbackAttempts(owner providerModel, endpoint st
 		}
 	}
 	return attempts
+}
+
+func shouldFallbackResponse(resp *http.Response, err error) bool {
+	if err != nil {
+		return shouldFallbackToNextProvider(err)
+	}
+	return resp != nil && resp.StatusCode >= http.StatusInternalServerError
 }
 
 func shouldFallbackToNextProvider(err error) bool {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -277,11 +277,17 @@ func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*h
 }
 
 func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	resp, err := h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, body, extraHeaders)
+	resp, _, err := h.postResponsesWithHeadersTracked(ctx, body, extraHeaders)
+	return resp, err
+}
+
+func (h *ProxyHandler) postResponsesWithHeadersTracked(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, providerModel, error) {
+	resp, owner, _, err := h.postJSONEndpointWithHeadersTracked(ctx, providerEndpointResponses, body, extraHeaders)
 	if err != nil {
-		return nil, err
+		return nil, providerModel{}, err
 	}
-	return h.maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx, body, extraHeaders, resp)
+	resp, err = h.maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx, body, extraHeaders, resp)
+	return resp, owner, err
 }
 
 func (h *ProxyHandler) postAnthropicMessages(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -40,6 +40,9 @@ func (h *ProxyHandler) newInferenceUpstreamContextFrom(inbound context.Context, 
 	if isRetryStatsTracked(inbound) {
 		ctx = markRetryStatsTracked(ctx)
 	}
+	if summary := RequestSummaryFromContext(inbound); summary != nil {
+		ctx = contextWithRequestSummary(ctx, summary)
+	}
 	return ctx, cancel
 }
 
@@ -213,7 +216,10 @@ func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body [
 }
 
 func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	resp, _, _, err := h.postJSONEndpointWithHeadersTracked(ctx, path, body, extraHeaders)
+	resp, selectedOwner, _, err := h.postJSONEndpointWithHeadersTracked(ctx, path, body, extraHeaders)
+	if err == nil {
+		h.observeSelectedProvider(ctx, selectedOwner)
+	}
 	return resp, err
 }
 

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -29,6 +29,22 @@ func (h *ProxyHandler) newInferenceUpstreamContext(streaming bool) (context.Cont
 // non-tracked callers (insight, model-catalog fetch, count-token probes) stay
 // uncounted. Pass the inbound r.Context(); a context without the marker (e.g.
 // context.Background()) yields an untracked upstream context.
+type upstreamAttemptTimeoutContextKey struct{}
+
+func contextWithUpstreamAttemptTimeout(ctx context.Context, timeout time.Duration) context.Context {
+	if timeout <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, upstreamAttemptTimeoutContextKey{}, timeout)
+}
+
+func upstreamAttemptTimeoutFromContext(ctx context.Context, fallback time.Duration) time.Duration {
+	if timeout, ok := ctx.Value(upstreamAttemptTimeoutContextKey{}).(time.Duration); ok && timeout > 0 {
+		return timeout
+	}
+	return fallback
+}
+
 func (h *ProxyHandler) newInferenceUpstreamContextFrom(inbound context.Context, streaming bool) (context.Context, context.CancelFunc) {
 	// Use background context with timeout to avoid cancellation from client
 	// disconnects while still preventing goroutine leaks on upstream hangs.
@@ -43,6 +59,7 @@ func (h *ProxyHandler) newInferenceUpstreamContextFrom(inbound context.Context, 
 	if summary := RequestSummaryFromContext(inbound); summary != nil {
 		ctx = contextWithRequestSummary(ctx, summary)
 	}
+	ctx = contextWithUpstreamAttemptTimeout(ctx, timeout)
 	return ctx, cancel
 }
 
@@ -217,9 +234,7 @@ func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body [
 
 func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
 	resp, selectedOwner, _, err := h.postJSONEndpointWithHeadersTracked(ctx, path, body, extraHeaders)
-	if err == nil {
-		h.observeSelectedProvider(ctx, selectedOwner)
-	}
+	h.observeSelectedProvider(ctx, selectedOwner)
 	return resp, err
 }
 
@@ -240,7 +255,7 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 		attemptCtx := ctx
 		var cancel context.CancelFunc
 		if i > 0 && ctx.Err() != nil {
-			attemptCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), upstreamTimeout)
+			attemptCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), upstreamAttemptTimeoutFromContext(ctx, upstreamTimeout))
 		}
 		attemptProvider := h.providerSetup().providerByID(attemptOwner.providerID)
 		if attemptProvider == nil || !attemptProvider.supportsEndpoint(path) || !providerModelSupportsEndpoint(attemptOwner, path) {
@@ -249,7 +264,7 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 			}
 			continue
 		}
-		attemptBody, prepErr := prepareProviderRequestBody(attemptProvider, attemptOwner, body, path)
+		attemptBody, prepErr := prepareProviderRequestBody(attemptProvider, attemptOwner, body, path, owner)
 		if prepErr != nil {
 			if cancel != nil {
 				cancel()
@@ -317,9 +332,12 @@ func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte
 func (h *ProxyHandler) postResponsesWithHeadersTracked(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, providerModel, error) {
 	resp, owner, _, err := h.postJSONEndpointWithHeadersTracked(ctx, providerEndpointResponses, body, extraHeaders)
 	if err != nil {
-		return nil, providerModel{}, err
+		return nil, owner, err
 	}
-	resp, err = h.maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx, body, extraHeaders, resp)
+	resp, retryOwner, err := h.maybeRetryResponsesWithoutUnverifiableEncryptedContent(ctx, body, extraHeaders, resp)
+	if retryOwner.providerID != "" {
+		owner = retryOwner
+	}
 	return resp, owner, err
 }
 
@@ -541,7 +559,7 @@ func rewriteAnthropicModelFields(payload map[string]json.RawMessage, publicModel
 	return changed
 }
 
-func prepareProviderRequestBody(provider *providerRuntime, owner providerModel, body []byte, endpoint string) ([]byte, error) {
+func prepareProviderRequestBody(provider *providerRuntime, owner providerModel, body []byte, endpoint string, sourceOwners ...providerModel) ([]byte, error) {
 	rewrittenBody := body
 	if provider == nil {
 		return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
@@ -555,7 +573,30 @@ func prepareProviderRequestBody(provider *providerRuntime, owner providerModel, 
 			}
 		}
 	}
+	if endpoint == providerEndpointResponses && len(sourceOwners) > 0 && providerFallbackChangesStateOwner(sourceOwners[0], owner) {
+		rewrittenBody = stripResponsesPreviousResponseID(rewrittenBody)
+	}
 	return applyProviderModelRequestPolicy(rewrittenBody, owner), nil
+}
+
+func providerFallbackChangesStateOwner(source, target providerModel) bool {
+	return strings.TrimSpace(source.providerID) != "" && strings.TrimSpace(target.providerID) != "" && source.providerID != target.providerID
+}
+
+func stripResponsesPreviousResponseID(body []byte) []byte {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+	if _, ok := payload["previous_response_id"]; !ok {
+		return body
+	}
+	delete(payload, "previous_response_id")
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return rewritten
 }
 
 func (h *ProxyHandler) providerFallbackAttempts(owner providerModel, endpoint string) []providerModel {

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -231,6 +231,14 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 	lastOwner := owner
 	lastBody := rewrittenBody
 	for i, attemptOwner := range attempts {
+		attemptCtx := ctx
+		var cancel context.CancelFunc
+		if i > 0 && ctx.Err() != nil {
+			attemptCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), upstreamTimeout)
+		}
+		if cancel != nil {
+			defer cancel()
+		}
 		attemptProvider := h.providerSetup().providerByID(attemptOwner.providerID)
 		if attemptProvider == nil || !attemptProvider.supportsEndpoint(path) || !providerModelSupportsEndpoint(attemptOwner, path) {
 			continue
@@ -240,7 +248,7 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, p
 			return nil, providerModel{}, nil, prepErr
 		}
 		resp, postErr := h.doWithRetry(func() (*http.Request, error) {
-			req, err := h.newProviderJSONRequest(ctx, attemptProvider, http.MethodPost, path, attemptBody, extraHeaders, "", attemptOwner)
+			req, err := h.newProviderJSONRequest(attemptCtx, attemptProvider, http.MethodPost, path, attemptBody, extraHeaders, "", attemptOwner)
 			if err != nil {
 				return nil, err
 			}
@@ -557,6 +565,9 @@ func shouldFallbackToNextProvider(err error) bool {
 	}
 	var providerErr *providerRequestError
 	if errors.As(err, &providerErr) {
+		return providerErr.statusCode >= http.StatusInternalServerError
+	}
+	if permanentTransportError(err) {
 		return false
 	}
 	var upstreamErr *upstreamError

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -571,7 +571,7 @@ func shouldFallbackToNextProvider(err error) bool {
 	}
 	var providerErr *providerRequestError
 	if errors.As(err, &providerErr) {
-		return providerErr.statusCode >= http.StatusInternalServerError
+		return providerErr.statusCode >= http.StatusInternalServerError && strings.Contains(strings.ToLower(providerErr.err.Error()), "no healthy endpoints")
 	}
 	if permanentTransportError(err) {
 		return false

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sozercan/vekil/logger"
 	"github.com/sozercan/vekil/models"
 )
 
@@ -167,17 +168,10 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 		}
 	}
 
-	rewrittenBody := body
-	if provider.kind != providerTypeAzureOpenAI || len(provider.endpoints) == 0 {
-		if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
-			var err error
-			rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)
-			if err != nil {
-				return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
-			}
-		}
+	rewrittenBody, err := prepareProviderRequestBody(provider, owner, body, endpoint)
+	if err != nil {
+		return nil, providerModel{}, nil, err
 	}
-	rewrittenBody = applyProviderModelRequestPolicy(rewrittenBody, owner)
 	return provider, owner, rewrittenBody, nil
 }
 
@@ -219,18 +213,51 @@ func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body [
 }
 
 func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	provider, owner, rewrittenBody, err := h.resolveProviderRequest(body, path)
+	resp, _, _, err := h.postJSONEndpointWithHeadersTracked(ctx, path, body, extraHeaders)
+	return resp, err
+}
+
+func (h *ProxyHandler) postJSONEndpointWithHeadersTracked(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, providerModel, []byte, error) {
+	_, owner, rewrittenBody, err := h.resolveProviderRequest(body, path)
 	if err != nil {
-		return nil, err
+		return nil, providerModel{}, nil, err
 	}
 
-	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "", owner)
-		if err != nil {
-			return nil, err
+	attempts := h.providerFallbackAttempts(owner, path)
+	if len(attempts) == 0 {
+		attempts = []providerModel{owner}
+	}
+	var lastErr error
+	lastOwner := owner
+	lastBody := rewrittenBody
+	for i, attemptOwner := range attempts {
+		attemptProvider := h.providerSetup().providerByID(attemptOwner.providerID)
+		if attemptProvider == nil || !attemptProvider.supportsEndpoint(path) || !providerModelSupportsEndpoint(attemptOwner, path) {
+			continue
 		}
-		return req, nil
-	})
+		attemptBody, prepErr := prepareProviderRequestBody(attemptProvider, attemptOwner, body, path)
+		if prepErr != nil {
+			return nil, providerModel{}, nil, prepErr
+		}
+		resp, postErr := h.doWithRetry(func() (*http.Request, error) {
+			req, err := h.newProviderJSONRequest(ctx, attemptProvider, http.MethodPost, path, attemptBody, extraHeaders, "", attemptOwner)
+			if err != nil {
+				return nil, err
+			}
+			return req, nil
+		})
+		lastOwner = attemptOwner
+		lastBody = attemptBody
+		if !shouldFallbackToNextProvider(postErr) || i == len(attempts)-1 {
+			return resp, attemptOwner, attemptBody, postErr
+		}
+		lastErr = postErr
+		h.logProviderFallback(owner.publicID, attemptOwner, attempts[i+1], postErr)
+	}
+	if lastErr != nil {
+		return nil, lastOwner, lastBody, lastErr
+	}
+	return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("no fallback provider available for model %q", owner.publicID)}
 }
 
 func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*http.Response, error) {
@@ -455,4 +482,86 @@ func rewriteAnthropicModelFields(payload map[string]json.RawMessage, publicModel
 	}
 
 	return changed
+}
+
+func prepareProviderRequestBody(provider *providerRuntime, owner providerModel, body []byte, endpoint string) ([]byte, error) {
+	rewrittenBody := body
+	if provider == nil {
+		return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
+	}
+	if provider.kind != providerTypeAzureOpenAI || len(provider.endpoints) == 0 {
+		if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
+			var err error
+			rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)
+			if err != nil {
+				return nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
+			}
+		}
+	}
+	return applyProviderModelRequestPolicy(rewrittenBody, owner), nil
+}
+
+func (h *ProxyHandler) providerFallbackAttempts(owner providerModel, endpoint string) []providerModel {
+	setup := h.providerSetup()
+	chain := setup.fallbackChain(owner.publicID)
+	if len(chain) == 0 {
+		return nil
+	}
+	attempts := make([]providerModel, 0, len(chain)+1)
+	seenCurrent := false
+	for _, candidate := range chain {
+		if candidate.providerID == owner.providerID && candidate.publicID == owner.publicID {
+			seenCurrent = true
+		}
+		if !seenCurrent {
+			continue
+		}
+		if providerModelSupportsEndpoint(candidate, endpoint) {
+			attempts = append(attempts, candidate)
+		}
+	}
+	if len(attempts) == 0 {
+		attempts = append(attempts, owner)
+		for _, candidate := range chain {
+			if candidate.providerID == owner.providerID && candidate.publicID == owner.publicID {
+				continue
+			}
+			if providerModelSupportsEndpoint(candidate, endpoint) {
+				attempts = append(attempts, candidate)
+			}
+		}
+	}
+	return attempts
+}
+
+func shouldFallbackToNextProvider(err error) bool {
+	if err == nil {
+		return false
+	}
+	var providerErr *providerRequestError
+	if errors.As(err, &providerErr) {
+		return false
+	}
+	var upstreamErr *upstreamError
+	if errors.As(err, &upstreamErr) {
+		return retryable(upstreamErr.statusCode)
+	}
+	return true
+}
+
+func (h *ProxyHandler) logProviderFallback(requested string, from, to providerModel, cause error) {
+	if h == nil || h.log == nil {
+		return
+	}
+	fields := []logger.Field{
+		logger.F("requested_model", requested),
+		logger.F("from_provider", from.providerID),
+		logger.F("from_model", from.publicID),
+		logger.F("to_provider", to.providerID),
+		logger.F("to_model", to.publicID),
+	}
+	if cause != nil {
+		fields = append(fields, logger.Err(cause))
+	}
+	h.log.Info("provider fallback", fields...)
 }


### PR DESCRIPTION
## Summary

Implements issue #78 as a stacked PR on top of provider endpoint load balancing (#245).

- adds top-level `fallbacks` provider config
- resolves ordered provider/model fallback chains
- advances to the next provider only after retryable failures (`429`, `5xx`, transient transport/timeout)
- short-circuits client errors unchanged
- returns the last upstream error when all hops fail
- logs structured `provider fallback` events with source and destination provider/model fields
- documents fallback chain YAML and field reference

## Validation

- `make test`
- `make lint`
- `bash -n scripts/*.sh`
- built local image `vekil:issue78`
- loaded and deployed `vekil:issue78` to the current kind cluster as `vekil-system/vekil-issue78`
- verified `/healthz`, `/readyz`, and `/v1/models`
- verified a live request for `local-chat-primary` retried primary `mock-east` through 429s, emitted a `provider fallback` log, and succeeded on backup `mock-west`

## Stack

Base PR: #245 (`orka/issue76-provider-load-balancing`)

Fixes #78
