### PR TITLE
fix(azure): surface streamed rate limits

### DIFF
--- a/docs/provider-routing.md
+++ b/docs/provider-routing.md
@@ -154,6 +154,7 @@ Successful decoded dynamic model catalogs are capped at 4 MiB before JSON decodi
 | `models_path` | generic providers | Upstream path for dynamic model discovery and readiness probes. Defaults to `/models`. |
 | `model_discovery` | generic providers | `static`, `openai`, `ollama`, or `openrouter-tools`. |
 | `models[].endpoints` | all static models | Public endpoint allowlist. This remains the source of truth for what Vekil advertises and routes. |
+| `models[].use_max_completion_tokens` | static models with `/chat/completions` | When `true`, rewrite translated Chat/Anthropic `max_tokens` to `max_completion_tokens` before forwarding. Use only for deployments that reject the legacy field. |
 
 ### Generic Provider Cookbook
 
@@ -329,6 +330,7 @@ Routing rules:
 - For Copilot-discovered models, Codex-compatible `/v1/models` metadata treats `capabilities.limits.max_prompt_tokens` as the active `context_window` and keeps `max_context_window_tokens` as `max_context_window`. If Copilot omits the prompt cap, the proxy falls back to the total context window.
 - `models[].endpoints` is an allowlist, not a guess. Keep it limited to the routes you have validated for that deployment.
 - Static provider models can also advertise richer Codex `/v1/models` metadata via optional fields on each `models[]` entry: `model_picker_category`, `reasoning_effort`, `vision`, `parallel_tool_calls`, and `context_window`. Without those fields, the proxy exposes a minimal but valid model entry.
+- `models[].use_max_completion_tokens: true` is a request policy for `/chat/completions`; it rewrites `max_tokens` to `max_completion_tokens` after translation. It does not affect `/responses` requests.
 - For Azure OpenAI, `/v1/models` only does a best-effort metadata overlay for each configured `models[]` entry by probing Azure's upstream `/models` response. The proxy matches by `public_id` first, then by `deployment` for aliased models.
 - Azure's upstream `/models` catalog can omit Codex-style fields entirely. The proxy only copies fields that Azure already returns; it does not derive reasoning levels, vision, parallel tool calls, model picker metadata, or context window from other Azure docs or capability hints.
 - Explicit `models[]` metadata overrides Azure `/models` overlay metadata. Configured public IDs and endpoint allowlists always win, and the proxy falls back to the static entry if the Azure `/models` probe fails or returns a sparse payload.

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -6813,6 +6813,81 @@ func TestHandleAnthropicMessages_UsesOpenAITranslationForGenericOpenAICompatible
 	}
 }
 
+func TestHandleAnthropicMessages_AzureUsesConfiguredMaxCompletionTokens(t *testing.T) {
+	t.Setenv("TEST_AZURE_API_KEY", "test-value")
+	useMaxCompletionTokens := true
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/openai/v1/chat/completions" {
+			t.Fatalf("expected Azure path /openai/v1/chat/completions, got %s", got)
+		}
+
+		var upstreamReq models.OpenAIRequest
+		if err := json.NewDecoder(r.Body).Decode(&upstreamReq); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if upstreamReq.Model != "gpt-5.6-sol" {
+			t.Fatalf("upstream model = %q, want gpt-5.6-sol", upstreamReq.Model)
+		}
+		if upstreamReq.MaxCompletionTokens == nil || *upstreamReq.MaxCompletionTokens != 64 {
+			t.Fatalf("max_completion_tokens = %v, want 64", upstreamReq.MaxCompletionTokens)
+		}
+		if upstreamReq.MaxTokens != nil {
+			t.Fatalf("max_tokens = %v, want nil", upstreamReq.MaxTokens)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello from Sol\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.New(logger.LevelInfo),
+		WithProvidersConfig(ProvidersConfig{
+			Providers: []ProviderConfig{{
+				ID:        "azure",
+				Type:      "azure-openai",
+				Default:   true,
+				BaseURL:   upstream.URL + "/openai/v1",
+				APIKeyEnv: "TEST_AZURE_API_KEY",
+				Models: []ProviderModelConfig{{
+					PublicID:               "gpt-5.6-sol",
+					Deployment:             "gpt-5.6-sol",
+					Endpoints:              []string{"/chat/completions"},
+					UseMaxCompletionTokens: &useMaxCompletionTokens,
+				}},
+			}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler returned error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model": "gpt-5.6-sol",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.HandleAnthropicMessages(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var anthropicResp models.AnthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&anthropicResp); err != nil {
+		t.Fatalf("decode Anthropic response: %v", err)
+	}
+	if len(anthropicResp.Content) != 1 || anthropicResp.Content[0].Text == nil || *anthropicResp.Content[0].Text != "Hello from Sol" {
+		t.Fatalf("unexpected Anthropic response: %+v", anthropicResp)
+	}
+}
+
 func TestHandleAnthropicMessages_DirectGenericAnthropicCompatibleProvider(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Path; got != "/native/messages" {

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -99,17 +99,18 @@ type ProviderConfig struct {
 // ProviderModelConfig maps a public model ID exposed by this proxy to the
 // upstream model or deployment name used by the provider.
 type ProviderModelConfig struct {
-	PublicID            string   `json:"public_id" yaml:"public_id"`
-	Deployment          string   `json:"deployment,omitempty" yaml:"deployment,omitempty"`
-	Name                string   `json:"name,omitempty" yaml:"name,omitempty"`
-	Endpoints           []string `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
-	ModelPickerEnabled  *bool    `json:"model_picker_enabled,omitempty" yaml:"model_picker_enabled,omitempty"`
-	ModelPickerCategory string   `json:"model_picker_category,omitempty" yaml:"model_picker_category,omitempty"`
-	ReasoningEffort     []string `json:"reasoning_effort,omitempty" yaml:"reasoning_effort,omitempty"`
-	Vision              *bool    `json:"vision,omitempty" yaml:"vision,omitempty"`
-	ParallelToolCalls   *bool    `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
-	DropSamplingParams  *bool    `json:"drop_sampling_params,omitempty" yaml:"drop_sampling_params,omitempty"`
-	ContextWindow       *int64   `json:"context_window,omitempty" yaml:"context_window,omitempty"`
+	PublicID               string   `json:"public_id" yaml:"public_id"`
+	Deployment             string   `json:"deployment,omitempty" yaml:"deployment,omitempty"`
+	Name                   string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Endpoints              []string `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
+	ModelPickerEnabled     *bool    `json:"model_picker_enabled,omitempty" yaml:"model_picker_enabled,omitempty"`
+	ModelPickerCategory    string   `json:"model_picker_category,omitempty" yaml:"model_picker_category,omitempty"`
+	ReasoningEffort        []string `json:"reasoning_effort,omitempty" yaml:"reasoning_effort,omitempty"`
+	Vision                 *bool    `json:"vision,omitempty" yaml:"vision,omitempty"`
+	ParallelToolCalls      *bool    `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
+	DropSamplingParams     *bool    `json:"drop_sampling_params,omitempty" yaml:"drop_sampling_params,omitempty"`
+	UseMaxCompletionTokens *bool    `json:"use_max_completion_tokens,omitempty" yaml:"use_max_completion_tokens,omitempty"`
+	ContextWindow          *int64   `json:"context_window,omitempty" yaml:"context_window,omitempty"`
 }
 
 type providerRuntime struct {
@@ -145,14 +146,15 @@ type providerEndpointPaths struct {
 }
 
 type providerModel struct {
-	publicID           string
-	upstreamModel      string
-	providerID         string
-	supportedEndpoints []string
-	parallelToolCalls  *bool
-	dropSamplingParams bool
-	disabled           bool
-	raw                json.RawMessage
+	publicID               string
+	upstreamModel          string
+	providerID             string
+	supportedEndpoints     []string
+	parallelToolCalls      *bool
+	dropSamplingParams     bool
+	useMaxCompletionTokens bool
+	disabled               bool
+	raw                    json.RawMessage
 }
 
 type providerSetup struct {
@@ -1027,13 +1029,14 @@ func buildStaticProviderModel(providerID string, cfg ProviderModelConfig, defaul
 	}
 
 	return providerModel{
-		publicID:           publicID,
-		upstreamModel:      upstreamModel,
-		providerID:         providerID,
-		supportedEndpoints: endpoints,
-		parallelToolCalls:  cloneBoolPtr(cfg.ParallelToolCalls),
-		dropSamplingParams: cfg.DropSamplingParams != nil && *cfg.DropSamplingParams,
-		raw:                raw,
+		publicID:               publicID,
+		upstreamModel:          upstreamModel,
+		providerID:             providerID,
+		supportedEndpoints:     endpoints,
+		parallelToolCalls:      cloneBoolPtr(cfg.ParallelToolCalls),
+		dropSamplingParams:     cfg.DropSamplingParams != nil && *cfg.DropSamplingParams,
+		useMaxCompletionTokens: cfg.UseMaxCompletionTokens != nil && *cfg.UseMaxCompletionTokens,
+		raw:                    raw,
 	}, nil
 }
 

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -45,6 +45,7 @@ func TestLoadProvidersConfigFileAzureV1BaseURLAndModelMetadata(t *testing.T) {
           "reasoning_effort": ["low", "medium", "high"],
           "vision": true,
           "parallel_tool_calls": true,
+          "use_max_completion_tokens": true,
           "context_window": 400000
         }
       ]
@@ -111,6 +112,9 @@ func TestLoadProvidersConfigFileAzureV1BaseURLAndModelMetadata(t *testing.T) {
 	if cfgModel.ParallelToolCalls == nil || !*cfgModel.ParallelToolCalls {
 		t.Fatalf("parallel_tool_calls = %v, want true", cfgModel.ParallelToolCalls)
 	}
+	if cfgModel.UseMaxCompletionTokens == nil || !*cfgModel.UseMaxCompletionTokens {
+		t.Fatalf("use_max_completion_tokens = %v, want true", cfgModel.UseMaxCompletionTokens)
+	}
 	if cfgModel.ContextWindow == nil || *cfgModel.ContextWindow != 400000 {
 		t.Fatalf("context_window = %v, want 400000", cfgModel.ContextWindow)
 	}
@@ -150,6 +154,7 @@ func TestLoadProvidersConfigFileYAML(t *testing.T) {
           - high
         vision: true
         parallel_tool_calls: true
+        use_max_completion_tokens: true
         context_window: 400000
   - id: openai-codex
     type: openai-codex
@@ -213,6 +218,9 @@ func TestLoadProvidersConfigFileYAML(t *testing.T) {
 			}
 			if model.ParallelToolCalls == nil || !*model.ParallelToolCalls {
 				t.Fatalf("parallel_tool_calls = %v, want true", model.ParallelToolCalls)
+			}
+			if model.UseMaxCompletionTokens == nil || !*model.UseMaxCompletionTokens {
+				t.Fatalf("use_max_completion_tokens = %v, want true", model.UseMaxCompletionTokens)
 			}
 			if model.ContextWindow == nil || *model.ContextWindow != 400000 {
 				t.Fatalf("context_window = %v, want 400000", model.ContextWindow)

--- a/proxy/responses_failure_translate.go
+++ b/proxy/responses_failure_translate.go
@@ -62,6 +62,7 @@ type peekResult struct {
 	terminal         *responsesWebSocketStreamEvent
 	bufferedBytes    int
 	peekDuration     time.Duration
+	preamble         bool
 }
 
 type responsesPeekChunk struct {
@@ -1110,7 +1111,8 @@ func runResponsesPeekPump(body io.ReadCloser, pw *io.PipeWriter, headers http.He
 			if len(chunk.data) > 0 {
 				_, _ = prefix.Write(chunk.data)
 				parser.push(chunk.data)
-				result, sawSemantic := inspectResponsesPeekMessages(&parser, headers, peekState)
+				holdPreamble := shouldHoldResponsesPrecommitPreamble(headers)
+				result, sawSemantic, sawBeyondPreamble := inspectResponsesPeekMessages(&parser, headers, peekState, holdPreamble)
 				result.bufferedBytes = prefix.Len()
 				result.peekDuration = time.Since(start)
 				if !decisionSent {
@@ -1122,7 +1124,7 @@ func runResponsesPeekPump(body io.ReadCloser, pw *io.PipeWriter, headers http.He
 						} else {
 							sendResult(peekResult{decision: responsesPeekDecisionPassthrough})
 						}
-					} else if sawSemantic {
+					} else if sawSemantic && (!holdPreamble || sawBeyondPreamble) {
 						sendResult(result)
 					}
 				}
@@ -1145,9 +1147,10 @@ func runResponsesPeekPump(body io.ReadCloser, pw *io.PipeWriter, headers http.He
 	}
 }
 
-func inspectResponsesPeekMessages(parser *responsesSSEParser, headers http.Header, peekState *responsesPeekState) (peekResult, bool) {
+func inspectResponsesPeekMessages(parser *responsesSSEParser, headers http.Header, peekState *responsesPeekState, preferTranslatedFailure bool) (peekResult, bool, bool) {
 	result := peekResult{decision: responsesPeekDecisionPassthrough}
 	sawSemantic := false
+	sawBeyondPreamble := false
 	for {
 		msg, ok := parser.nextSemantic()
 		if !ok {
@@ -1159,12 +1162,15 @@ func inspectResponsesPeekMessages(parser *responsesSSEParser, headers http.Heade
 		}
 		classified := classifyResponsesPeekMessage(msg, headers)
 		peekState.publishTerminal(classified)
-		if !sawSemantic {
+		if !sawSemantic || (preferTranslatedFailure && !sawBeyondPreamble && classified.decision == responsesPeekDecisionTranslate) {
 			result = classified
+		}
+		if !classified.preamble {
+			sawBeyondPreamble = true
 		}
 		sawSemantic = true
 	}
-	return result, sawSemantic
+	return result, sawSemantic, sawBeyondPreamble
 }
 
 func readResponsesPeekChunks(body io.ReadCloser, chunkCh chan<- responsesPeekChunk, abortCh, observeOnlyCh <-chan struct{}, headers http.Header, peekState *responsesPeekState) {
@@ -1282,6 +1288,7 @@ func classifyResponsesPeekEvent(event responsesWebSocketStreamEvent, eventName s
 		terminalType = eventName
 	}
 	event.Type = terminalType
+	result.preamble = terminalType == "response.created" || terminalType == "response.in_progress"
 	switch terminalType {
 	case "response.completed", "response.failed", "response.incomplete":
 		terminal := event
@@ -1311,6 +1318,31 @@ func classifyResponsesPeekEvent(event responsesWebSocketStreamEvent, eventName s
 	result.retryAfter = retryAfter
 	result.retryAfterSource = source
 	return result
+}
+
+// shouldHoldResponsesPrecommitPreamble keeps Azure/compatible streaming
+// responses uncommitted when their headers already report exhausted quota.
+// These upstreams can emit response.created and then fail the stream a few
+// hundred milliseconds later with response.failed. Waiting within the existing
+// precommit timeout lets the proxy translate that terminal event into HTTP 429
+// so clients can apply their normal Retry-After behavior. Healthy streams and
+// providers without exhausted-quota headers retain the low-latency first-event
+// passthrough path.
+func shouldHoldResponsesPrecommitPreamble(headers http.Header) bool {
+	if retryAfter, _ := selectResponsesRetryAfter(headers); retryAfter == "" {
+		return false
+	}
+	for _, name := range []string{"x-ratelimit-remaining-tokens", "x-ratelimit-remaining-requests"} {
+		value := strings.TrimSpace(headerGetCI(headers, name))
+		if value == "" {
+			continue
+		}
+		remaining, err := strconv.ParseInt(value, 10, 64)
+		if err == nil && remaining <= 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func classifyPrecommitResponsesFailure(event responsesWebSocketStreamEvent) (int, string, bool) {

--- a/proxy/responses_failure_translate_test.go
+++ b/proxy/responses_failure_translate_test.go
@@ -96,6 +96,33 @@ func TestHandleResponses_PrecommitFailureTranslation(t *testing.T) {
 			wantRawBody:     "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-unknown\",\"error\":{\"type\":\"server_error\",\"code\":\"context_length_exceeded\",\"message\":\"too long\"}}}\n\n",
 		},
 		{
+			name: "created then immediate rate limit translates before commit",
+			body: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-created-rate-limit\"}}\n\nevent: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-created-rate-limit\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"token rate limit exceeded\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type":                 []string{"text/event-stream"},
+				"retry-after-ms":               []string{"2457"},
+				"x-ratelimit-remaining-tokens": []string{"-40957"},
+				"x-ratelimit-reset-tokens":     []string{"62"},
+			},
+			wantStatus:       http.StatusTooManyRequests,
+			wantContentType:  "application/json",
+			wantRetryAfter:   "3",
+			wantErrorType:    "rate_limit_error",
+			wantErrorMessage: "token rate limit exceeded",
+		},
+		{
+			name: "output before rate limit preserves stream",
+			body: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-output-rate-limit\"}}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"response_id\":\"resp-output-rate-limit\",\"delta\":\"partial\"}\n\nevent: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-output-rate-limit\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"token rate limit exceeded\"}}}\n\n",
+			headers: http.Header{
+				"Content-Type":                 []string{"text/event-stream"},
+				"retry-after-ms":               []string{"2457"},
+				"x-ratelimit-remaining-tokens": []string{"-40957"},
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "text/event-stream",
+			wantRawBody:     "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-output-rate-limit\"}}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"response_id\":\"resp-output-rate-limit\",\"delta\":\"partial\"}\n\nevent: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp-output-rate-limit\",\"error\":{\"type\":\"server_error\",\"code\":\"too_many_requests\",\"message\":\"token rate limit exceeded\"}}}\n\n",
+		},
+		{
 			name: "non failed first event stays passthrough",
 			body: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
 			headers: http.Header{

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -192,12 +192,13 @@ func (h *ProxyHandler) resolveProviderRequestForModel(body []byte, endpoint stri
 			return nil, providerModel{}, nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 		}
 	}
-	rewrittenBody = applyProviderModelRequestPolicy(rewrittenBody, owner)
+	rewrittenBody = applyProviderModelRequestPolicy(rewrittenBody, endpoint, owner)
 	return provider, owner, rewrittenBody, nil
 }
 
-func applyProviderModelRequestPolicy(body []byte, owner providerModel) []byte {
-	if !owner.dropSamplingParams && (owner.parallelToolCalls == nil || *owner.parallelToolCalls) {
+func applyProviderModelRequestPolicy(body []byte, endpoint string, owner providerModel) []byte {
+	rewriteMaxTokens := endpoint == providerEndpointChatCompletions && owner.useMaxCompletionTokens
+	if !owner.dropSamplingParams && !rewriteMaxTokens && (owner.parallelToolCalls == nil || *owner.parallelToolCalls) {
 		return body
 	}
 	var payload map[string]json.RawMessage
@@ -211,6 +212,15 @@ func applyProviderModelRequestPolicy(body []byte, owner providerModel) []byte {
 				delete(payload, field)
 				changed = true
 			}
+		}
+	}
+	if rewriteMaxTokens {
+		if maxTokens, ok := payload["max_tokens"]; ok {
+			if _, exists := payload["max_completion_tokens"]; !exists {
+				payload["max_completion_tokens"] = maxTokens
+			}
+			delete(payload, "max_tokens")
+			changed = true
 		}
 	}
 	if owner.parallelToolCalls != nil && !*owner.parallelToolCalls {


### PR DESCRIPTION
## Summary

- hold the initial Responses preamble when upstream headers already report exhausted quota
- translate an immediate streamed `response.failed` into HTTP 429 with `Retry-After`
- add an opt-in model policy to rewrite Chat Completions `max_tokens` to `max_completion_tokens`
- document and test the new provider model setting

## Root cause

Microsoft Foundry can accept a streaming Responses request with HTTP 200, emit `response.created`, and then terminate with `response.failed` when the token-per-minute quota is exhausted. Vekil committed the downstream 200 after the first semantic event, preventing its existing failure translator from returning a retryable HTTP 429.

## Impact

Clients now receive a normal rate-limit response for this exhausted-quota pattern and can honor the upstream retry delay instead of reporting a generic stream disconnect. Healthy streams keep the existing low-latency passthrough behavior.

## Validation

- `make test`
- `make vet`
- `make build`
- `git diff --check`