### PR TITLE
perf(proxy): reduce responses replay CPU usage

### DIFF
--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -1170,23 +1170,17 @@ func providerModelSupportsEndpoint(model providerModel, endpoint string) bool {
 }
 
 func rewriteRequestModelForProvider(body []byte, upstreamModel string) ([]byte, bool, error) {
+	return rewriteRequestModelForProviderFromModel(body, extractResponsesRequestModel(body), upstreamModel)
+}
+
+func rewriteRequestModelForProviderFromModel(body []byte, currentModel string, upstreamModel string) ([]byte, bool, error) {
 	upstreamModel = strings.TrimSpace(upstreamModel)
 	if upstreamModel == "" {
 		return body, false, nil
 	}
 
-	current := extractResponsesRequestModel(body)
-	if current == "" {
-		var payload struct {
-			Model string `json:"model"`
-		}
-		if err := json.Unmarshal(body, &payload); err != nil {
-			return body, false, nil
-		}
-		current = strings.TrimSpace(payload.Model)
-	}
-
-	if current == "" || current == upstreamModel {
+	currentModel = strings.TrimSpace(currentModel)
+	if currentModel == "" || currentModel == upstreamModel {
 		return body, false, nil
 	}
 	return rewriteResponsesRequestModel(body, upstreamModel)

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -70,39 +70,63 @@ func responsesUpstreamHeaders(extraHeaders http.Header, stream bool) http.Header
 
 type preparedResponsesRequest struct {
 	body            []byte
+	model           string
 	extraHeaders    http.Header
 	upstreamHeaders http.Header
 	headerToolScope string
 	streaming       bool
 }
 
+type responsesRequestMetadata struct {
+	Model              string
+	PreviousResponseID string
+	Stream             bool
+}
+
+// parseResponsesRequestMetadata extracts the fields needed by routing, streaming,
+// and tool scoping in one decode so long replay bodies are not rescanned for each
+// field independently.
+func parseResponsesRequestMetadata(bodyBytes []byte) responsesRequestMetadata {
+	var raw struct {
+		Model              json.RawMessage `json:"model"`
+		PreviousResponseID json.RawMessage `json:"previous_response_id,omitempty"`
+		Stream             json.RawMessage `json:"stream,omitempty"`
+	}
+	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+		return responsesRequestMetadata{}
+	}
+
+	var metadata responsesRequestMetadata
+	if err := json.Unmarshal(raw.Model, &metadata.Model); err == nil {
+		metadata.Model = strings.TrimSpace(metadata.Model)
+	}
+	if err := json.Unmarshal(raw.PreviousResponseID, &metadata.PreviousResponseID); err == nil {
+		metadata.PreviousResponseID = strings.TrimSpace(metadata.PreviousResponseID)
+	}
+	_ = json.Unmarshal(raw.Stream, &metadata.Stream)
+	return metadata
+}
+
 func (h *ProxyHandler) prepareResponsesRequest(ctx context.Context, r *http.Request, bodyBytes []byte) preparedResponsesRequest {
+	metadata := parseResponsesRequestMetadata(bodyBytes)
 	extraHeaders := responsesExtraHeadersFromRequest(r)
 	headerToolScope := toolExecutionScopeFromHeaders(extraHeaders)
-	requestToolScope := responsesRequestToolExecutionScope(headerToolScope, bodyBytes)
+	requestToolScope := responsesRequestToolExecutionScope(headerToolScope, metadata.PreviousResponseID)
 
-	bodyBytes = h.rewriteResponsesRequestBodyWithToolOptimizers(ctx, bodyBytes, "responses", true, h.toolContexts, requestToolScope)
-	streaming := responsesRequestStreams(bodyBytes)
+	bodyBytes = h.rewriteResponsesRequestBodyWithToolOptimizersForModel(ctx, bodyBytes, metadata.Model, "responses", true, h.toolContexts, requestToolScope)
 
 	return preparedResponsesRequest{
 		body:            bodyBytes,
+		model:           metadata.Model,
 		extraHeaders:    extraHeaders,
-		upstreamHeaders: responsesUpstreamHeaders(extraHeaders, streaming),
+		upstreamHeaders: responsesUpstreamHeaders(extraHeaders, metadata.Stream),
 		headerToolScope: headerToolScope,
-		streaming:       streaming,
+		streaming:       metadata.Stream,
 	}
 }
 
-func responsesRequestStreams(bodyBytes []byte) bool {
-	var partial struct {
-		Stream *bool `json:"stream,omitempty"`
-	}
-	_ = json.Unmarshal(bodyBytes, &partial)
-	return partial.Stream != nil && *partial.Stream
-}
-
-func (h *ProxyHandler) postPreparedResponsesRequest(ctx, observeCtx context.Context, req preparedResponsesRequest) (*http.Response, error) {
-	resp, err := h.postResponsesWithHeaders(ctx, req.body, req.upstreamHeaders)
+func (h *ProxyHandler) postPreparedResponsesRequest(ctx context.Context, observeCtx context.Context, req preparedResponsesRequest) (*http.Response, error) {
+	resp, err := h.postResponsesWithHeadersForModel(ctx, req.body, req.upstreamHeaders, req.model)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +155,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = r.Body.Close() }()
 
 	prepared := h.prepareResponsesRequest(r.Context(), r, bodyBytes)
-	h.observeRequestSummary(r.Context(), "responses", extractRequestModel(prepared.body), prepared.streaming, providerEndpointResponses)
+	h.observeRequestSummary(r.Context(), "responses", prepared.model, prepared.streaming, providerEndpointResponses)
 
 	upstreamCtx, upstreamCancel := h.newInferenceUpstreamContextFrom(r.Context(), prepared.streaming)
 	defer upstreamCancel()
@@ -165,8 +189,7 @@ func (h *ProxyHandler) HandleResponses(w http.ResponseWriter, r *http.Request) {
 	observeUpstreamHeaders(r.Context(), resp.Header)
 
 	if prepared.streaming && resp.StatusCode == http.StatusOK {
-		model := extractRequestModel(prepared.body)
-		peekAndForwardResponses(h, w, r, resp, upstreamCancel, model, prepared.headerToolScope)
+		peekAndForwardResponses(h, w, r, resp, upstreamCancel, prepared.model, prepared.headerToolScope)
 		return
 	}
 
@@ -1913,7 +1936,10 @@ func fallbackMergedCompactionSummaries(summaries []string) string {
 }
 
 func (h *ProxyHandler) rewriteResponsesRequestBody(bodyBytes []byte, endpoint string, injectResumePrompt bool) []byte {
-	requestedModel := extractResponsesRequestModel(bodyBytes)
+	return h.rewriteResponsesRequestBodyForModel(bodyBytes, extractResponsesRequestModel(bodyBytes), endpoint, injectResumePrompt)
+}
+
+func (h *ProxyHandler) rewriteResponsesRequestBodyForModel(bodyBytes []byte, requestedModel string, endpoint string, injectResumePrompt bool) []byte {
 	provider, _, _ := h.resolveProviderModel(requestedModel, "/responses")
 
 	if rewrittenBody, strippedFields := stripUnsupportedResponsesRequestFields(bodyBytes, provider); len(strippedFields) > 0 {
@@ -1977,6 +2003,9 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *provider
 	unsupportedSamplingFields := unsupportedResponsesSamplingFields(provider)
 	stripInternalChatMetadata := !providerSupportsResponsesInternalChatMessageMetadataPassthrough(provider) && bytes.Contains(bodyBytes, responsesInternalChatMessageMetadataPassthroughFieldBytes)
 	if len(unsupportedToolTypes) == 0 && len(unsupportedSamplingFields) == 0 && !stripInternalChatMetadata {
+		return bodyBytes, nil
+	}
+	if !responsesRequestNeedsUnsupportedFieldRewrite(bodyBytes, unsupportedToolTypes, unsupportedSamplingFields, stripInternalChatMetadata) {
 		return bodyBytes, nil
 	}
 
@@ -2049,12 +2078,68 @@ func stripUnsupportedResponsesRequestFields(bodyBytes []byte, provider *provider
 	return rewrittenBody, strippedFields
 }
 
+// responsesRequestNeedsUnsupportedFieldRewrite is a conservative preflight.
+// Cheap byte checks keep ordinary long histories on the passthrough path; a JSON
+// unicode escape forces structural inspection so escaped policy values still work.
+func responsesRequestNeedsUnsupportedFieldRewrite(bodyBytes []byte, unsupportedToolTypes map[string]struct{}, unsupportedSamplingFields []string, stripInternalChatMetadata bool) bool {
+	if stripInternalChatMetadata {
+		return true
+	}
+
+	hasUnicodeEscape := bytes.Contains(bodyBytes, []byte(`\u`))
+	for _, field := range unsupportedSamplingFields {
+		if hasUnicodeEscape || bytes.Contains(bodyBytes, []byte(`"`+field+`"`)) {
+			return true
+		}
+	}
+
+	if len(unsupportedToolTypes) == 0 {
+		return false
+	}
+	hasUnsupportedToolMarker := hasUnicodeEscape
+	if !hasUnsupportedToolMarker {
+		for toolType := range unsupportedToolTypes {
+			if bytes.Contains(bodyBytes, []byte(toolType)) {
+				hasUnsupportedToolMarker = true
+				break
+			}
+		}
+	}
+	if !hasUnsupportedToolMarker {
+		return false
+	}
+
+	var probe struct {
+		Tools json.RawMessage `json:"tools"`
+	}
+	if err := json.Unmarshal(bodyBytes, &probe); err != nil || len(probe.Tools) == 0 {
+		return false
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal(probe.Tools, &tools); err != nil {
+		return false
+	}
+	for _, rawTool := range tools {
+		if _, unsupported := unsupportedToolTypes[responsesToolType(rawTool)]; unsupported {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	openAICodexUnsupportedResponsesSamplingFields = []string{"top_p", "temperature"}
+	imageGenerationUnsupportedResponsesToolTypes  = map[string]struct{}{
+		"image_generation": {},
+	}
+)
+
 func unsupportedResponsesSamplingFields(provider *providerRuntime) []string {
 	if provider == nil {
 		return nil
 	}
 	if provider.kind == providerTypeOpenAICodex {
-		return []string{"top_p", "temperature"}
+		return openAICodexUnsupportedResponsesSamplingFields
 	}
 	return nil
 }
@@ -2157,9 +2242,7 @@ func unsupportedResponsesToolTypes(provider *providerRuntime) map[string]struct{
 
 	switch provider.kind {
 	case providerTypeCopilot, providerTypeAzureOpenAI:
-		return map[string]struct{}{
-			"image_generation": {},
-		}
+		return imageGenerationUnsupportedResponsesToolTypes
 	default:
 		return nil
 	}

--- a/proxy/responses_handler_test.go
+++ b/proxy/responses_handler_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -39,28 +40,96 @@ func TestExtractResponsesOutputText_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestResponsesRequestStreams(t *testing.T) {
+func TestParseResponsesRequestMetadata(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name string
 		body []byte
-		want bool
+		want responsesRequestMetadata
 	}{
-		{name: "stream true", body: []byte(`{"stream":true}`), want: true},
-		{name: "stream false", body: []byte(`{"stream":false}`), want: false},
-		{name: "stream omitted", body: []byte(`{"input":"hi"}`), want: false},
-		{name: "invalid json", body: []byte(`{`), want: false},
+		{
+			name: "extracts fields after input",
+			body: []byte(`{"input":[{"type":"message","content":"history"}],"model":"  gpt-5.4  ","previous_response_id":"  resp-123  ","stream":true}`),
+			want: responsesRequestMetadata{Model: "gpt-5.4", PreviousResponseID: "resp-123", Stream: true},
+		},
+		{
+			name: "invalid stream leaves other metadata intact",
+			body: []byte(`{"model":"gpt-5.4","stream":"yes","previous_response_id":"resp-123"}`),
+			want: responsesRequestMetadata{Model: "gpt-5.4", PreviousResponseID: "resp-123"},
+		},
+		{
+			name: "invalid model leaves stream intact",
+			body: []byte(`{"model":42,"stream":true}`),
+			want: responsesRequestMetadata{Stream: true},
+		},
+		{
+			name: "stream false",
+			body: []byte(`{"model":"gpt-5.4","stream":false}`),
+			want: responsesRequestMetadata{Model: "gpt-5.4"},
+		},
+		{
+			name: "stream omitted",
+			body: []byte(`{"model":"gpt-5.4"}`),
+			want: responsesRequestMetadata{Model: "gpt-5.4"},
+		},
+		{
+			name: "invalid json",
+			body: []byte(`{`),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := responsesRequestStreams(tt.body); got != tt.want {
-				t.Fatalf("responsesRequestStreams() = %v, want %v", got, tt.want)
+			if got := parseResponsesRequestMetadata(tt.body); got != tt.want {
+				t.Fatalf("parseResponsesRequestMetadata() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}
+}
+
+func TestStripUnsupportedResponsesRequestFieldsHandlesEscapedPolicyValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sampling field names", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5-codex","input":"hi","top_\u0070":0.9,"temper\u0061ture":0.2}`)
+		rewritten, fields := stripUnsupportedResponsesRequestFields(body, &providerRuntime{kind: providerTypeOpenAICodex})
+		if len(fields) != 2 {
+			t.Fatalf("stripped fields = %v, want top_p and temperature", fields)
+		}
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal(rewritten, &payload); err != nil {
+			t.Fatalf("decode rewritten body: %v", err)
+		}
+		if _, ok := payload["top_p"]; ok {
+			t.Fatalf("rewritten body retained top_p: %s", rewritten)
+		}
+		if _, ok := payload["temperature"]; ok {
+			t.Fatalf("rewritten body retained temperature: %s", rewritten)
+		}
+	})
+
+	t.Run("tool type", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.4","input":"hi","tools":[{"type":"image_\u0067eneration"}],"tool_choice":"required"}`)
+		rewritten, fields := stripUnsupportedResponsesRequestFields(body, &providerRuntime{kind: providerTypeCopilot})
+		if len(fields) != 2 {
+			t.Fatalf("stripped fields = %v, want tool and tool_choice", fields)
+		}
+		var payload struct {
+			Tools      []json.RawMessage `json:"tools"`
+			ToolChoice json.RawMessage   `json:"tool_choice"`
+		}
+		if err := json.Unmarshal(rewritten, &payload); err != nil {
+			t.Fatalf("decode rewritten body: %v", err)
+		}
+		if len(payload.Tools) != 0 {
+			t.Fatalf("rewritten tools = %s, want empty", payload.Tools)
+		}
+		if len(payload.ToolChoice) != 0 {
+			t.Fatalf("rewritten body retained tool_choice: %s", payload.ToolChoice)
+		}
+	})
 }
 
 func TestPrepareResponsesRequestBuildsHeaderAndStreamingPlan(t *testing.T) {
@@ -84,6 +153,9 @@ func TestPrepareResponsesRequestBuildsHeaderAndStreamingPlan(t *testing.T) {
 	}
 	if !prepared.streaming {
 		t.Fatal("prepared.streaming = false, want true")
+	}
+	if got := prepared.model; got != "gpt-test" {
+		t.Fatalf("prepared.model = %q, want %q", got, "gpt-test")
 	}
 	if got := prepared.headerToolScope; got != "codex:|window-123" {
 		t.Fatalf("headerToolScope = %q, want codex:|window-123", got)

--- a/proxy/responses_transport_bench_test.go
+++ b/proxy/responses_transport_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -76,20 +77,55 @@ func BenchmarkResponsesTransportWSSCold(b *testing.B) {
 }
 
 func BenchmarkResponsesSessionHTTPSFullReplayLongHistoryWarm(b *testing.B) {
+	benchmarkResponsesSessionHTTPSFullReplayLongHistoryWarm(b, false)
+}
+
+func BenchmarkResponsesSessionHTTPSFullReplayLongHistoryToolOptimizerWarm(b *testing.B) {
+	benchmarkResponsesSessionHTTPSFullReplayLongHistoryWarm(b, true)
+}
+
+func BenchmarkResponsesSessionHTTPSFullReplayToolHistoryToolOptimizerWarm(b *testing.B) {
+	history := benchmarkResponsesToolHistory(b, 100, 256, false)
+	benchmarkResponsesSessionHTTPSBodyWarm(b, marshalBenchmarkResponsesPOSTRequest(b, history), true)
+}
+
+func BenchmarkResponsesSessionHTTPSFullReplayToolHistoryMetadataToolOptimizerWarm(b *testing.B) {
+	history := benchmarkResponsesToolHistory(b, 100, 256, true)
+	benchmarkResponsesSessionHTTPSBodyWarm(b, marshalBenchmarkResponsesPOSTRequest(b, history), true)
+}
+
+func benchmarkResponsesSessionHTTPSFullReplayLongHistoryWarm(b *testing.B, enableToolOptimizer bool) {
 	fixtures := newResponsesSessionBenchmarkFixtures(b)
-	env := newResponsesTransportBenchmarkEnvWithHandler(b, newTestProxyHandler(b, func(w http.ResponseWriter, r *http.Request) {
+	benchmarkResponsesSessionHTTPSBodyWarm(b, fixtures.fullReplayPOSTBody, enableToolOptimizer)
+}
+
+func benchmarkResponsesSessionHTTPSBodyWarm(b *testing.B, requestBody []byte, enableToolOptimizer bool) {
+	handler := newTestProxyHandler(b, func(w http.ResponseWriter, r *http.Request) {
 		discardBenchmarkRequestBody(b, r)
 		writeBenchmarkResponsesStream(b, w, "")
-	}))
+	})
+	if enableToolOptimizer {
+		handler.toolOptimizers = NewToolOptimizerManager(ToolOptimizersConfig{
+			Enabled: true,
+			CommandRewrite: ToolOptimizerRewriteConfig{
+				Enabled: true,
+			},
+			OutputReduce: ToolOptimizerOutputConfig{
+				Enabled: true,
+			},
+		}, nil)
+		handler.toolContexts = NewToolExecutionContextStore()
+	}
+	env := newResponsesTransportBenchmarkEnvWithHandler(b, handler)
 	client := newResponsesTransportHTTPClient(b, env.proxyServer, false)
 
-	totalBytes := 2*len(fixtures.fullReplayPOSTBody) + 2*len(benchmarkResponsesStreamingSSE)
+	totalBytes := 2*len(requestBody) + 2*len(benchmarkResponsesStreamingSSE)
 	b.ReportAllocs()
 	b.SetBytes(int64(totalBytes))
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		req, err := http.NewRequest(http.MethodPost, env.proxyServer.URL+"/v1/responses", bytes.NewReader(fixtures.fullReplayPOSTBody))
+		req, err := http.NewRequest(http.MethodPost, env.proxyServer.URL+"/v1/responses", bytes.NewReader(requestBody))
 		if err != nil {
 			b.Fatalf("create long-history HTTPS request: %v", err)
 		}
@@ -479,6 +515,56 @@ func discardBenchmarkRequestBody(b *testing.B, r *http.Request) {
 	if err := r.Body.Close(); err != nil {
 		b.Fatalf("close benchmark request body: %v", err)
 	}
+}
+
+func benchmarkResponsesToolHistory(b *testing.B, turns, payloadSize int, includeMetadata bool) []json.RawMessage {
+	b.Helper()
+
+	history := make([]json.RawMessage, 0, turns*4)
+	for i := 0; i < turns; i++ {
+		callID := fmt.Sprintf("call-bench-%03d", i)
+		history = append(history, marshalBenchmarkResponsesHistoryMessage(b, "user", fmt.Sprintf("run command %03d", i), i, includeMetadata))
+		history = append(history, marshalBenchmarkResponsesItem(b, map[string]interface{}{
+			"type":      "function_call",
+			"name":      "shell_command",
+			"call_id":   callID,
+			"arguments": fmt.Sprintf(`{"command":"printf %03d"}`, i),
+		}))
+		history = append(history, marshalBenchmarkResponsesItem(b, map[string]interface{}{
+			"type":    "function_call_output",
+			"call_id": callID,
+			"output":  strings.Repeat("x", payloadSize),
+		}))
+		history = append(history, marshalBenchmarkResponsesHistoryMessage(b, "assistant", fmt.Sprintf("command %03d complete", i), i, includeMetadata))
+	}
+	return history
+}
+
+func marshalBenchmarkResponsesHistoryMessage(b *testing.B, role, text string, index int, includeMetadata bool) json.RawMessage {
+	b.Helper()
+	item := map[string]interface{}{
+		"type": "message",
+		"role": role,
+		"content": []map[string]string{{
+			"type": "input_text",
+			"text": text,
+		}},
+	}
+	if includeMetadata {
+		item[responsesInternalChatMessageMetadataPassthroughField] = map[string]interface{}{
+			"turn_id": fmt.Sprintf("turn-bench-%03d", index),
+		}
+	}
+	return marshalBenchmarkResponsesItem(b, item)
+}
+
+func marshalBenchmarkResponsesItem(b *testing.B, item map[string]interface{}) json.RawMessage {
+	b.Helper()
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		b.Fatalf("marshal benchmark responses item: %v", err)
+	}
+	return encoded
 }
 
 func marshalBenchmarkResponsesPOSTRequest(b *testing.B, input []json.RawMessage) []byte {

--- a/proxy/responses_websocket.go
+++ b/proxy/responses_websocket.go
@@ -771,7 +771,7 @@ func (s *responsesWebSocketSession) postCreateRequestSegments(h *ProxyHandler, c
 	if err != nil {
 		return nil, err
 	}
-	bodyBytes = h.rewriteResponsesRequestBodyWithToolOptimizers(ctx, bodyBytes, "responses/websocket", true, s.toolContexts, s.toolScope)
+	bodyBytes = h.rewriteResponsesRequestBodyWithToolOptimizersForModel(ctx, bodyBytes, request.Model, "responses/websocket", true, s.toolContexts, s.toolScope)
 	headers := s.requestHeaders(request, includeTurnState)
 	// The websocket bridge records each turn's usage downstream from the streamed
 	// response body (recordTurnStats), so the per-turn usage total returned here
@@ -779,7 +779,7 @@ func (s *responsesWebSocketSession) postCreateRequestSegments(h *ProxyHandler, c
 	if compactionResp, handled, _, err := h.maybeBuildResponsesCompactionTriggerResponse(ctx, bodyBytes, headers, true); handled || err != nil {
 		return compactionResp, err
 	}
-	return h.postResponsesWithHeaders(ctx, bodyBytes, headers)
+	return h.postResponsesWithHeadersForModel(ctx, bodyBytes, headers, request.Model)
 }
 
 func (s *responsesWebSocketSession) requestHeaders(request *responsesWebSocketCreateRequest, includeTurnState bool) http.Header {

--- a/proxy/tool_optimizer_responses.go
+++ b/proxy/tool_optimizer_responses.go
@@ -68,16 +68,6 @@ func uniqueToolExecutionScopes(scopes ...string) []string {
 	return out
 }
 
-func toolExecutionScopeFromPreviousResponseID(bodyBytes []byte) string {
-	var partial struct {
-		PreviousResponseID string `json:"previous_response_id,omitempty"`
-	}
-	if err := json.Unmarshal(bodyBytes, &partial); err != nil {
-		return ""
-	}
-	return toolExecutionScopeFromResponseID(partial.PreviousResponseID)
-}
-
 func toolExecutionScopeFromResponsePayload(payload map[string]json.RawMessage) string {
 	if payload == nil {
 		return ""
@@ -89,8 +79,8 @@ func toolExecutionScopeFromResponsePayload(payload map[string]json.RawMessage) s
 	return toolExecutionScopeFromResponseID(responseID)
 }
 
-func responsesRequestToolExecutionScope(headerScope string, bodyBytes []byte) string {
-	previousScope := toolExecutionScopeFromPreviousResponseID(bodyBytes)
+func responsesRequestToolExecutionScope(headerScope, previousResponseID string) string {
+	previousScope := toolExecutionScopeFromResponseID(previousResponseID)
 	scope := strings.TrimSpace(headerScope)
 	if isClientRequestToolExecutionScope(scope) && previousScope != "" {
 		return previousScope
@@ -308,9 +298,24 @@ func (h *ProxyHandler) maybeRewriteOrCaptureToolCommandItemInScopes(ctx context.
 	return rawItem, changed
 }
 
+var (
+	responsesFunctionCallMarker      = []byte("function_call")
+	responsesLocalShellCallMarker    = []byte("local_shell_call")
+	responsesJSONUnicodeEscapeMarker = []byte(`\u`)
+)
+
+// responsesPayloadMayContainOptimizableToolItems avoids decoding replay items
+// that cannot be tool calls or tool outputs. Unicode escapes force inspection to
+// avoid missing an escaped type value.
+func responsesPayloadMayContainOptimizableToolItems(payload []byte) bool {
+	return bytes.Contains(payload, responsesFunctionCallMarker) ||
+		bytes.Contains(payload, responsesLocalShellCallMarker) ||
+		bytes.Contains(payload, responsesJSONUnicodeEscapeMarker)
+}
+
 func (h *ProxyHandler) maybeReduceResponsesToolOutputsInRequestBody(ctx context.Context, bodyBytes []byte, store *ToolExecutionContextStore, scope string) ([]byte, int) {
 	manager := h.toolOptimizers
-	if manager == nil || !manager.OutputReduceEnabled() {
+	if manager == nil || !manager.OutputReduceEnabled() || !responsesPayloadMayContainOptimizableToolItems(bodyBytes) {
 		return bodyBytes, 0
 	}
 	var payload map[string]json.RawMessage
@@ -329,7 +334,24 @@ func (h *ProxyHandler) maybeReduceResponsesToolOutputsInRequestBody(ctx context.
 	localContexts := make(map[string]ToolExecutionContext)
 	changedCount := 0
 	for i, rawItem := range inputItems {
-		if commandItem, ok := extractShellFunctionCommandItem(rawItem, manager); ok {
+		if !responsesPayloadMayContainOptimizableToolItems(rawItem) {
+			continue
+		}
+		var item map[string]json.RawMessage
+		if err := json.Unmarshal(rawItem, &item); err != nil {
+			continue
+		}
+		itemType, ok := extractNonEmptyJSONStringField(item, "type")
+		if !ok {
+			continue
+		}
+
+		switch itemType {
+		case "function_call", "local_shell_call":
+			commandItem, ok := extractShellFunctionCommand(item, manager)
+			if !ok {
+				continue
+			}
 			toolCtx := newToolExecutionContext(commandItem, commandItem.Command, commandItem.Command, "")
 			localContexts[commandItem.CallID] = toolCtx
 			if store != nil && scope != "" {
@@ -338,9 +360,12 @@ func (h *ProxyHandler) maybeReduceResponsesToolOutputsInRequestBody(ctx context.
 				}
 			}
 			continue
+		case "function_call_output", "local_shell_call_output":
+		default:
+			continue
 		}
 
-		outputItem, ok := extractFunctionCallOutputItem(rawItem)
+		outputItem, ok := extractFunctionCallOutput(item)
 		if !ok {
 			continue
 		}
@@ -386,7 +411,11 @@ func (h *ProxyHandler) maybeReduceResponsesToolOutputsInRequestBody(ctx context.
 }
 
 func (h *ProxyHandler) rewriteResponsesRequestBodyWithToolOptimizers(ctx context.Context, bodyBytes []byte, endpoint string, injectResumePrompt bool, store *ToolExecutionContextStore, scope string) []byte {
-	bodyBytes = h.rewriteResponsesRequestBody(bodyBytes, endpoint, injectResumePrompt)
+	return h.rewriteResponsesRequestBodyWithToolOptimizersForModel(ctx, bodyBytes, extractResponsesRequestModel(bodyBytes), endpoint, injectResumePrompt, store, scope)
+}
+
+func (h *ProxyHandler) rewriteResponsesRequestBodyWithToolOptimizersForModel(ctx context.Context, bodyBytes []byte, requestedModel string, endpoint string, injectResumePrompt bool, store *ToolExecutionContextStore, scope string) []byte {
+	bodyBytes = h.rewriteResponsesRequestBodyForModel(bodyBytes, requestedModel, endpoint, injectResumePrompt)
 	rewritten, count := h.maybeReduceResponsesToolOutputsInRequestBody(ctx, bodyBytes, store, scope)
 	if count > 0 {
 		h.log.Debug("reduced responses tool outputs", logger.F("endpoint", endpoint), logger.F("count", count))

--- a/proxy/tool_optimizer_responses_test.go
+++ b/proxy/tool_optimizer_responses_test.go
@@ -140,3 +140,65 @@ func TestToolOptimizerResponsesReducePrefersLocalToolContextOverStore(t *testing
 		t.Fatalf("rewritten output = %v, want reduced output", got)
 	}
 }
+
+func TestResponsesPayloadMayContainOptimizableToolItems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{name: "ordinary messages", body: []byte(`{"input":[{"type":"message","content":"hello"}]}`), want: false},
+		{name: "function call", body: []byte(`{"type":"function_call"}`), want: true},
+		{name: "local shell call", body: []byte(`{"type":"local_shell_call_output"}`), want: true},
+		{name: "unicode escaped type", body: []byte(`{"type":"function_\u0063all"}`), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := responsesPayloadMayContainOptimizableToolItems(tt.body); got != tt.want {
+				t.Fatalf("responsesPayloadMayContainOptimizableToolItems() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToolOptimizerResponsesReduceHandlesUnicodeEscapedItemTypes(t *testing.T) {
+	fake := &recordingToolOptimizer{}
+	handler := &ProxyHandler{}
+	configureRecordingToolOptimizer(handler, fake)
+
+	body := []byte(`{
+		"model": "gpt-4",
+		"input": [
+			{
+				"type": "function_\u0063all",
+				"name": "shell_command",
+				"call_id": "call-escaped-1",
+				"arguments": "{\"command\":\"fresh command\"}"
+			},
+			{
+				"type": "function_\u0063all_output",
+				"call_id": "call-escaped-1",
+				"output": "large output"
+			}
+		]
+	}`)
+
+	rewritten, count := handler.maybeReduceResponsesToolOutputsInRequestBody(context.Background(), body, handler.toolContexts, "session:escaped-types")
+	if count != 1 {
+		t.Fatalf("reduced output count = %d, want 1; body=%s", count, rewritten)
+	}
+
+	var payload struct {
+		Input []map[string]interface{} `json:"input"`
+	}
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("decode rewritten body: %v", err)
+	}
+	if got := payload.Input[1]["output"]; got != "reduced output" {
+		t.Fatalf("rewritten output = %v, want reduced output", got)
+	}
+}

--- a/proxy/tool_shapes.go
+++ b/proxy/tool_shapes.go
@@ -429,6 +429,10 @@ func extractFunctionCallOutputItem(raw json.RawMessage) (toolOutputItem, bool) {
 	if err := json.Unmarshal(raw, &item); err != nil {
 		return toolOutputItem{}, false
 	}
+	return extractFunctionCallOutput(item)
+}
+
+func extractFunctionCallOutput(item map[string]json.RawMessage) (toolOutputItem, bool) {
 	itemType, ok := extractNonEmptyJSONStringField(item, "type")
 	if !ok || (itemType != "function_call_output" && itemType != "local_shell_call_output") {
 		return toolOutputItem{}, false

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -139,7 +139,10 @@ func mergeHeaderValues(dst, src http.Header) {
 }
 
 func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*providerRuntime, providerModel, []byte, error) {
-	model := extractRequestModel(body)
+	return h.resolveProviderRequestForModel(body, endpoint, extractRequestModel(body))
+}
+
+func (h *ProxyHandler) resolveProviderRequestForModel(body []byte, endpoint string, model string) (*providerRuntime, providerModel, []byte, error) {
 	lookupModel := model
 	if endpoint == providerEndpointMessages {
 		lookupModel = NormalizeModelName(model)
@@ -170,7 +173,7 @@ func (h *ProxyHandler) resolveProviderRequest(body []byte, endpoint string) (*pr
 	rewrittenBody := body
 	if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
 		var err error
-		rewrittenBody, _, err = rewriteRequestModelForProvider(body, owner.upstreamModel)
+		rewrittenBody, _, err = rewriteRequestModelForProviderFromModel(body, model, owner.upstreamModel)
 		if err != nil {
 			return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 		}
@@ -217,7 +220,11 @@ func (h *ProxyHandler) postJSONEndpoint(ctx context.Context, path string, body [
 }
 
 func (h *ProxyHandler) postJSONEndpointWithHeaders(ctx context.Context, path string, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	provider, owner, rewrittenBody, err := h.resolveProviderRequest(body, path)
+	return h.postJSONEndpointWithHeadersForModel(ctx, path, body, extraHeaders, extractRequestModel(body))
+}
+
+func (h *ProxyHandler) postJSONEndpointWithHeadersForModel(ctx context.Context, path string, body []byte, extraHeaders http.Header, model string) (*http.Response, error) {
+	provider, owner, rewrittenBody, err := h.resolveProviderRequestForModel(body, path, model)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +243,11 @@ func (h *ProxyHandler) postChatCompletions(ctx context.Context, body []byte) (*h
 }
 
 func (h *ProxyHandler) postResponsesWithHeaders(ctx context.Context, body []byte, extraHeaders http.Header) (*http.Response, error) {
-	resp, err := h.postJSONEndpointWithHeaders(ctx, providerEndpointResponses, body, extraHeaders)
+	return h.postResponsesWithHeadersForModel(ctx, body, extraHeaders, extractRequestModel(body))
+}
+
+func (h *ProxyHandler) postResponsesWithHeadersForModel(ctx context.Context, body []byte, extraHeaders http.Header, model string) (*http.Response, error) {
+	resp, err := h.postJSONEndpointWithHeadersForModel(ctx, providerEndpointResponses, body, extraHeaders, model)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- parse Responses routing, streaming, and scope metadata once per request
- carry the resolved public model through HTTP and websocket forwarding instead of rescanning replay bodies
- avoid full request decoding when provider-specific field rewrites cannot apply
- skip ordinary history items during tool-output optimization and decode relevant tool items once
- add regression coverage and long-history benchmarks for default, optimizer-enabled, and tool-heavy workloads

## Root cause

Long `/v1/responses` replay bodies were decoded repeatedly to recover small top-level fields. With tool optimizers enabled, ordinary message histories were also decoded item-by-item even when they contained no optimizable calls or outputs. The repeated JSON scans and allocations dominated CPU under concurrent agent workloads.

## Benchmark results

Median of three runs on Apple M1 Max using `-benchtime=3s -count=3`:

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| Long-history replay | 8.80 ms/op | 1.36 ms/op | 84.6% faster |
| Optimizer enabled, no tool items | 12.53 ms/op | 1.40 ms/op | 88.8% faster |
| Tool history with internal metadata | 10.79 ms/op | 5.53 ms/op | 48.7% faster |

The default long-history case drops from 76,621 to 411 allocations per operation. The optimizer-enabled no-tool case drops from 93,155 to 414 allocations per operation.

## Validation

- `make test`
- `make vet`
- `make build`
- `go test -race ./proxy/ -count=1`
