### PR TITLE
fix(proxy): allow bounded policy request translation

### DIFF
--- a/docs/policy-routing.md
+++ b/docs/policy-routing.md
@@ -269,7 +269,7 @@ Classifier facts are built before tool-output optimization and contain bounded u
 - original byte counts and truncation flags.
 
 The serialized canonical facts JSON is capped at `max_request_bytes`; the fixed forced-tool Chat envelope is separately bounded by the implementation.
- Policy requests larger than 1 MiB are rejected before fact materialization so classifier admission cannot be bypassed with oversized message/tool arrays.
+Client policy requests larger than 1 MiB are rejected before translation or fact materialization so classifier admission cannot be bypassed with oversized message/tool arrays. The trusted policy Responses-to-Chat bridge may expand an accepted request while flattening namespace tools and adding canonical Chat wrappers; that internal body is separately capped at the ordinary 10 MiB Chat request ceiling before facts are built or a terminal route is selected.
 
 Vekil excludes provider credentials, inbound authorization, provider state, replay IDs, session identifiers, raw routing metadata, physical deployment names, function parameter schemas, and tool arguments. Classifier decisions and metrics also exclude prompt text and raw model output.
 

--- a/proxy/chat_policy_facts.go
+++ b/proxy/chat_policy_facts.go
@@ -32,6 +32,9 @@ const (
 type policyFactOptions struct {
 	RecentTurns     int
 	MaxRequestBytes int
+	// MaxSourceBytes is an internal ceiling for already-validated canonical
+	// request bodies. Zero preserves the 1 MiB public policy request limit.
+	MaxSourceBytes int
 }
 
 func (o policyFactOptions) normalized() (policyFactOptions, error) {
@@ -43,6 +46,12 @@ func (o policyFactOptions) normalized() (policyFactOptions, error) {
 	}
 	if o.MaxRequestBytes < policyFactMinRequestBytes || o.MaxRequestBytes > policyFactMaxRequestBytes {
 		return policyFactOptions{}, fmt.Errorf("max_request_bytes must be in %d..%d", policyFactMinRequestBytes, policyFactMaxRequestBytes)
+	}
+	if o.MaxSourceBytes == 0 {
+		o.MaxSourceBytes = policyFactMaxSourceBytes
+	}
+	if o.MaxSourceBytes < 1 || o.MaxSourceBytes > maxRequestBodySize {
+		return policyFactOptions{}, fmt.Errorf("max_source_bytes must be in 1..%d", maxRequestBodySize)
 	}
 	return o, nil
 }
@@ -165,12 +174,12 @@ type parsedPolicyFactMessage struct {
 // buildPolicyClassifierFacts validates the supported first-release Chat shape
 // and builds a deterministic, bounded facts snapshot from the original body.
 func buildPolicyClassifierFacts(body []byte, opts policyFactOptions) (policyClassifierFacts, error) {
-	if len(body) > policyFactMaxSourceBytes {
-		return policyClassifierFacts{}, newPolicyFactBuildError("", fmt.Sprintf("policy request exceeds %d-byte fact-processing limit", policyFactMaxSourceBytes))
-	}
 	normalized, err := opts.normalized()
 	if err != nil {
 		return policyClassifierFacts{}, err
+	}
+	if len(body) > normalized.MaxSourceBytes {
+		return policyClassifierFacts{}, newPolicyFactBuildError("", fmt.Sprintf("policy request exceeds %d-byte fact-processing limit", normalized.MaxSourceBytes))
 	}
 
 	root, err := decodePolicyFactObject(body, "")

--- a/proxy/chat_policy_facts_test.go
+++ b/proxy/chat_policy_facts_test.go
@@ -481,6 +481,8 @@ func TestBuildPolicyClassifierFactsRejectsInvalidOptionsAndJSON(t *testing.T) {
 		{RecentTurns: policyFactMaxRecentTurns + 1},
 		{MaxRequestBytes: policyFactMinRequestBytes - 1},
 		{MaxRequestBytes: policyFactMaxRequestBytes + 1},
+		{MaxSourceBytes: -1},
+		{MaxSourceBytes: maxRequestBodySize + 1},
 	} {
 		if _, err := buildPolicyClassifierFacts(validBody, opts); err == nil {
 			t.Fatalf("buildPolicyClassifierFacts(%#v) error = nil", opts)

--- a/proxy/chat_policy_planner.go
+++ b/proxy/chat_policy_planner.go
@@ -18,6 +18,9 @@ type chatPolicyInput struct {
 	OperationID  string
 	Model        string
 	OriginalBody []byte
+	// FactSourceBytesLimit is non-zero only for a trusted canonical translation
+	// whose public ingress was already checked against the default fact limit.
+	FactSourceBytesLimit int
 }
 
 func (i chatPolicyInput) normalized() chatPolicyInput {
@@ -30,10 +33,14 @@ func (i chatPolicyInput) normalized() chatPolicyInput {
 }
 
 func (h *ProxyHandler) planOpenAIChatPolicy(ctx context.Context, model string, originalBody []byte) (chatOperationPlan, error) {
+	return h.planOpenAIChatPolicyWithFactSourceLimit(ctx, model, originalBody, 0)
+}
+
+func (h *ProxyHandler) planOpenAIChatPolicyWithFactSourceLimit(ctx context.Context, model string, originalBody []byte, factSourceBytesLimit int) (chatOperationPlan, error) {
 	if h == nil || h.chatPolicyPlanner == nil {
 		return chatOperationPlan{}, nil
 	}
-	input := chatPolicyInput{Model: model, OriginalBody: originalBody}
+	input := chatPolicyInput{Model: model, OriginalBody: originalBody, FactSourceBytesLimit: factSourceBytesLimit}
 	// Policy ingress may establish a client-visible request identity before
 	// translation and planning. Reuse it so sampling, route attempts, response
 	// headers, and request summaries all describe the same logical operation.

--- a/proxy/policy_responses.go
+++ b/proxy/policy_responses.go
@@ -31,7 +31,9 @@ func (h *ProxyHandler) handlePolicyResponses(w http.ResponseWriter, r *http.Requ
 		writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error")
 		return
 	}
-	policyPlan, err := h.planOpenAIChatPolicy(r.Context(), translated.PublicModel, translated.Body)
+	policyPlan, err := h.planOpenAIChatPolicyWithFactSourceLimit(
+		r.Context(), translated.PublicModel, translated.Body, policyResponsesMaxTranslatedChatBytes,
+	)
 	if err != nil {
 		if h.handleShutdownError(w, r, nil, err) {
 			return

--- a/proxy/policy_responses_ingress_test.go
+++ b/proxy/policy_responses_ingress_test.go
@@ -101,6 +101,31 @@ func TestPolicyResponsesIngressStreamsTextThroughBaselineChatRoute(t *testing.T)
 	}
 }
 
+func TestPolicyResponsesIngressAllowsBoundedCanonicalExpansion(t *testing.T) {
+	light := newPolicyIntegrationUpstream(t, policyClassifierSignals{})
+	powerful := newPolicyIntegrationUpstream(t, policyClassifierSignals{})
+	h, err := NewProxyHandler(nil, logger.New(logger.ParseLevel("error")),
+		WithProvidersConfig(policyIntegrationConfig(light.server.URL, powerful.server.URL, policyConfigModeOff)),
+		WithPolicyRoutingMode(PolicyRoutingModeOff),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	body := policyResponsesCanonicalExpansionRequest(t, "coding-economy")
+	h.HandleResponses(recorder, httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(string(body))))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if sends, models := light.snapshot(); sends != 1 || strings.Join(models, ",") != "light-model" {
+		t.Fatalf("light requests=%d models=%v", sends, models)
+	}
+	if sends, _ := powerful.snapshot(); sends != 0 {
+		t.Fatalf("powerful requests=%d", sends)
+	}
+}
+
 func TestPolicyResponsesIngressAllowsResolvedPolicyAliasWithinLaunchScope(t *testing.T) {
 	light := newPolicyIntegrationUpstream(t, policyClassifierSignals{})
 	powerful := newPolicyIntegrationUpstream(t, policyClassifierSignals{})

--- a/proxy/policy_responses_translate.go
+++ b/proxy/policy_responses_translate.go
@@ -18,9 +18,13 @@ const (
 	policyResponsesToolKindFunction = "function"
 
 	policyResponsesMaxRequestBytes = 1 << 20
-	policyResponsesMaxJSONDepth    = 128
-	policyResponsesMaxInputItems   = 1024
-	policyResponsesMaxContentParts = 1024
+	// Translation adds canonical Chat wrappers and flattened tool aliases. Keep
+	// the public policy ingress at 1 MiB, but allow that already-bounded input to
+	// expand up to the ordinary Chat request ceiling.
+	policyResponsesMaxTranslatedChatBytes = maxRequestBodySize
+	policyResponsesMaxJSONDepth           = 128
+	policyResponsesMaxInputItems          = 1024
+	policyResponsesMaxContentParts        = 1024
 	// Responses-backed Chat bridges used by managed Codex launches can accept
 	// Responses-scale catalogs beyond the 128-function native OpenAI/Azure Chat
 	// limit. Operators using narrower native-Chat destinations must constrain the
@@ -252,8 +256,8 @@ func translatePolicyResponsesRequestToChat(body []byte) (policyResponsesChatRequ
 	if err != nil {
 		return policyResponsesChatRequest{}, fmt.Errorf("marshal policy Chat request: %w", err)
 	}
-	if len(chatBody) > policyResponsesMaxRequestBytes {
-		return policyResponsesChatRequest{}, newChatInvalidRequest("", fmt.Sprintf("translated policy Chat request exceeds %d bytes", policyResponsesMaxRequestBytes))
+	if len(chatBody) > policyResponsesMaxTranslatedChatBytes {
+		return policyResponsesChatRequest{}, newChatInvalidRequest("", fmt.Sprintf("translated policy Chat request exceeds %d bytes", policyResponsesMaxTranslatedChatBytes))
 	}
 	return policyResponsesChatRequest{
 		Body:          chatBody,
@@ -740,6 +744,17 @@ func parsePolicyResponsesTools(raw json.RawMessage) ([]policyResponsesParsedTool
 		return nil, newChatInvalidRequest("tools", "tools must be an array")
 	}
 	parsed := make([]policyResponsesParsedTool, 0, len(values))
+	flattenedDescriptionBytes := 0
+	appendTool := func(tool policyResponsesParsedTool, namespaceDescription string, namespaceDescriptionBytes int) error {
+		descriptionBytes := policyResponsesCombinedToolDescriptionJSONBytes(namespaceDescription, namespaceDescriptionBytes, tool.description)
+		if descriptionBytes > policyResponsesMaxTranslatedChatBytes-flattenedDescriptionBytes {
+			return newChatInvalidRequest(tool.param+".description", fmt.Sprintf("flattened tool descriptions exceed %d encoded bytes", policyResponsesMaxTranslatedChatBytes))
+		}
+		flattenedDescriptionBytes += descriptionBytes
+		tool.description = combinePolicyResponsesToolDescriptions(namespaceDescription, tool.description)
+		parsed = append(parsed, tool)
+		return nil
+	}
 	for index, toolRaw := range values {
 		if len(parsed) >= policyResponsesMaxFunctionTools {
 			return nil, newChatInvalidRequest("tools", fmt.Sprintf("tools may contain at most %d flattened function tools", policyResponsesMaxFunctionTools))
@@ -759,7 +774,9 @@ func parsePolicyResponsesTools(raw json.RawMessage) ([]policyResponsesParsedTool
 			if err != nil {
 				return nil, err
 			}
-			parsed = append(parsed, tool)
+			if err := appendTool(tool, "", 0); err != nil {
+				return nil, err
+			}
 		case "namespace":
 			if err := validatePolicyResponsesObjectFields(object, param, "type", "name", "description", "tools"); err != nil {
 				return nil, err
@@ -772,6 +789,7 @@ func parsePolicyResponsesTools(raw json.RawMessage) ([]policyResponsesParsedTool
 			if err != nil {
 				return nil, err
 			}
+			namespaceDescriptionBytes := policyResponsesJSONStringBytes(namespaceDescription)
 			childrenRaw, ok := object["tools"]
 			if !ok {
 				return nil, newChatInvalidRequest(param+".tools", "namespace tools are required")
@@ -800,8 +818,9 @@ func parsePolicyResponsesTools(raw json.RawMessage) ([]policyResponsesParsedTool
 				if err != nil {
 					return nil, err
 				}
-				child.description = combinePolicyResponsesToolDescriptions(namespaceDescription, child.description)
-				parsed = append(parsed, child)
+				if err := appendTool(child, namespaceDescription, namespaceDescriptionBytes); err != nil {
+					return nil, err
+				}
 			}
 		case "custom", "web_search", "web_search_preview", "image_generation", "file_search", "computer_use_preview", "tool_search", "mcp":
 			return nil, newChatInvalidRequest(param+".type", fmt.Sprintf("hosted or custom tool type %q is not supported for policy models", toolType))
@@ -810,6 +829,28 @@ func parsePolicyResponsesTools(raw json.RawMessage) ([]policyResponsesParsedTool
 		}
 	}
 	return parsed, nil
+}
+
+func policyResponsesJSONStringBytes(value string) int {
+	if value == "" {
+		return 0
+	}
+	encoded, _ := json.Marshal(value)
+	return len(encoded)
+}
+
+func policyResponsesCombinedToolDescriptionJSONBytes(namespace string, namespaceBytes int, child string) int {
+	childBytes := policyResponsesJSONStringBytes(child)
+	switch {
+	case namespace == "":
+		return childBytes
+	case child == "":
+		return namespaceBytes
+	default:
+		// Each input length includes its own quotes. The combined string drops two
+		// quote pairs, adds one pair, and encodes the two newlines as \n\n.
+		return namespaceBytes + childBytes + 2
+	}
 }
 
 func combinePolicyResponsesToolDescriptions(namespace, child string) string {

--- a/proxy/policy_responses_translate_test.go
+++ b/proxy/policy_responses_translate_test.go
@@ -634,6 +634,124 @@ func TestTranslatePolicyResponsesRequestToChatAcceptsCodexScaleNamespaceCatalog(
 	}
 }
 
+func TestTranslatePolicyResponsesRequestToChatAllowsBoundedCanonicalExpansion(t *testing.T) {
+	body := policyResponsesCanonicalExpansionRequest(t, "policy")
+	translated, err := translatePolicyResponsesRequestToChat(body)
+	if err != nil {
+		t.Fatalf("translate request with bounded canonical expansion: %v", err)
+	}
+	if len(translated.Body) <= policyResponsesMaxRequestBytes {
+		t.Fatalf("translated request size = %d, want expansion beyond ingress limit %d", len(translated.Body), policyResponsesMaxRequestBytes)
+	}
+	if len(translated.Body) > policyResponsesMaxTranslatedChatBytes {
+		t.Fatalf("translated request size = %d, want at most %d", len(translated.Body), policyResponsesMaxTranslatedChatBytes)
+	}
+	facts, err := buildPolicyClassifierFacts(translated.Body, policyFactOptions{MaxSourceBytes: policyResponsesMaxTranslatedChatBytes})
+	if err != nil {
+		t.Fatalf("build facts from expanded canonical request: %v", err)
+	}
+	if facts.Counts.FunctionTools != policyResponsesMaxFunctionTools {
+		t.Fatalf("function tool count = %d, want %d", facts.Counts.FunctionTools, policyResponsesMaxFunctionTools)
+	}
+}
+
+func policyResponsesCanonicalExpansionRequest(t *testing.T, model string) []byte {
+	t.Helper()
+	tools := make([]any, 0, policyResponsesMaxFunctionTools)
+	for index := 0; index < policyResponsesMaxFunctionTools; index++ {
+		tools = append(tools, map[string]any{
+			"type":       "function",
+			"name":       fmt.Sprintf("f_%04d", index),
+			"parameters": map[string]any{"type": "object"},
+		})
+	}
+	request := map[string]any{
+		"model":        model,
+		"input":        "hi",
+		"instructions": "",
+		"tools":        tools,
+		"store":        false,
+		"stream":       false,
+	}
+	base, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paddingBytes := policyResponsesMaxRequestBytes - len(base) - 1024
+	if paddingBytes <= 0 {
+		t.Fatalf("base request size = %d, want room below ingress limit %d", len(base), policyResponsesMaxRequestBytes)
+	}
+	request["instructions"] = strings.Repeat("x", paddingBytes)
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) >= policyResponsesMaxRequestBytes {
+		t.Fatalf("request size = %d, want below ingress limit %d", len(body), policyResponsesMaxRequestBytes)
+	}
+	return body
+}
+
+func TestPolicyResponsesCombinedToolDescriptionJSONBytesMatchesEncoding(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		namespace string
+		child     string
+	}{
+		{name: "empty"},
+		{name: "namespace only", namespace: "namespace <&>"},
+		{name: "child only", child: "child\n<&>"},
+		{name: "combined", namespace: "namespace <&>", child: "child\n<&>"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			combined := combinePolicyResponsesToolDescriptions(test.namespace, test.child)
+			encoded, err := json.Marshal(combined)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := policyResponsesCombinedToolDescriptionJSONBytes(test.namespace, policyResponsesJSONStringBytes(test.namespace), test.child)
+			want := len(encoded)
+			if combined == "" {
+				want = 0
+			}
+			if got != want {
+				t.Fatalf("encoded size = %d, want %d (%s)", got, want, encoded)
+			}
+		})
+	}
+}
+
+func TestTranslatePolicyResponsesRequestToChatRejectsAmplifiedNamespaceDescriptions(t *testing.T) {
+	children := make([]any, 0, policyResponsesMaxFunctionTools)
+	for index := 0; index < policyResponsesMaxFunctionTools; index++ {
+		children = append(children, map[string]any{
+			"type":       "function",
+			"name":       fmt.Sprintf("f_%04d", index),
+			"parameters": map[string]any{"type": "object"},
+		})
+	}
+	body, err := json.Marshal(map[string]any{
+		"model": "policy",
+		"input": "hi",
+		"tools": []any{map[string]any{
+			"type":        "namespace",
+			"name":        "bulk",
+			"description": strings.Repeat("<", policyResponsesMaxTranslatedChatBytes/6/policyResponsesMaxFunctionTools+1),
+			"tools":       children,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) >= policyResponsesMaxRequestBytes {
+		t.Fatalf("request size = %d, want below ingress limit %d", len(body), policyResponsesMaxRequestBytes)
+	}
+	_, err = translatePolicyResponsesRequestToChat(body)
+	if err == nil || !strings.Contains(err.Error(), "flattened tool descriptions exceed") {
+		t.Fatalf("error = %v, want flattened-description bound", err)
+	}
+}
+
 func TestTranslatePolicyResponsesRequestToChatEnforcesIngressBounds(t *testing.T) {
 	t.Run("request bytes", func(t *testing.T) {
 		body := []byte(`{"model":"policy","input":"` + strings.Repeat("x", policyResponsesMaxRequestBytes) + `"}`)

--- a/proxy/policy_routing.go
+++ b/proxy/policy_routing.go
@@ -438,6 +438,7 @@ func (c *chatPolicyRoutingController) Plan(ctx context.Context, input chatPolicy
 	facts, err := buildPolicyClassifierFacts(input.OriginalBody, policyFactOptions{
 		RecentTurns:     profile.config.Classifier.RecentTurns,
 		MaxRequestBytes: profile.config.Classifier.MaxRequestBytes,
+		MaxSourceBytes:  input.FactSourceBytesLimit,
 	})
 	if err != nil {
 		return chatOperationPlan{}, &providerRequestError{statusCode: http.StatusBadRequest, err: fmt.Errorf("policy model %q supports text and standard function tools only: %w", entry.id, err)}


### PR DESCRIPTION
## Summary

- keep the public policy Responses ingress limit at 1 MiB
- allow validated canonical Chat translation to expand up to the standard 10 MiB request ceiling
- preserve the direct policy Chat fact limit while allowing the trusted translated body through planning
- bound namespace-description amplification before materializing flattened tools
- add translator and full `/v1/responses` regression coverage and update policy-routing documentation

## Root cause

The Responses-to-Chat bridge applied the same 1 MiB limit to both the client request and the expanded canonical Chat body. Tool flattening, aliases, wrappers, and JSON encoding could push an accepted request over that limit. Raising only the translator limit would still fail at the policy fact-builder's independent 1 MiB source limit.

## Validation

- `make test`
- `make vet`
- `make build`
- targeted policy Responses race tests