### PR TITLE
docs: correct Codex proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,10 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 ```bash
 env OPENAI_API_KEY=dummy \
   codex exec --skip-git-repo-check -m gpt-5.5 \
+  -c 'model_provider="openai"' \
   -c 'openai_base_url="http://localhost:1337/v1"' \
   "Reply with exactly PROXY_OK"
 ```
-
-Codex takes the endpoint from its own configuration, not from `OPENAI_BASE_URL`. See [Client Examples](docs/clients.md#openai-codex-cli).
 
 ### GitHub Copilot CLI
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ env ANTHROPIC_BASE_URL=http://localhost:1337 \
 
 ```bash
 env OPENAI_API_KEY=dummy \
-  OPENAI_BASE_URL=http://localhost:1337/v1 \
-  codex exec --skip-git-repo-check -m gpt-5.5 "Reply with exactly PROXY_OK"
+  codex exec --skip-git-repo-check -m gpt-5.5 \
+  -c 'openai_base_url="http://localhost:1337/v1"' \
+  "Reply with exactly PROXY_OK"
 ```
+
+Codex takes the endpoint from its own configuration, not from `OPENAI_BASE_URL`. See [Client Examples](docs/clients.md#openai-codex-cli).
 
 ### GitHub Copilot CLI
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -57,19 +57,14 @@ Use [`vekil launch codex`](agent-launchers.md) for an ephemeral supervised sessi
 ```bash
 env OPENAI_API_KEY=dummy \
   codex exec --skip-git-repo-check -m gpt-5.5 \
+  -c 'model_provider="openai"' \
   -c 'openai_base_url="http://localhost:1337/v1"' \
   "Reply with exactly PROXY_OK"
 ```
 
-Codex resolves the built-in `openai` provider's endpoint from the `openai_base_url` config key only — set it with `-c` as above, or persist it in `~/.codex/config.toml`. `OPENAI_BASE_URL` is not read: exporting it leaves Codex calling the upstream provider directly, with no error to indicate the proxy was bypassed. This is the same routing [`vekil launch codex`](agent-launchers.md) applies, which is why the launcher sets `model_providers.<id>.base_url` and clears `OPENAI_BASE_URL` from the child environment.
+Codex resolves the built-in `openai` provider's endpoint from the `openai_base_url` config key. Set both `model_provider` and `openai_base_url` with `-c` as above, or persist both in `~/.codex/config.toml`; pinning the provider prevents an existing custom provider from bypassing Vekil. `OPENAI_BASE_URL` is not read: exporting it leaves Codex calling the upstream provider directly, with no error to indicate the proxy was bypassed. [`vekil launch codex`](agent-launchers.md) applies the same explicit routing with a generated provider: it selects that provider, sets `model_providers.<id>.base_url`, and clears `OPENAI_BASE_URL` from the child environment.
 
-Codex also requires `~/.codex/auth.json` to exist before it will run a session, even though the proxy accepts a placeholder key. For non-interactive setups, create one without going through the sign-in flow:
-
-```bash
-printf 'dummy' | codex login --with-api-key
-```
-
-With `wire_api = "responses"`, Codex probes the [Responses WebSocket bridge](responses-websocket.md) before falling back to HTTPS streaming. When the bridge is disabled — the default — that probe logs a single `426 Upgrade Required` at startup and the session proceeds normally over HTTPS.
+For this manual configuration, Codex's built-in `openai` provider probes the [Responses WebSocket bridge](responses-websocket.md) before falling back to HTTP streaming. When the bridge is disabled — the default — that probe logs a single `426 Upgrade Required` at startup and the session proceeds normally over HTTP. The managed launcher disables this WebSocket probe.
 
 ## GitHub Copilot CLI
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -56,9 +56,20 @@ Use [`vekil launch codex`](agent-launchers.md) for an ephemeral supervised sessi
 
 ```bash
 env OPENAI_API_KEY=dummy \
-  OPENAI_BASE_URL=http://localhost:1337/v1 \
-  codex exec --skip-git-repo-check -m gpt-5.5 "Reply with exactly PROXY_OK"
+  codex exec --skip-git-repo-check -m gpt-5.5 \
+  -c 'openai_base_url="http://localhost:1337/v1"' \
+  "Reply with exactly PROXY_OK"
 ```
+
+Codex resolves the built-in `openai` provider's endpoint from the `openai_base_url` config key only — set it with `-c` as above, or persist it in `~/.codex/config.toml`. `OPENAI_BASE_URL` is not read: exporting it leaves Codex calling the upstream provider directly, with no error to indicate the proxy was bypassed. This is the same routing [`vekil launch codex`](agent-launchers.md) applies, which is why the launcher sets `model_providers.<id>.base_url` and clears `OPENAI_BASE_URL` from the child environment.
+
+Codex also requires `~/.codex/auth.json` to exist before it will run a session, even though the proxy accepts a placeholder key. For non-interactive setups, create one without going through the sign-in flow:
+
+```bash
+printf 'dummy' | codex login --with-api-key
+```
+
+With `wire_api = "responses"`, Codex probes the [Responses WebSocket bridge](responses-websocket.md) before falling back to HTTPS streaming. When the bridge is disabled — the default — that probe logs a single `426 Upgrade Required` at startup and the session proceeds normally over HTTPS.
 
 ## GitHub Copilot CLI
 


### PR DESCRIPTION
## Problem

The Codex examples in `README.md` and `docs/clients.md` route with `OPENAI_BASE_URL`. Codex does not read that variable. Requests go to the upstream provider directly, and nothing in the output indicates the proxy was bypassed — the failure is silent.

## Repro (codex-cli 0.146.0)

Point the documented variable at a local listener that logs every request:

```bash
env OPENAI_API_KEY=dummy OPENAI_BASE_URL=http://127.0.0.1:59999/v1 \
  codex exec --skip-git-repo-check "hi"
```

Zero requests reach the listener; Codex calls `https://api.openai.com/v1/responses`. Swapping in `-c 'openai_base_url="http://127.0.0.1:59999/v1"'` sends every request to the listener. Against a running Vekil proxy the corrected form returns `PROXY_OK`.

## Why

`built_in_model_providers` takes the built-in `openai` provider's base URL from configuration only (`openai_base_url` → `create_openai_provider`); there is no env fallback on that path. `launch/codex.go` already handles this correctly — it sets `model_providers.<id>.base_url` and lists `OPENAI_BASE_URL` in its unset list — so only the manual instructions are affected.

## Note on the smoke test

`scripts/live-cli-smoke.sh` writes `openai_base_url` into a generated `config.toml` (L547) *and* exports `OPENAI_BASE_URL` (L554). The config file is what routes; the env var is a no-op. That is likely why the documented recipe went unchallenged — the green smoke run never exercised it. Left alone here to keep this docs-only; happy to drop the redundant line in a follow-up.

## Also included

The `auth.json` prerequisite with a non-interactive form, and an explanation of the benign `426 Upgrade Required` the Responses WebSocket probe logs at startup — both surface immediately when following these examples.
