### PR TITLE
feat(tray): replace subprocess dialogs with xdg-desktop-portal

### DIFF
--- a/cmd/menubar/dialog_common.go
+++ b/cmd/menubar/dialog_common.go
@@ -3,3 +3,12 @@ package main
 import "errors"
 
 var errDialogCanceled = errors.New("dialog canceled")
+
+// confirmationPrompt describes a yes/no confirmation shown to the user before
+// an action (such as opening a browser for GitHub sign-in) proceeds.
+type confirmationPrompt struct {
+	Title        string
+	Message      string
+	ApproveLabel string
+	DeclineLabel string
+}

--- a/cmd/menubar/dialog_darwin.go
+++ b/cmd/menubar/dialog_darwin.go
@@ -1,29 +1,30 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 )
 
-// showOsascriptDialog displays a macOS dialog using osascript and returns the
-// button the user clicked (e.g. "Open GitHub" or "Cancel"). If the user clicks
-// Cancel (or closes the dialog), "Cancel" is returned.
-func showOsascriptDialog(title, message, defaultButton, secondButton string) string {
+// confirmAction displays a macOS confirmation dialog using osascript and
+// returns true only when the user clicks the exact approve label. false is
+// the safe default for a declined, cancelled, or dismissed dialog.
+func confirmAction(ctx context.Context, prompt confirmationPrompt) bool {
 	script := fmt.Sprintf(
 		`display dialog %q with title %q buttons {%q, %q} default button %q`,
-		message, title, secondButton, defaultButton, defaultButton,
+		prompt.Message, prompt.Title, prompt.DeclineLabel, prompt.ApproveLabel, prompt.ApproveLabel,
 	)
-	out, err := exec.Command("osascript", "-e", script).Output()
+	out, err := exec.CommandContext(ctx, "osascript", "-e", script).Output()
 	if err != nil {
-		// User clicked Cancel or closed the dialog.
-		return "Cancel"
+		// User clicked decline, closed the dialog, or ctx was cancelled.
+		return false
 	}
 	// osascript returns "button returned:Open GitHub\n"
 	result := strings.TrimSpace(string(out))
 	result = strings.TrimPrefix(result, "button returned:")
-	return result
+	return result == prompt.ApproveLabel
 }
 
 // showErrorDialog displays a simple macOS error dialog with an OK button.

--- a/cmd/menubar/dialog_linux.go
+++ b/cmd/menubar/dialog_linux.go
@@ -14,6 +14,7 @@ import (
 const dbusNotifyDest = "org.freedesktop.Notifications"
 const dbusNotifyPath = "/org/freedesktop/Notifications"
 const dbusNotifyIface = "org.freedesktop.Notifications"
+const providersConfigSelectionGuidance = "install and run a desktop portal backend, run vekil --providers-config PATH, or edit the saved menubar config file directly"
 
 var (
 	errNotificationDismissed = errors.New("notification dismissed")
@@ -161,7 +162,7 @@ func portalShow(title, message, priority string) error {
 func chooseProvidersConfigPath() (string, error) {
 	conn, err := newPortalConn()
 	if err != nil {
-		return "", fmt.Errorf("connect to xdg-desktop-portal: %w; install and run a desktop portal backend", err)
+		return "", fmt.Errorf("connect to xdg-desktop-portal: %w; %s", err, providersConfigSelectionGuidance)
 	}
 	defer func() { _ = conn.Close() }()
 
@@ -176,7 +177,7 @@ func chooseProvidersConfigPath() (string, error) {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			return "", errDialogCanceled
 		}
-		return "", fmt.Errorf("xdg-desktop-portal file chooser failed; install and run a desktop portal backend: %w", err)
+		return "", fmt.Errorf("xdg-desktop-portal file chooser failed: %w; %s", err, providersConfigSelectionGuidance)
 	}
 
 	switch resp.Code {
@@ -185,7 +186,7 @@ func chooseProvidersConfigPath() (string, error) {
 	case 1:
 		return "", errDialogCanceled
 	default:
-		return "", fmt.Errorf("xdg-desktop-portal file chooser failed (response code %d); install and run a desktop portal backend", resp.Code)
+		return "", fmt.Errorf("xdg-desktop-portal file chooser failed (response code %d); %s", resp.Code, providersConfigSelectionGuidance)
 	}
 
 	uris, err := decodePortalStringArray(resp.Results, "uris")

--- a/cmd/menubar/dialog_linux.go
+++ b/cmd/menubar/dialog_linux.go
@@ -174,9 +174,6 @@ func chooseProvidersConfigPath() (string, error) {
 
 	resp, err := portalOpenFile(ctx, conn, token, predicted, "Choose Providers Config")
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			return "", errDialogCanceled
-		}
 		return "", fmt.Errorf("xdg-desktop-portal file chooser failed: %w; %s", err, providersConfigSelectionGuidance)
 	}
 
@@ -361,33 +358,75 @@ func dbusNotifyWithActions(ctx context.Context, summary, body string, actions []
 		return "", err
 	}
 
+	return waitForLegacyNotificationAction(ctx, sigCh, nid, validActions, func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+		_ = obj.CallWithContext(closeCtx, dbusNotifyIface+".CloseNotification", 0, nid).Err
+		cancel()
+	})
+}
+
+// waitForLegacyNotificationAction waits for an action or dismissal belonging
+// to notificationID. When ctx ends, an already-buffered matching result wins;
+// otherwise closeNotification is invoked before returning the context error.
+func waitForLegacyNotificationAction(ctx context.Context, sigCh <-chan *dbus.Signal, notificationID uint32, validActions map[string]bool, closeNotification func()) (string, error) {
 	for {
 		select {
 		case sig, ok := <-sigCh:
 			if !ok {
 				return "", fmt.Errorf("signal channel closed")
 			}
-			switch sig.Name {
-			case dbusNotifyIface + ".ActionInvoked":
-				if len(sig.Body) >= 2 {
-					if id, ok := sig.Body[0].(uint32); ok && id == nid {
-						if action, ok := sig.Body[1].(string); ok && validActions[action] {
-							return action, nil
-						}
-					}
-				}
-			case dbusNotifyIface + ".NotificationClosed":
-				if len(sig.Body) >= 1 {
-					if id, ok := sig.Body[0].(uint32); ok && id == nid {
-						return "", errNotificationDismissed
-					}
-				}
+			if action, err, matched := decodeLegacyNotificationResult(sig, notificationID, validActions); matched {
+				return action, err
 			}
 		case <-ctx.Done():
-			closeCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
-			_ = obj.CallWithContext(closeCtx, dbusNotifyIface+".CloseNotification", 0, nid).Err
-			cancel()
+			// A user action can already be buffered when the shared timeout
+			// expires. Preserve that explicit answer instead of randomly
+			// choosing cancellation and closing the notification first.
+			if action, err, matched := drainQueuedLegacyNotificationResult(sigCh, notificationID, validActions); matched {
+				return action, err
+			}
+			closeNotification()
 			return "", ctx.Err()
 		}
 	}
+}
+
+// drainQueuedLegacyNotificationResult non-blockingly drains signals already
+// buffered on sigCh, looking for a matching action or dismissal.
+func drainQueuedLegacyNotificationResult(sigCh <-chan *dbus.Signal, notificationID uint32, validActions map[string]bool) (string, error, bool) {
+	for {
+		select {
+		case sig, ok := <-sigCh:
+			if !ok {
+				return "", nil, false
+			}
+			if action, err, matched := decodeLegacyNotificationResult(sig, notificationID, validActions); matched {
+				return action, err, true
+			}
+		default:
+			return "", nil, false
+		}
+	}
+}
+
+// decodeLegacyNotificationResult decodes a matching ActionInvoked or
+// NotificationClosed signal for notificationID.
+func decodeLegacyNotificationResult(sig *dbus.Signal, notificationID uint32, validActions map[string]bool) (string, error, bool) {
+	switch sig.Name {
+	case dbusNotifyIface + ".ActionInvoked":
+		if len(sig.Body) >= 2 {
+			if id, ok := sig.Body[0].(uint32); ok && id == notificationID {
+				if action, ok := sig.Body[1].(string); ok && validActions[action] {
+					return action, nil, true
+				}
+			}
+		}
+	case dbusNotifyIface + ".NotificationClosed":
+		if len(sig.Body) >= 1 {
+			if id, ok := sig.Body[0].(uint32); ok && id == notificationID {
+				return "", errNotificationDismissed, true
+			}
+		}
+	}
+	return "", nil, false
 }

--- a/cmd/menubar/dialog_linux.go
+++ b/cmd/menubar/dialog_linux.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -16,136 +17,186 @@ const dbusNotifyIface = "org.freedesktop.Notifications"
 
 var (
 	errNotificationDismissed = errors.New("notification dismissed")
-	execLookPath             = exec.LookPath
-	execCommand              = exec.Command
 	notifyWithActions        = dbusNotifyWithActions
 	notify                   = dbusNotify
+	runXDGOpen               = func(rawURL string) { _ = exec.Command("xdg-open", rawURL).Start() }
 )
 
-type dialogAttemptResult int
+// confirmAction prompts the user through an xdg-desktop-portal notification
+// with approve/decline actions, falling back to a legacy
+// org.freedesktop.Notifications action prompt only when the portal
+// notification was provably never shown. false is the safe default: once a
+// prompt may have been shown by either mechanism, any decline, dismissal,
+// timeout, ctx cancellation, or ambiguous delivery failure returns false
+// without ever trying the other mechanism, so at most one prompt is ever
+// shown. One overall timeout budget covers both the portal attempt and any
+// legacy fallback.
+func confirmAction(ctx context.Context, prompt confirmationPrompt) bool {
+	ctx, cancel := context.WithTimeout(ctx, portalConfirmationTimeout)
+	defer cancel()
 
-const (
-	dialogUnavailable dialogAttemptResult = iota
-	dialogAccepted
-	dialogCanceled
-)
-
-// showOsascriptDialog displays a dialog using zenity, kdialog, or a DBus
-// notification with action buttons, and returns the button the user clicked.
-// If no dialog mechanism is available, defaultButton is returned so that the
-// calling flow proceeds automatically.
-func showOsascriptDialog(title, message, defaultButton, secondButton string) string {
-	// Try zenity first (GNOME/GTK).
-	if zenity, err := execLookPath("zenity"); err == nil {
-		switch runQuestionDialog(zenity,
-			"--question",
-			"--title="+title,
-			"--text="+message,
-			"--ok-label="+defaultButton,
-			"--cancel-label="+secondButton,
-		) {
-		case dialogAccepted:
-			return defaultButton
-		case dialogCanceled:
-			return "Cancel"
+	if conn, err := sharedPortalNotificationConn.get(); err == nil {
+		switch portalConfirm(ctx, conn, prompt) {
+		case portalConfirmApproved:
+			return true
+		case portalConfirmDeclined:
+			return false
+		case portalConfirmNotShown:
+			// The portal notification was never displayed; fall through to
+			// the bounded legacy fallback below.
 		}
 	}
 
-	// Fall back to kdialog (KDE).
-	if kdialog, err := execLookPath("kdialog"); err == nil {
-		switch runQuestionDialog(kdialog,
-			"--title", title,
-			"--yesno", message,
-			"--yes-label", defaultButton,
-			"--no-label", secondButton,
-		) {
-		case dialogAccepted:
-			return defaultButton
-		case dialogCanceled:
-			return "Cancel"
-		}
+	if ctx.Err() != nil {
+		// The shared budget above already covers the legacy attempt too:
+		// never post a second prompt once it is exhausted, or once the
+		// caller (e.g. a cancelled sign-in) has already moved on.
+		return false
 	}
 
-	// Fall back to DBus notification with action buttons.
-	action, err := notifyWithActions(title, message, []string{
-		"default", defaultButton,
-		"cancel", secondButton,
+	action, err := notifyWithActions(ctx, prompt.Title, prompt.Message, []string{
+		portalActionApprove, prompt.ApproveLabel,
+		portalActionDecline, prompt.DeclineLabel,
 	})
-	if err == nil {
-		if action == "cancel" {
-			return "Cancel"
-		}
-		return defaultButton
+	if err != nil {
+		return false
 	}
-	if errors.Is(err, errNotificationDismissed) {
-		return "Cancel"
-	}
-
-	// No dialog mechanism available — proceed automatically.
-	return defaultButton
+	return action == portalActionApprove
 }
 
-// showErrorDialog displays a simple error dialog using zenity, kdialog, or a
-// DBus notification.
+// portalConfirmOutcome is the three-state result of showing a portal
+// confirmation notification and waiting for the user's answer.
+type portalConfirmOutcome int
+
+const (
+	// portalConfirmNotShown means the notification was never actually
+	// displayed (an ActionInvoked subscribe failure, or an AddNotification
+	// failure portalErrorProvesNotShown recognizes as having occurred before
+	// display). The caller may safely retry through the legacy fallback path.
+	portalConfirmNotShown portalConfirmOutcome = iota
+	// portalConfirmApproved means the user clicked the explicit approve
+	// button.
+	portalConfirmApproved
+	// portalConfirmDeclined covers every other outcome once the notification
+	// may already have been displayed: an explicit decline, any other
+	// action, a timeout, a cancellation, or an ambiguous delivery failure.
+	// At most one prompt is ever shown, so this is always final.
+	portalConfirmDeclined
+)
+
+// portalConfirm shows a portal notification with approve/decline buttons and
+// no default-action (so activating the notification body cannot approve) and
+// waits for the user's answer. See portalConfirmOutcome for what each result
+// means to the caller.
+func portalConfirm(ctx context.Context, conn portalConn, prompt confirmationPrompt) portalConfirmOutcome {
+	id := newPortalToken("confirm")
+	notification := portalConfirmationNotification(prompt)
+
+	action, err := waitForPortalAction(ctx, conn, id, func() error {
+		callCtx, callCancel := context.WithTimeout(ctx, portalMethodCallTimeout)
+		defer callCancel()
+		_, callErr := conn.Call(callCtx, portalBusName, portalObjectPath, portalNotification+".AddNotification", id, notification)
+		return callErr
+	})
+
+	removeCtx, removeCancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+	portalRemoveNotification(removeCtx, conn, id)
+	removeCancel()
+
+	if err != nil {
+		if errors.Is(err, errPortalNotificationNotShown) {
+			return portalConfirmNotShown
+		}
+		return portalConfirmDeclined
+	}
+	if action == portalActionApprove {
+		return portalConfirmApproved
+	}
+	return portalConfirmDeclined
+}
+
+// showErrorDialog displays an urgent-priority portal notification, falling
+// back to a plain legacy notification. Linux errors are notifications rather
+// than modal windows because the portal exposes no generic message-dialog
+// interface.
 func showErrorDialog(title, message string) {
-	if zenity, err := execLookPath("zenity"); err == nil && runDialog(zenity,
-		"--error",
-		"--title="+title,
-		"--text="+message,
-	) {
+	if err := portalShow(title, message, portalPriorityUrgent); err == nil {
 		return
 	}
-
-	if kdialog, err := execLookPath("kdialog"); err == nil && runDialog(kdialog,
-		"--title", title,
-		"--error", message,
-	) {
-		return
-	}
-
-	// Fall back to a plain DBus notification (no actions needed).
 	_ = notify(title, message)
 }
 
+// showNotification displays a normal-priority portal notification, falling
+// back to a plain legacy notification.
+func showNotification(title, message string) {
+	if err := portalShow(title, message, portalPriorityNormal); err == nil {
+		return
+	}
+	_ = notify(title, message)
+}
+
+// portalShow calls Notification.AddNotification on the shared
+// Notification-interface connection. On failure it simply returns the
+// error: it never evicts or closes the shared connection, and callers fall
+// back to a plain legacy notification for this one call only. Unlike
+// confirmAction's at-most-once semantics, a duplicate plain toast (e.g. if
+// the portal actually displayed one before an ambiguous error) is an
+// acceptable, low-consequence outcome.
+func portalShow(title, message, priority string) error {
+	conn, err := sharedPortalNotificationConn.get()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), portalMethodCallTimeout)
+	defer cancel()
+	return portalAddNotification(ctx, conn, newPortalToken("notify"), title, message, priority)
+}
+
+// chooseProvidersConfigPath opens the xdg-desktop-portal file chooser. There
+// is no subprocess dialog fallback: no remaining in-process mechanism
+// provides an equivalent picker without reintroducing the dependency being
+// removed. Pass --providers-config or edit the saved menubar config directly
+// when no portal backend is available.
 func chooseProvidersConfigPath() (string, error) {
-	if zenity, err := execLookPath("zenity"); err == nil {
-		output, runErr := execCommand(zenity,
-			"--file-selection",
-			"--title=Choose Providers Config",
-			"--file-filter=Provider config files | *.json *.yaml *.yml",
-			"--file-filter=All files | *",
-		).CombinedOutput()
-		if runErr == nil {
-			path := strings.TrimSpace(string(output))
-			if path == "" {
-				return "", errDialogCanceled
-			}
-			return path, nil
-		}
-		if isDialogCancel(runErr, output) {
+	conn, err := newPortalConn()
+	if err != nil {
+		return "", fmt.Errorf("connect to xdg-desktop-portal: %w; install and run a desktop portal backend", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), portalFileChooserTimeout)
+	defer cancel()
+
+	token := newPortalToken("file")
+	predicted := predictRequestPath(conn.UniqueName(), token)
+
+	resp, err := portalOpenFile(ctx, conn, token, predicted, "Choose Providers Config")
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			return "", errDialogCanceled
 		}
+		return "", fmt.Errorf("xdg-desktop-portal file chooser failed; install and run a desktop portal backend: %w", err)
 	}
 
-	if kdialog, err := execLookPath("kdialog"); err == nil {
-		output, runErr := execCommand(kdialog,
-			"--getopenfilename",
-			"",
-			"*.json *.yaml *.yml|Provider config files",
-		).CombinedOutput()
-		if runErr == nil {
-			path := strings.TrimSpace(string(output))
-			if path == "" {
-				return "", errDialogCanceled
-			}
-			return path, nil
-		}
-		if isDialogCancel(runErr, output) {
-			return "", errDialogCanceled
-		}
+	switch resp.Code {
+	case 0:
+		// success
+	case 1:
+		return "", errDialogCanceled
+	default:
+		return "", fmt.Errorf("xdg-desktop-portal file chooser failed (response code %d); install and run a desktop portal backend", resp.Code)
 	}
 
-	return "", errors.New("file selection is unavailable; install zenity or kdialog")
+	uris, err := decodePortalStringArray(resp.Results, "uris")
+	if err != nil {
+		return "", fmt.Errorf("xdg-desktop-portal file chooser returned a successful response without usable file selection results: %w", err)
+	}
+	if len(uris) == 0 {
+		return "", fmt.Errorf("xdg-desktop-portal file chooser returned a successful response with no selected files")
+	}
+
+	return decodePortalFileURI(uris[0])
 }
 
 // copyToClipboard copies the given text to the clipboard, trying Wayland and
@@ -177,44 +228,48 @@ func copyToClipboard(text string) {
 	}
 }
 
-// openURL opens a URL in the default browser using xdg-open.
-func openURL(url string) {
-	_ = exec.Command("xdg-open", url).Start()
-}
-
-// showNotification displays a desktop notification. It tries DBus directly
-// first, falling back to notify-send.
-func showNotification(title, message string) {
-	if err := notify(title, message); err == nil {
+// openURL opens an HTTP(S) URL via the xdg-desktop-portal OpenURI method,
+// awaiting its Request response before deciding whether to fall back.
+// Response code 0 (success) and code 1 (a deliberate user cancellation, e.g.
+// dismissing an application chooser) are both final; xdg-open only runs when
+// the portal cannot be reached, the method call itself fails, the response
+// wait fails or times out, or the response reports any other code.
+func openURL(rawURL string) {
+	if !isSupportedOpenURIScheme(rawURL) {
+		runXDGOpen(rawURL)
 		return
 	}
-	_ = execCommand("notify-send", title, message).Run()
-}
 
-func runQuestionDialog(command string, args ...string) dialogAttemptResult {
-	output, err := execCommand(command, args...).CombinedOutput()
-	if err == nil {
-		return dialogAccepted
+	conn, err := newPortalConn()
+	if err != nil {
+		runXDGOpen(rawURL)
+		return
 	}
-	if isDialogCancel(err, output) {
-		return dialogCanceled
-	}
-	return dialogUnavailable
-}
+	defer func() { _ = conn.Close() }()
 
-func runDialog(command string, args ...string) bool {
-	return execCommand(command, args...).Run() == nil
-}
+	ctx, cancel := context.WithTimeout(context.Background(), portalOpenURITimeout)
+	defer cancel()
 
-func isDialogCancel(err error, output []byte) bool {
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		return false
+	token := newPortalToken("open")
+	predicted := predictRequestPath(conn.UniqueName(), token)
+	activationToken := os.Getenv("XDG_ACTIVATION_TOKEN")
+
+	resp, err := portalOpenURICall(ctx, conn, token, predicted, activationToken, rawURL)
+	if err != nil {
+		runXDGOpen(rawURL)
+		return
 	}
-	if exitErr.ExitCode() != 1 {
-		return false
+
+	switch resp.Code {
+	case 0:
+		// success
+	case 1:
+		// user canceled (e.g. dismissed an application chooser); a
+		// deliberate cancel is final, not a signal to try a second
+		// mechanism.
+	default:
+		runXDGOpen(rawURL)
 	}
-	return len(bytes.TrimSpace(output)) == 0
 }
 
 // dbusNotify sends a simple notification (no action buttons) via DBus.
@@ -241,12 +296,14 @@ func dbusNotify(summary, body string) error {
 	return call.Err
 }
 
-// dbusNotifyWithActions sends a notification with action buttons via DBus and
-// blocks until the user clicks an action or dismisses the notification.
-// The actions slice contains alternating key/label pairs: ["key1", "Label 1", "key2", "Label 2"].
-// Returns the action key the user clicked, or an error if the notification was
-// dismissed or if DBus is unavailable.
-func dbusNotifyWithActions(summary, body string, actions []string) (string, error) {
+// dbusNotifyWithActions sends a notification with action buttons via the
+// legacy org.freedesktop.Notifications interface and blocks until the user
+// clicks an action, dismisses the notification, or ctx is done. The actions
+// slice contains alternating key/label pairs: ["key1", "Label 1", "key2",
+// "Label 2"]; only signals reporting one of those keys are honored. Returns
+// the action key the user clicked, or an error if the notification was
+// dismissed, ctx ended, or DBus is unavailable.
+func dbusNotifyWithActions(ctx context.Context, summary, body string, actions []string) (string, error) {
 	conn, err := dbus.ConnectSessionBus()
 	if err != nil {
 		return "", err
@@ -255,9 +312,34 @@ func dbusNotifyWithActions(summary, body string, actions []string) (string, erro
 		_ = conn.Close()
 	}()
 
-	obj := conn.Object(dbusNotifyDest, dbusNotifyPath)
+	validActions := make(map[string]bool, len(actions)/2)
+	for i := 0; i+1 < len(actions); i += 2 {
+		validActions[actions[i]] = true
+	}
 
-	call := obj.Call(dbusNotifyIface+".Notify", 0,
+	sigCh := make(chan *dbus.Signal, 10)
+	conn.Signal(sigCh)
+	defer conn.RemoveSignal(sigCh)
+
+	if err := conn.AddMatchSignalContext(ctx,
+		dbus.WithMatchSender(dbusNotifyDest),
+		dbus.WithMatchObjectPath(dbusNotifyPath),
+		dbus.WithMatchInterface(dbusNotifyIface),
+	); err != nil {
+		return "", err
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+		defer cancel()
+		_ = conn.RemoveMatchSignalContext(cleanupCtx,
+			dbus.WithMatchSender(dbusNotifyDest),
+			dbus.WithMatchObjectPath(dbusNotifyPath),
+			dbus.WithMatchInterface(dbusNotifyIface),
+		)
+	}()
+
+	obj := conn.Object(dbusNotifyDest, dbusNotifyPath)
+	call := obj.CallWithContext(ctx, dbusNotifyIface+".Notify", 0,
 		"Vekil",   // app_name
 		uint32(0), // replaces_id
 		"",        // app_icon
@@ -278,36 +360,33 @@ func dbusNotifyWithActions(summary, body string, actions []string) (string, erro
 		return "", err
 	}
 
-	// Subscribe to notification signals.
-	if err := conn.AddMatchSignal(
-		dbus.WithMatchObjectPath(dbusNotifyPath),
-		dbus.WithMatchInterface(dbusNotifyIface),
-	); err != nil {
-		return "", err
-	}
-
-	sigCh := make(chan *dbus.Signal, 10)
-	conn.Signal(sigCh)
-	defer conn.RemoveSignal(sigCh)
-
-	for sig := range sigCh {
-		switch sig.Name {
-		case dbusNotifyIface + ".ActionInvoked":
-			if len(sig.Body) >= 2 {
-				if id, ok := sig.Body[0].(uint32); ok && id == nid {
-					if action, ok := sig.Body[1].(string); ok {
-						return action, nil
+	for {
+		select {
+		case sig, ok := <-sigCh:
+			if !ok {
+				return "", fmt.Errorf("signal channel closed")
+			}
+			switch sig.Name {
+			case dbusNotifyIface + ".ActionInvoked":
+				if len(sig.Body) >= 2 {
+					if id, ok := sig.Body[0].(uint32); ok && id == nid {
+						if action, ok := sig.Body[1].(string); ok && validActions[action] {
+							return action, nil
+						}
+					}
+				}
+			case dbusNotifyIface + ".NotificationClosed":
+				if len(sig.Body) >= 1 {
+					if id, ok := sig.Body[0].(uint32); ok && id == nid {
+						return "", errNotificationDismissed
 					}
 				}
 			}
-		case dbusNotifyIface + ".NotificationClosed":
-			if len(sig.Body) >= 1 {
-				if id, ok := sig.Body[0].(uint32); ok && id == nid {
-					return "", errNotificationDismissed
-				}
-			}
+		case <-ctx.Done():
+			closeCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+			_ = obj.CallWithContext(closeCtx, dbusNotifyIface+".CloseNotification", 0, nid).Err
+			cancel()
+			return "", ctx.Err()
 		}
 	}
-
-	return "", fmt.Errorf("signal channel closed")
 }

--- a/cmd/menubar/dialog_linux_test.go
+++ b/cmd/menubar/dialog_linux_test.go
@@ -302,6 +302,52 @@ func TestChooseProvidersConfigPathSetupFailureIsActionable(t *testing.T) {
 	if err == nil || errors.Is(err, errDialogCanceled) {
 		t.Fatalf("chooseProvidersConfigPath() error = %v, want a descriptive setup error", err)
 	}
+	requireProvidersConfigSelectionGuidance(t, err)
+}
+
+func TestChooseProvidersConfigPathOpenFailureIsActionable(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.18")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			return nil, errors.New("open failed")
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	_, err := chooseProvidersConfigPath()
+	if err == nil || errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want a descriptive open error", err)
+	}
+	requireProvidersConfigSelectionGuidance(t, err)
+}
+
+func TestChooseProvidersConfigPathErrorResponseIsActionable(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.19")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(2), map[string]dbus.Variant{}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	_, err := chooseProvidersConfigPath()
+	if err == nil || errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want a descriptive portal response error", err)
+	}
+	requireProvidersConfigSelectionGuidance(t, err)
 }
 
 func TestOpenURLSuccessfulPortalCallDoesNotInvokeXDGOpen(t *testing.T) {
@@ -706,6 +752,19 @@ func TestChooseProvidersConfigPathEmptyURIsInSuccessResponseIsActionable(t *test
 	_, err := chooseProvidersConfigPath()
 	if err == nil || errors.Is(err, errDialogCanceled) {
 		t.Fatalf("chooseProvidersConfigPath() error = %v, want a distinct actionable error, not errDialogCanceled", err)
+	}
+}
+
+func requireProvidersConfigSelectionGuidance(t *testing.T, err error) {
+	t.Helper()
+
+	for _, want := range []string{
+		"vekil --providers-config PATH",
+		"edit the saved menubar config file directly",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("chooseProvidersConfigPath() error = %q, want it to contain %q", err, want)
+		}
 	}
 }
 

--- a/cmd/menubar/dialog_linux_test.go
+++ b/cmd/menubar/dialog_linux_test.go
@@ -135,6 +135,59 @@ func TestConfirmActionLegacyDismissalDeclines(t *testing.T) {
 	}
 }
 
+// TestWaitForLegacyNotificationActionReturnsQueuedApprovalWhenContextEndsSimultaneously
+// exercises the same ctx.Done()-vs-buffered-signal race as the portal action
+// path. An explicit approval already delivered to the process must win over
+// the shared confirmation deadline, and the notification must not be closed.
+func TestWaitForLegacyNotificationActionReturnsQueuedApprovalWhenContextEndsSimultaneously(t *testing.T) {
+	const notificationID = uint32(42)
+	validActions := map[string]bool{portalActionApprove: true, portalActionDecline: true}
+
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
+		sigCh := make(chan *dbus.Signal, 1)
+		sigCh <- &dbus.Signal{
+			Path: dbusNotifyPath,
+			Name: dbusNotifyIface + ".ActionInvoked",
+			Body: []any{notificationID, portalActionApprove},
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		closeCalls := 0
+		action, err := waitForLegacyNotificationAction(ctx, sigCh, notificationID, validActions, func() {
+			closeCalls++
+		})
+
+		if err != nil {
+			t.Fatalf("iteration %d: waitForLegacyNotificationAction() error = %v, want queued approval honored", i, err)
+		}
+		if action != portalActionApprove {
+			t.Fatalf("iteration %d: waitForLegacyNotificationAction() = %q, want %q", i, action, portalActionApprove)
+		}
+		if closeCalls != 0 {
+			t.Fatalf("iteration %d: closeNotification calls = %d, want 0 after queued approval", i, closeCalls)
+		}
+	}
+}
+
+func TestWaitForLegacyNotificationActionCancellationClosesNotification(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	closeCalls := 0
+	_, err := waitForLegacyNotificationAction(ctx, make(chan *dbus.Signal, 1), 42, map[string]bool{}, func() {
+		closeCalls++
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForLegacyNotificationAction() error = %v, want context.Canceled", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("closeNotification calls = %d, want 1", closeCalls)
+	}
+}
+
 func TestConfirmActionTotalUIUnavailabilityDeclines(t *testing.T) {
 	restoreDialogHooks(t)
 
@@ -291,6 +344,28 @@ func TestChooseProvidersConfigPathCancellationReturnsErrDialogCanceled(t *testin
 	if !errors.Is(err, errDialogCanceled) {
 		t.Fatalf("chooseProvidersConfigPath() error = %v, want errDialogCanceled", err)
 	}
+}
+
+func TestChooseProvidersConfigPathTimeoutIsActionable(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.34")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			return nil, context.DeadlineExceeded
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	_, err := chooseProvidersConfigPath()
+	if err == nil || errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want a descriptive timeout error", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want context.DeadlineExceeded preserved", err)
+	}
+	requireProvidersConfigSelectionGuidance(t, err)
 }
 
 func TestChooseProvidersConfigPathSetupFailureIsActionable(t *testing.T) {

--- a/cmd/menubar/dialog_linux_test.go
+++ b/cmd/menubar/dialog_linux_test.go
@@ -1,150 +1,750 @@
 package main
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
+	"context"
+	"errors"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/godbus/dbus/v5"
 )
 
-func TestShowOsascriptDialogDBusDismissedReturnsCancel(t *testing.T) {
+func TestConfirmActionPortalApprovalApproves(t *testing.T) {
 	restoreDialogHooks(t)
 
-	execLookPath = func(string) (string, error) {
-		return "", exec.ErrNotFound
+	fake := newFakePortalConn(":1.1")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			id := call.Args[0].(string)
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   portalObjectPath,
+				Name:   portalNotification + "." + portalActionInvoked,
+				Body:   []any{id, portalActionApprove},
+			})
+		}
+		return nil, nil
 	}
-	notifyWithActions = func(string, string, []string) (string, error) {
-		return "", errNotificationDismissed
-	}
-
-	got := showOsascriptDialog("Sign in", "message", "Open GitHub", "Cancel")
-	if got != "Cancel" {
-		t.Fatalf("showOsascriptDialog() = %q, want Cancel", got)
-	}
-}
-
-func TestShowOsascriptDialogZenityCancelStopsFallback(t *testing.T) {
-	restoreDialogHooks(t)
-
-	tmpDir := t.TempDir()
-	zenity := writeTestExecutable(t, tmpDir, "zenity", `#!/bin/sh
-exit 1
-`)
-
-	execLookPath = dialogLookup(map[string]string{
-		"zenity": zenity,
-	})
-	notifyWithActions = func(string, string, []string) (string, error) {
-		t.Fatal("notifyWithActions should not be called after a user cancel")
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		t.Fatal("legacy notification fallback should not be used when the portal approves")
 		return "", nil
 	}
 
-	got := showOsascriptDialog("Sign in", "message", "Open GitHub", "Cancel")
-	if got != "Cancel" {
-		t.Fatalf("showOsascriptDialog() = %q, want Cancel", got)
+	got := confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+	if !got {
+		t.Fatal("confirmAction() = false, want true on portal approval")
+	}
+	if fake.isClosed() {
+		t.Fatal("confirmAction() closed the shared notification connection; it must persist for reuse by later notification calls")
 	}
 }
 
-func TestShowOsascriptDialogZenityErrorFallsBackToDBus(t *testing.T) {
+func TestConfirmActionPortalDeclineDoesNotInvokeFallback(t *testing.T) {
 	restoreDialogHooks(t)
 
-	tmpDir := t.TempDir()
-	zenity := writeTestExecutable(t, tmpDir, "zenity", `#!/bin/sh
-echo "cannot open display" >&2
-exit 1
-`)
+	fake := newFakePortalConn(":1.2")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			id := call.Args[0].(string)
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   portalObjectPath,
+				Name:   portalNotification + "." + portalActionInvoked,
+				Body:   []any{id, portalActionDecline},
+			})
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		t.Fatal("legacy notification fallback should not be used after a portal decline")
+		return "", nil
+	}
 
-	execLookPath = dialogLookup(map[string]string{
-		"zenity": zenity,
+	got := confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
 	})
-
-	dbusCalled := false
-	notifyWithActions = func(string, string, []string) (string, error) {
-		dbusCalled = true
-		return "default", nil
-	}
-
-	got := showOsascriptDialog("Sign in", "message", "Open GitHub", "Cancel")
-	if got != "Open GitHub" {
-		t.Fatalf("showOsascriptDialog() = %q, want Open GitHub", got)
-	}
-	if !dbusCalled {
-		t.Fatal("expected DBus fallback to be used after zenity failed")
+	if got {
+		t.Fatal("confirmAction() = true, want false on portal decline")
 	}
 }
 
-func TestShowErrorDialogFallsBackAfterZenityFailure(t *testing.T) {
+func TestConfirmActionPortalTimeoutDoesNotInvokeFallback(t *testing.T) {
 	restoreDialogHooks(t)
 
-	tmpDir := t.TempDir()
-	zenity := writeTestExecutable(t, tmpDir, "zenity", `#!/bin/sh
-dir=$(dirname "$0")
-printf 'zenity\n' >> "$dir/calls.log"
-echo "cannot open display" >&2
-exit 1
-`)
-	kdialog := writeTestExecutable(t, tmpDir, "kdialog", `#!/bin/sh
-dir=$(dirname "$0")
-printf 'kdialog\n' >> "$dir/calls.log"
-exit 0
-`)
+	parentCtx, cancelParent := context.WithCancel(t.Context())
+	t.Cleanup(cancelParent)
 
-	execLookPath = dialogLookup(map[string]string{
-		"zenity":  zenity,
-		"kdialog": kdialog,
+	fake := newFakePortalConn(":1.3")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			// AddNotification succeeds (the notification was shown), and
+			// only then does the caller's context end while still waiting
+			// for an ActionInvoked signal that never arrives.
+			cancelParent()
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		t.Fatal("legacy notification fallback should not be used after portal accepted the notification")
+		return "", nil
+	}
+
+	got := confirmAction(parentCtx, confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
 	})
+	if got {
+		t.Fatal("confirmAction() = true, want false when cancelled after the portal accepted the notification")
+	}
+}
 
-	notifyCalled := false
+func TestConfirmActionPortalSetupFailureFallsBackToLegacyActionPath(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+	notifyWithActions = func(_ context.Context, title, message string, actions []string) (string, error) {
+		if title != "Sign in" || message != "message" {
+			t.Fatalf("notifyWithActions() got title=%q message=%q", title, message)
+		}
+		return portalActionApprove, nil
+	}
+
+	got := confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+	if !got {
+		t.Fatal("confirmAction() = false, want true from legacy fallback approval")
+	}
+}
+
+func TestConfirmActionLegacyDismissalDeclines(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		return "", errNotificationDismissed
+	}
+
+	if got := confirmAction(withPortalTestTimeout(t), confirmationPrompt{Title: "t", Message: "m", ApproveLabel: "A", DeclineLabel: "D"}); got {
+		t.Fatal("confirmAction() = true, want false on legacy dismissal")
+	}
+}
+
+func TestConfirmActionTotalUIUnavailabilityDeclines(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		return "", errors.New("dbus unavailable")
+	}
+
+	if got := confirmAction(withPortalTestTimeout(t), confirmationPrompt{Title: "t", Message: "m", ApproveLabel: "A", DeclineLabel: "D"}); got {
+		t.Fatal("confirmAction() = true, want false when no confirmation UI is available")
+	}
+}
+
+func TestShowErrorDialogUsesUrgentPortalPriority(t *testing.T) {
+	restoreDialogHooks(t)
+
+	var gotPriority string
+	fake := newFakePortalConn(":1.4")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			notification := call.Args[1].(map[string]dbus.Variant)
+			gotPriority = notification["priority"].Value().(string)
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
 	notify = func(string, string) error {
-		notifyCalled = true
+		t.Fatal("legacy notify should not be used when the portal call succeeds")
 		return nil
 	}
 
 	showErrorDialog("title", "message")
 
-	data, err := os.ReadFile(filepath.Join(tmpDir, "calls.log"))
+	if gotPriority != portalPriorityUrgent {
+		t.Fatalf("showErrorDialog() priority = %q, want %q", gotPriority, portalPriorityUrgent)
+	}
+}
+
+func TestShowNotificationUsesNormalPortalPriority(t *testing.T) {
+	restoreDialogHooks(t)
+
+	var gotPriority string
+	fake := newFakePortalConn(":1.5")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			notification := call.Args[1].(map[string]dbus.Variant)
+			gotPriority = notification["priority"].Value().(string)
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notify = func(string, string) error {
+		t.Fatal("legacy notify should not be used when the portal call succeeds")
+		return nil
+	}
+
+	showNotification("title", "message")
+
+	if gotPriority != portalPriorityNormal {
+		t.Fatalf("showNotification() priority = %q, want %q", gotPriority, portalPriorityNormal)
+	}
+}
+
+func TestShowNotificationFallsBackToLegacyNotifyNeverNotifySend(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+	notifyCalled := false
+	notify = func(title, message string) error {
+		notifyCalled = true
+		if title != "title" || message != "message" {
+			t.Fatalf("notify() got title=%q message=%q", title, message)
+		}
+		return nil
+	}
+
+	showNotification("title", "message")
+
+	if !notifyCalled {
+		t.Fatal("showNotification() did not fall back to the legacy notify path on portal failure")
+	}
+}
+
+func TestShowErrorDialogFallsBackToLegacyNotifyNeverNotifySend(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+	notifyCalled := false
+	notify = func(title, message string) error {
+		notifyCalled = true
+		if title != "title" || message != "message" {
+			t.Fatalf("notify() got title=%q message=%q", title, message)
+		}
+		return nil
+	}
+
+	showErrorDialog("title", "message")
+
+	if !notifyCalled {
+		t.Fatal("showErrorDialog() did not fall back to the legacy notify path on portal failure")
+	}
+}
+
+func TestChooseProvidersConfigPathReturnsDecodedPath(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.6")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body: []any{uint32(0), map[string]dbus.Variant{
+					"uris": dbus.MakeVariant([]string{"file:///home/user/providers.yaml"}),
+				}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	got, err := chooseProvidersConfigPath()
 	if err != nil {
-		t.Fatalf("failed to read dialog call log: %v", err)
+		t.Fatalf("chooseProvidersConfigPath() error = %v", err)
 	}
-	if got := string(data); got != "zenity\nkdialog\n" {
-		t.Fatalf("unexpected dialog fallback order %q", got)
+	if got != "/home/user/providers.yaml" {
+		t.Fatalf("chooseProvidersConfigPath() = %q, want /home/user/providers.yaml", got)
 	}
-	if notifyCalled {
-		t.Fatal("expected kdialog success to stop before DBus fallback")
+}
+
+func TestChooseProvidersConfigPathCancellationReturnsErrDialogCanceled(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.7")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(1), map[string]dbus.Variant{}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	_, err := chooseProvidersConfigPath()
+	if !errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want errDialogCanceled", err)
+	}
+}
+
+func TestChooseProvidersConfigPathSetupFailureIsActionable(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+
+	_, err := chooseProvidersConfigPath()
+	if err == nil || errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want a descriptive setup error", err)
+	}
+}
+
+func TestOpenURLSuccessfulPortalCallDoesNotInvokeXDGOpen(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.8")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalOpenURI+".OpenURI" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(0), map[string]dbus.Variant{}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	runXDGOpen = func(string) {
+		t.Fatal("xdg-open should not run when the portal reports a successful response")
+	}
+
+	openURL("https://example.com")
+
+	calls := fake.callsMatching(portalOpenURI + ".OpenURI")
+	if len(calls) != 1 {
+		t.Fatalf("OpenURI.OpenURI calls = %d, want 1", len(calls))
+	}
+}
+
+func TestOpenURLPortalMethodFailureInvokesXDGOpen(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.9")
+	fake.callFn = func(fakePortalCall) ([]any, error) { return nil, errors.New("method call failed") }
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	xdgOpenCalled := false
+	runXDGOpen = func(rawURL string) {
+		xdgOpenCalled = true
+		if rawURL != "https://example.com" {
+			t.Fatalf("runXDGOpen() got %q", rawURL)
+		}
+	}
+
+	openURL("https://example.com")
+
+	if !xdgOpenCalled {
+		t.Fatal("openURL() did not fall back to xdg-open after the portal method call failed")
+	}
+}
+
+func TestOpenURLUserCanceledResponseDoesNotInvokeXDGOpen(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.10")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalOpenURI+".OpenURI" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(1), map[string]dbus.Variant{}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	runXDGOpen = func(string) {
+		t.Fatal("xdg-open should not run after a deliberate user cancel (response code 1)")
+	}
+
+	openURL("https://example.com")
+}
+
+func TestOpenURLOtherResponseCodeInvokesXDGOpen(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.11")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalOpenURI+".OpenURI" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(2), map[string]dbus.Variant{}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	xdgOpenCalled := false
+	runXDGOpen = func(string) { xdgOpenCalled = true }
+
+	openURL("https://example.com")
+
+	if !xdgOpenCalled {
+		t.Fatal("openURL() did not fall back to xdg-open for a non-success, non-cancel response code")
+	}
+}
+
+func TestOpenURLResponseWaitSetupFailureInvokesXDGOpen(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.12")
+	fake.addMatchErr = errors.New("subscribe failed")
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	xdgOpenCalled := false
+	runXDGOpen = func(string) { xdgOpenCalled = true }
+
+	openURL("https://example.com")
+
+	if !xdgOpenCalled {
+		t.Fatal("openURL() did not fall back to xdg-open when subscribing to the portal response failed")
+	}
+}
+
+func TestSharedNotificationConnectionIsReusedAcrossCalls(t *testing.T) {
+	restoreDialogHooks(t)
+
+	dialCount := 0
+	fake := newFakePortalConn(":1.13")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			id := call.Args[0].(string)
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   portalObjectPath,
+				Name:   portalNotification + "." + portalActionInvoked,
+				Body:   []any{id, portalActionApprove},
+			})
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) {
+		dialCount++
+		return fake, nil
+	}
+
+	showNotification("title", "message")
+	showErrorDialog("title", "message")
+	confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+
+	if dialCount != 1 {
+		t.Fatalf("newPortalConn() called %d times across three notification operations, want 1 (shared connection)", dialCount)
+	}
+	if fake.isClosed() {
+		t.Fatal("shared notification connection was closed; it must persist for the process lifetime")
+	}
+}
+
+func TestSharedNotificationConnectionSurvivesTransientAddNotificationFailure(t *testing.T) {
+	restoreDialogHooks(t)
+
+	dialCount := 0
+	fake := newFakePortalConn(":1.14")
+	fake.callFn = func(fakePortalCall) ([]any, error) { return nil, errors.New("add notification failed") }
+	newPortalConn = func() (portalConn, error) {
+		dialCount++
+		return fake, nil
+	}
+	notify = func(string, string) error { return nil }
+
+	showNotification("title", "message")
+	showNotification("title", "message")
+
+	if dialCount != 1 {
+		t.Fatalf("newPortalConn() called %d times after two transient AddNotification failures, want 1: a transient method failure must never evict or redial the shared connection", dialCount)
+	}
+	if fake.isClosed() {
+		t.Fatal("a transient AddNotification failure closed the shared notification connection; production must never do this")
+	}
+}
+
+func TestSharedNotificationConnectionRedialsOnlyAfterGenuineDisconnect(t *testing.T) {
+	restoreDialogHooks(t)
+
+	dialCount := 0
+	var current *fakePortalConn
+	newPortalConn = func() (portalConn, error) {
+		dialCount++
+		current = newFakePortalConn(":1.14")
+		return current, nil
+	}
+	notify = func(string, string) error { return nil }
+
+	showNotification("title", "message")
+	if dialCount != 1 {
+		t.Fatalf("newPortalConn() called %d times on first use, want 1", dialCount)
+	}
+
+	// Simulate the peer genuinely disconnecting: Connected() now reports
+	// false, the only condition production treats as a reason to redial.
+	_ = current.Close()
+
+	showNotification("title", "message")
+	if dialCount != 2 {
+		t.Fatalf("newPortalConn() called %d times after a genuine disconnect, want 2 (redial)", dialCount)
+	}
+}
+
+func TestSharedConnectionTransientAddNotificationFailureDoesNotDisruptConcurrentConfirmation(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.25")
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notify = func(string, string) error { return nil }
+
+	var confirmSubscribed sync.WaitGroup
+	confirmSubscribed.Add(1)
+	var confirmSubscribedOnce sync.Once
+
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method != portalNotification+".AddNotification" {
+			return nil, nil
+		}
+		id, _ := call.Args[0].(string)
+		if strings.HasPrefix(id, "confirm_") {
+			confirmSubscribedOnce.Do(confirmSubscribed.Done)
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   portalObjectPath,
+				Name:   portalNotification + "." + portalActionInvoked,
+				Body:   []any{id, portalActionApprove},
+			})
+			return nil, nil
+		}
+		// The concurrent plain-notification call fails transiently; this
+		// must never disrupt the still-pending confirmation sharing this
+		// connection.
+		confirmSubscribed.Wait()
+		return nil, errors.New("transient add notification failure")
+	}
+
+	var wg sync.WaitGroup
+	var confirmResult bool
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		confirmResult = confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+			Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+		})
+	}()
+
+	showNotification("title", "message")
+	wg.Wait()
+
+	if !confirmResult {
+		t.Fatal("confirmAction() = false, want true: a concurrent transient AddNotification failure on the shared connection must not disrupt a pending confirmation")
+	}
+	if fake.isClosed() {
+		t.Fatal("a transient AddNotification failure closed the shared connection out from under a concurrent confirmation")
+	}
+}
+
+func TestConfirmActionAmbiguousAddNotificationTimeoutDeclinesWithoutFallback(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.15")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalNotification+".AddNotification" {
+			// AddNotification's own sub-timeout elapsed. context.DeadlineExceeded
+			// is not in the safe "proves not shown" allowlist -- the deadline
+			// can fire after the portal already accepted and displayed the
+			// request -- so this must be an ambiguous delivery failure, not
+			// proof the notification was never shown.
+			return nil, context.DeadlineExceeded
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notifyWithActions = func(_ context.Context, title, message string, actions []string) (string, error) {
+		t.Fatal("legacy notification fallback should not be used for an ambiguous AddNotification failure")
+		return "", nil
+	}
+
+	got := confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+	if got {
+		t.Fatal("confirmAction() = true, want false: an ambiguous AddNotification timeout must decline, not fall back to a second prompt")
+	}
+}
+
+func TestConfirmActionLegacyFallbackReceivesABoundedContext(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+
+	gotDeadline := false
+	notifyWithActions = func(ctx context.Context, title, message string, actions []string) (string, error) {
+		_, gotDeadline = ctx.Deadline()
+		return portalActionApprove, nil
+	}
+
+	confirmAction(withPortalTestTimeout(t), confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+
+	if !gotDeadline {
+		t.Fatal("confirmAction() invoked the legacy fallback with a context that has no deadline; one shared confirmation timeout must bound both the portal attempt and any legacy fallback")
+	}
+}
+
+func TestConfirmActionNeverPostsLegacyFallbackWhenParentContextAlreadyDone(t *testing.T) {
+	restoreDialogHooks(t)
+
+	newPortalConn = func() (portalConn, error) { return nil, errors.New("no session bus") }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		t.Fatal("legacy notification fallback must not run once the caller's context has already ended")
+		return "", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := confirmAction(ctx, confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+	if got {
+		t.Fatal("confirmAction() = true, want false when the caller's context is already done")
+	}
+}
+
+func TestConfirmActionNeverPostsLegacyFallbackAfterNotShownWhenContextAlreadyCanceled(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.26")
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+	notifyWithActions = func(context.Context, string, string, []string) (string, error) {
+		t.Fatal("legacy notification fallback must not run once the caller's context has already ended, even after a NotShown portal outcome")
+		return "", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := confirmAction(ctx, confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Open GitHub", DeclineLabel: "Cancel",
+	})
+	if got {
+		t.Fatal("confirmAction() = true, want false when the caller's context is already done")
+	}
+}
+
+func TestChooseProvidersConfigPathMissingURIsInSuccessResponseIsActionable(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.16")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(0), map[string]dbus.Variant{}}, // success, but no "uris" key
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	_, err := chooseProvidersConfigPath()
+	if err == nil || errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want a distinct actionable error, not errDialogCanceled", err)
+	}
+}
+
+func TestChooseProvidersConfigPathEmptyURIsInSuccessResponseIsActionable(t *testing.T) {
+	restoreDialogHooks(t)
+
+	fake := newFakePortalConn(":1.17")
+	fake.callFn = func(call fakePortalCall) ([]any, error) {
+		if call.Method == portalFileChooser+".OpenFile" {
+			handle := predictRequestPath(fake.unique, extractHandleToken(t, call))
+			go fake.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   handle,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body: []any{uint32(0), map[string]dbus.Variant{
+					"uris": dbus.MakeVariant([]string{}),
+				}},
+			})
+			return []any{handle}, nil
+		}
+		return nil, nil
+	}
+	newPortalConn = func() (portalConn, error) { return fake, nil }
+
+	_, err := chooseProvidersConfigPath()
+	if err == nil || errors.Is(err, errDialogCanceled) {
+		t.Fatalf("chooseProvidersConfigPath() error = %v, want a distinct actionable error, not errDialogCanceled", err)
 	}
 }
 
 func restoreDialogHooks(t *testing.T) {
 	t.Helper()
 
-	oldLookPath := execLookPath
-	oldCommand := execCommand
+	oldNewPortalConn := newPortalConn
 	oldNotifyWithActions := notifyWithActions
 	oldNotify := notify
+	oldRunXDGOpen := runXDGOpen
+
+	// Each test case must not observe another test's cached shared
+	// notification connection.
+	resetSharedPortalNotificationConnForTest()
 
 	t.Cleanup(func() {
-		execLookPath = oldLookPath
-		execCommand = oldCommand
+		newPortalConn = oldNewPortalConn
 		notifyWithActions = oldNotifyWithActions
 		notify = oldNotify
+		runXDGOpen = oldRunXDGOpen
+		resetSharedPortalNotificationConnForTest()
 	})
 }
 
-func dialogLookup(paths map[string]string) func(string) (string, error) {
-	return func(name string) (string, error) {
-		if path, ok := paths[name]; ok {
-			return path, nil
-		}
-		return "", exec.ErrNotFound
-	}
-}
-
-func writeTestExecutable(t *testing.T, dir, name, body string) string {
+// extractHandleToken pulls the handle_token option back out of an OpenFile
+// call's options argument so tests can predict the same request path the
+// portal_linux.go implementation predicted.
+func extractHandleToken(t *testing.T, call fakePortalCall) string {
 	t.Helper()
-
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
-		t.Fatalf("failed to write %s: %v", name, err)
+	if len(call.Args) < 3 {
+		t.Fatalf("OpenFile call args = %v, want at least 3", call.Args)
 	}
-	return path
+	options, ok := call.Args[2].(map[string]dbus.Variant)
+	if !ok {
+		t.Fatalf("OpenFile options arg has unexpected type %T", call.Args[2])
+	}
+	token, ok := options["handle_token"].Value().(string)
+	if !ok {
+		t.Fatal("OpenFile options missing handle_token")
+	}
+	return token
 }

--- a/cmd/menubar/main.go
+++ b/cmd/menubar/main.go
@@ -136,7 +136,7 @@ func onReady() {
 					startProxy()
 				}
 			case <-mDashboard.ClickedCh:
-				openDashboard()
+				go openDashboard()
 			case <-mProvidersChoose.ClickedCh:
 				selectProvidersConfig()
 			case <-mProvidersClear.ClickedCh:
@@ -431,7 +431,10 @@ func stopMenubarProxyServer(current menubarProxyServer, timeout time.Duration) e
 
 // openDashboard opens the live traffic dashboard in the default browser. It is a
 // convenience shortcut; the dashboard is served by the proxy itself and is also
-// reachable directly at the dashboard URL.
+// reachable directly at the dashboard URL. On Linux this waits on the portal's
+// bounded, asynchronous OpenURI response (see portalOpenURITimeout), so it is
+// expected to be called on its own goroutine rather than the tray's single
+// menu-dispatch loop, the same as GitHub sign-in.
 func openDashboard() {
 	if !proxyLifecycle.isRunning() {
 		showErrorDialog("Vekil Not Running", "Start Vekil before opening the dashboard.")
@@ -440,8 +443,9 @@ func openDashboard() {
 	openURL(dashboardURL())
 }
 
-// signInWithGitHub drives the interactive GitHub device-code flow via native macOS
-// dialogs. It is expected to be called in its own goroutine.
+// signInWithGitHub drives the interactive GitHub device-code flow via the
+// platform's native confirmation prompt. It is expected to be called in its
+// own goroutine.
 func signInWithGitHub() {
 	// Guard against double sign-in.
 	signInMu.Lock()
@@ -473,14 +477,20 @@ func signInWithGitHub() {
 
 	copyToClipboard(dcResp.UserCode)
 
-	button := showOsascriptDialog(
-		"Sign in to GitHub Copilot",
-		fmt.Sprintf("Your code has been copied to the clipboard.\n\nEnter this code on GitHub:\n\n%s", dcResp.UserCode),
-		"Open GitHub",
-		"Cancel",
-	)
+	// The menu title shows the device code only while confirmation is
+	// awaited: refreshSessionUI (called on every exit path below, including
+	// a decline) immediately overwrites it. Only the clipboard copy survives
+	// a decline or refresh; retrying sign-in requests a fresh code.
+	mAuthMenu.SetTitle(fmt.Sprintf("GitHub Auth: Confirm code %s to continue", dcResp.UserCode))
 
-	if button == "Cancel" {
+	approved := confirmAction(ctx, confirmationPrompt{
+		Title:        "Sign in to GitHub Copilot",
+		Message:      fmt.Sprintf("Your code has been copied to the clipboard.\n\nEnter this code on GitHub:\n\n%s", dcResp.UserCode),
+		ApproveLabel: "Open GitHub",
+		DeclineLabel: "Cancel",
+	})
+
+	if !approved {
 		cancel()
 		refreshSessionUI()
 		setAuthActionsEnabled(true)

--- a/cmd/menubar/portal_linux.go
+++ b/cmd/menubar/portal_linux.go
@@ -302,7 +302,8 @@ type portalResponse struct {
 // match/signal on completion or on ctx cancellation. The path-namespace
 // scope keeps this subscription from also receiving every other
 // application's portal Request.Response traffic on the session bus. On
-// cancellation, Request.Close is invoked best-effort with a short,
+// cancellation, any matching response already queued on the signal channel
+// wins; otherwise Request.Close is invoked best-effort with a short,
 // independent cleanup context.
 func runPortalRequest(ctx context.Context, conn portalConn, predicted dbus.ObjectPath, call func() (dbus.ObjectPath, error)) (portalResponse, error) {
 	sigCh := make(chan *dbus.Signal, portalSignalBufferSize)
@@ -339,10 +340,36 @@ func runPortalRequest(ctx context.Context, conn portalConn, predicted dbus.Objec
 				return resp, nil
 			}
 		case <-ctx.Done():
+			// Go may choose ctx.Done() even when the matching response was
+			// already delivered and buffered. Honor that completed response
+			// before closing the request so a file selection is not discarded
+			// and a successful OpenURI request does not trigger a fallback.
+			if resp, ok := drainQueuedPortalResponse(sigCh, predicted, handle); ok {
+				return resp, nil
+			}
 			closeCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
 			_, _ = conn.Call(closeCtx, portalBusName, handle, portalRequestIface+".Close")
 			cancel()
 			return portalResponse{}, ctx.Err()
+		}
+	}
+}
+
+// drainQueuedPortalResponse non-blockingly drains signals already buffered on
+// sigCh, looking for a Request.Response matching predicted or handle. See
+// runPortalRequest's ctx.Done() case for why this is needed.
+func drainQueuedPortalResponse(sigCh <-chan *dbus.Signal, predicted, handle dbus.ObjectPath) (portalResponse, bool) {
+	for {
+		select {
+		case sig, ok := <-sigCh:
+			if !ok {
+				return portalResponse{}, false
+			}
+			if resp, matched := decodePortalResponse(sig, predicted, handle); matched {
+				return resp, true
+			}
+		default:
+			return portalResponse{}, false
 		}
 	}
 }

--- a/cmd/menubar/portal_linux.go
+++ b/cmd/menubar/portal_linux.go
@@ -1,0 +1,658 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// Portal bus identity and interface names. All calls target the well-known
+// org.freedesktop.portal.Desktop service; "sender" match options below refer
+// to this well-known name so the message bus resolves the current owner.
+const (
+	portalBusName       = "org.freedesktop.portal.Desktop"
+	portalObjectPath    = dbus.ObjectPath("/org/freedesktop/portal/desktop")
+	portalRequestIface  = "org.freedesktop.portal.Request"
+	portalFileChooser   = "org.freedesktop.portal.FileChooser"
+	portalOpenURI       = "org.freedesktop.portal.OpenURI"
+	portalNotification  = "org.freedesktop.portal.Notification"
+	portalResponseName  = "Response"
+	portalActionInvoked = "ActionInvoked"
+
+	portalActionApprove = "approve"
+	portalActionDecline = "decline"
+
+	portalPriorityNormal = "normal"
+	portalPriorityUrgent = "urgent"
+
+	portalRequestPathPrefix = "/org/freedesktop/portal/desktop/request/"
+
+	portalSignalBufferSize    = 8
+	portalCleanupTimeout      = 2 * time.Second
+	portalMethodCallTimeout   = 5 * time.Second
+	portalFileChooserTimeout  = 5 * time.Minute
+	portalConfirmationTimeout = 2 * time.Minute
+
+	// portalOpenURITimeout bounds the wait for OpenURI.OpenURI's asynchronous
+	// Request.Response. openURL passes ask: false, so a chooser dialog rarely
+	// appears (only when no default handler exists or the URI needs
+	// disambiguation); when it does appear it is a much lighter-weight prompt
+	// than the file chooser, so this is shorter than portalFileChooserTimeout.
+	// Every caller of openURL (Open Dashboard, GitHub sign-in) runs on its own
+	// goroutine rather than the tray's single menu-dispatch loop (see
+	// main.go), so this bounded wait can never block or drop other systray
+	// clicks.
+	portalOpenURITimeout = 15 * time.Second
+)
+
+// errPortalNotificationNotShown marks an error that proves a portal
+// notification was never displayed: subscribing to ActionInvoked failed
+// before AddNotification was even attempted, or AddNotification itself
+// failed in a way portalErrorProvesNotShown recognizes as safe (see its doc
+// comment). Callers may retry through the legacy org.freedesktop.Notifications
+// path in this case without risking a duplicate prompt. Every other
+// AddNotification error, and any error from the ActionInvoked wait itself
+// (timeout, cancellation, decline, or a closed signal channel), is ambiguous:
+// the notification may already have been displayed before the failure, so
+// callers must decline rather than show a second prompt.
+var errPortalNotificationNotShown = errors.New("portal notification was not shown")
+
+// dbusErrorNamesProvingNotShown are D-Bus error names that can only occur
+// before a method call reaches the target service: the well-known portal
+// service has no owner, could not be activated, or does not implement the
+// method/interface/object being called. None of these are possible after
+// xdg-desktop-portal has actually accepted and processed AddNotification.
+var dbusErrorNamesProvingNotShown = map[string]bool{
+	"org.freedesktop.DBus.Error.ServiceUnknown":   true,
+	"org.freedesktop.DBus.Error.NameHasNoOwner":   true,
+	"org.freedesktop.DBus.Error.UnknownMethod":    true,
+	"org.freedesktop.DBus.Error.UnknownInterface": true,
+	"org.freedesktop.DBus.Error.UnknownObject":    true,
+}
+
+// dbusErrorSpawnPrefix additionally covers every org.freedesktop.DBus.Error.Spawn.*
+// name (e.g. Spawn.ServiceNotFound, Spawn.ChildExited): all reported by the
+// bus daemon when it cannot even launch the service that would have handled
+// the call.
+const dbusErrorSpawnPrefix = "org.freedesktop.DBus.Error.Spawn."
+
+// portalErrorProvesNotShown reports whether err proves an AddNotification
+// call never reached xdg-desktop-portal's notification code, so a caller may
+// safely retry through the legacy fallback path without risking a duplicate
+// prompt.
+//
+// dbus.ErrClosed is safe: with the pinned godbus version, a method call only
+// produces it when the output handler observes the connection already
+// closed before the message is written, i.e. before anything was sent.
+//
+// A narrow allowlist of D-Bus bus-level error names is also safe: they are
+// only returned by the message bus itself (service routing/activation
+// failures, or the method/interface/object not existing), never by the
+// portal backend after it has accepted a call.
+//
+// Every other error -- including org.freedesktop.DBus.Error.NoReply, a
+// backend-reported Failed, deadline/cancellation, or a raw transport
+// read/write failure -- is ambiguous: the portal may already have displayed
+// the notification before the reply was lost, so it is not safe to retry.
+func portalErrorProvesNotShown(err error) bool {
+	if errors.Is(err, dbus.ErrClosed) {
+		return true
+	}
+	var dbusErr dbus.Error
+	if errors.As(err, &dbusErr) {
+		if dbusErrorNamesProvingNotShown[dbusErr.Name] {
+			return true
+		}
+		if strings.HasPrefix(dbusErr.Name, dbusErrorSpawnPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// portalConn is the subset of a private D-Bus session-bus connection needed by
+// the portal helpers below. It is replaceable in unit tests so request
+// lifecycle, race, and cancellation behavior can be driven deterministically
+// without a live session bus.
+type portalConn interface {
+	UniqueName() string
+	Call(ctx context.Context, dest string, path dbus.ObjectPath, method string, args ...any) ([]any, error)
+	AddMatch(ctx context.Context, options ...dbus.MatchOption) error
+	RemoveMatch(ctx context.Context, options ...dbus.MatchOption) error
+	Signal(ch chan<- *dbus.Signal)
+	RemoveSignal(ch chan<- *dbus.Signal)
+	// Connected reports whether the underlying transport is still live. It is
+	// a liveness check only, not a portal/backend health check: it can
+	// report true even though the last method call against this connection
+	// failed, and it only reports false once the transport itself has
+	// actually been torn down (e.g. after Close, or an unrecoverable
+	// transport error godbus itself detected).
+	Connected() bool
+	Close() error
+}
+
+// sessionPortalConn adapts a real *dbus.Conn to portalConn.
+type sessionPortalConn struct {
+	conn *dbus.Conn
+}
+
+// dialSessionPortalConn opens a fresh, private session-bus connection.
+// FileChooser and OpenURI operations each dial their own connection rather
+// than sharing one; this isolates signal channels between concurrent
+// operations and avoids a global signal router. Notification-interface
+// operations instead share one process-lifetime connection through
+// sharedPortalNotificationConn below; see its doc comment for why.
+func dialSessionPortalConn() (portalConn, error) {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return nil, err
+	}
+	return &sessionPortalConn{conn: conn}, nil
+}
+
+// newPortalConn is a seam so tests can substitute a fake bus connection.
+var newPortalConn = dialSessionPortalConn
+
+// sharedPortalNotificationConn is a lazily-dialed, process-lifetime-shared
+// connection used only for org.freedesktop.portal.Notification operations:
+// AddNotification, RemoveNotification, and the ActionInvoked wait around
+// them. xdg-desktop-portal's notification backend keys pending notification
+// bookkeeping by the calling app's identity (an empty app_id for every
+// non-sandboxed process) and tears that identity's bookkeeping down when it
+// sees a peer sharing that identity disconnect from the bus. A short-lived
+// per-call connection for showErrorDialog/showNotification could therefore
+// race a concurrent confirmAction wait running on its own connection and
+// cause the portal daemon to discard the in-flight confirmation
+// notification. FileChooser and OpenURI are unaffected by this app_id-keyed
+// bookkeeping and keep their own per-call connections dialed directly via
+// newPortalConn.
+//
+// Production code never explicitly closes or evicts this connection: no
+// method or setup error is treated as proof the connection is dead, because
+// doing so could close the signal channel of, or purge the portal's
+// app-id-keyed notification bookkeeping for, a concurrently in-flight
+// confirmation sharing the same peer. A genuine transport loss is instead
+// observed by godbus itself (see Connected on portalConn), and only then does
+// the next get() call redial.
+var sharedPortalNotificationConn portalNotificationConn
+
+// portalNotificationConn lazily dials and shares a single portalConn across
+// every Notification-interface operation. newPortalConn is resolved fresh on
+// every dial attempt (never captured once) so tests that replace that
+// package var to inject a fake connection still take effect here.
+type portalNotificationConn struct {
+	mu   sync.Mutex
+	conn portalConn
+}
+
+// get returns the cached connection if it is still live, or dials (and
+// caches) a fresh one via newPortalConn otherwise. The liveness check, dial,
+// and store are one operation under a single mutex hold so concurrent
+// callers can never race a dial against each other. Connected() is a
+// transport-liveness check only, not a portal/backend health check: an
+// ordinary method error on the returned connection is not, by itself, a
+// reason to redial.
+func (c *portalNotificationConn) get() (portalConn, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != nil && c.conn.Connected() {
+		return c.conn, nil
+	}
+	conn, err := newPortalConn()
+	if err != nil {
+		return nil, err
+	}
+	c.conn = conn
+	return conn, nil
+}
+
+func (c *sessionPortalConn) UniqueName() string {
+	names := c.conn.Names()
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
+}
+
+func (c *sessionPortalConn) Call(ctx context.Context, dest string, path dbus.ObjectPath, method string, args ...any) ([]any, error) {
+	call := c.conn.Object(dest, path).CallWithContext(ctx, method, 0, args...)
+	if call.Err != nil {
+		return nil, call.Err
+	}
+	return call.Body, nil
+}
+
+func (c *sessionPortalConn) AddMatch(ctx context.Context, options ...dbus.MatchOption) error {
+	return c.conn.AddMatchSignalContext(ctx, options...)
+}
+
+func (c *sessionPortalConn) RemoveMatch(ctx context.Context, options ...dbus.MatchOption) error {
+	return c.conn.RemoveMatchSignalContext(ctx, options...)
+}
+
+func (c *sessionPortalConn) Signal(ch chan<- *dbus.Signal) {
+	c.conn.Signal(ch)
+}
+
+func (c *sessionPortalConn) RemoveSignal(ch chan<- *dbus.Signal) {
+	c.conn.RemoveSignal(ch)
+}
+
+func (c *sessionPortalConn) Connected() bool {
+	return c.conn.Connected()
+}
+
+func (c *sessionPortalConn) Close() error {
+	return c.conn.Close()
+}
+
+// newPortalToken generates a random, object-path-safe token for use as a
+// portal handle_token or notification id.
+func newPortalToken(prefix string) string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// crypto/rand.Read failing is effectively unreachable on supported
+		// platforms; fall back to a still-unique, path-safe value rather than
+		// reusing a fixed token.
+		return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	}
+	return prefix + "_" + hex.EncodeToString(buf[:])
+}
+
+// requestPathNamespace returns the object path under which every
+// org.freedesktop.portal.Request object created by a call from the given
+// connection's unique name will appear, per the xdg-desktop-portal
+// specification's sender-escaping rule: the leading colon is stripped and
+// dots are replaced with underscores. Used with dbus.WithMatchPathNamespace
+// so a Request.Response subscription only receives this connection's own
+// outstanding portal requests rather than every application's on the session
+// bus.
+func requestPathNamespace(uniqueName string) dbus.ObjectPath {
+	sender := strings.ReplaceAll(strings.TrimPrefix(uniqueName, ":"), ".", "_")
+	return dbus.ObjectPath(portalRequestPathPrefix + sender)
+}
+
+// predictRequestPath predicts the object path of the org.freedesktop.portal.Request
+// object a portal method call with the given handle_token will create.
+func predictRequestPath(uniqueName, token string) dbus.ObjectPath {
+	return dbus.ObjectPath(string(requestPathNamespace(uniqueName)) + "/" + token)
+}
+
+// portalResponse is the decoded body of an org.freedesktop.portal.Request.Response
+// signal.
+type portalResponse struct {
+	Code    uint32
+	Results map[string]dbus.Variant
+}
+
+// runPortalRequest performs the race-free portal Request lifecycle described in
+// the design: it subscribes to Request.Response (scoped to the portal
+// service, the Request interface, the Response member, and this
+// connection's own request path namespace, but not yet to the specific
+// predicted object path) before invoking call, accepts the response on
+// either the predicted path or the handle call returns, and cleans up the
+// match/signal on completion or on ctx cancellation. The path-namespace
+// scope keeps this subscription from also receiving every other
+// application's portal Request.Response traffic on the session bus. On
+// cancellation, Request.Close is invoked best-effort with a short,
+// independent cleanup context.
+func runPortalRequest(ctx context.Context, conn portalConn, predicted dbus.ObjectPath, call func() (dbus.ObjectPath, error)) (portalResponse, error) {
+	sigCh := make(chan *dbus.Signal, portalSignalBufferSize)
+	conn.Signal(sigCh)
+	defer conn.RemoveSignal(sigCh)
+
+	matchOpts := []dbus.MatchOption{
+		dbus.WithMatchSender(portalBusName),
+		dbus.WithMatchInterface(portalRequestIface),
+		dbus.WithMatchMember(portalResponseName),
+		dbus.WithMatchPathNamespace(requestPathNamespace(conn.UniqueName())),
+	}
+	if err := conn.AddMatch(ctx, matchOpts...); err != nil {
+		return portalResponse{}, fmt.Errorf("subscribe to portal request response: %w", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+		defer cancel()
+		_ = conn.RemoveMatch(cleanupCtx, matchOpts...)
+	}()
+
+	handle, err := call()
+	if err != nil {
+		return portalResponse{}, err
+	}
+
+	for {
+		select {
+		case sig, ok := <-sigCh:
+			if !ok {
+				return portalResponse{}, fmt.Errorf("portal signal channel closed")
+			}
+			if resp, matched := decodePortalResponse(sig, predicted, handle); matched {
+				return resp, nil
+			}
+		case <-ctx.Done():
+			closeCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+			_, _ = conn.Call(closeCtx, portalBusName, handle, portalRequestIface+".Close")
+			cancel()
+			return portalResponse{}, ctx.Err()
+		}
+	}
+}
+
+// decodePortalResponse reports whether sig is a Request.Response signal for
+// the predicted or actual request handle, decoding its body when it is.
+// Signals for any other path (a concurrent, unrelated portal request) are
+// reported as not matched so the caller keeps waiting.
+func decodePortalResponse(sig *dbus.Signal, predicted, handle dbus.ObjectPath) (portalResponse, bool) {
+	if sig.Name != portalRequestIface+"."+portalResponseName {
+		return portalResponse{}, false
+	}
+	if sig.Path != predicted && sig.Path != handle {
+		return portalResponse{}, false
+	}
+	if len(sig.Body) < 2 {
+		return portalResponse{}, false
+	}
+	code, ok := sig.Body[0].(uint32)
+	if !ok {
+		return portalResponse{}, false
+	}
+	results, ok := sig.Body[1].(map[string]dbus.Variant)
+	if !ok {
+		return portalResponse{}, false
+	}
+	return portalResponse{Code: code, Results: results}, true
+}
+
+// waitForPortalAction subscribes to the portal Notification.ActionInvoked
+// signal, invokes addNotification (expected to call AddNotification), and
+// waits for an ActionInvoked signal carrying the given notification id.
+// Unlike Request objects, the Notification object path is fixed, so no
+// prediction/race handling is required.
+//
+// Failing to subscribe to ActionInvoked always wraps errPortalNotificationNotShown:
+// no attempt to show the notification was even made yet. A failing
+// addNotification wraps errPortalNotificationNotShown only when
+// portalErrorProvesNotShown reports the failure could only have happened
+// before xdg-desktop-portal's notification code ran; otherwise it returns an
+// ordinary, unwrapped error, because the notification may already have been
+// displayed. Once addNotification succeeds, every subsequent outcome (a
+// decline, another action, a closed signal channel, or ctx ending) is an
+// ordinary, unwrapped error or a non-approve action: the notification was
+// shown, so callers must not retry through a second mechanism.
+func waitForPortalAction(ctx context.Context, conn portalConn, notificationID string, addNotification func() error) (string, error) {
+	sigCh := make(chan *dbus.Signal, portalSignalBufferSize)
+	conn.Signal(sigCh)
+	defer conn.RemoveSignal(sigCh)
+
+	matchOpts := []dbus.MatchOption{
+		dbus.WithMatchSender(portalBusName),
+		dbus.WithMatchInterface(portalNotification),
+		dbus.WithMatchMember(portalActionInvoked),
+		dbus.WithMatchObjectPath(portalObjectPath),
+	}
+	if err := conn.AddMatch(ctx, matchOpts...); err != nil {
+		return "", fmt.Errorf("%w: subscribe to portal notification actions: %w", errPortalNotificationNotShown, err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), portalCleanupTimeout)
+		defer cancel()
+		_ = conn.RemoveMatch(cleanupCtx, matchOpts...)
+	}()
+
+	if err := addNotification(); err != nil {
+		if portalErrorProvesNotShown(err) {
+			return "", fmt.Errorf("%w: %w", errPortalNotificationNotShown, err)
+		}
+		return "", fmt.Errorf("portal notification delivery is ambiguous, declining without a second prompt: %w", err)
+	}
+
+	for {
+		select {
+		case sig, ok := <-sigCh:
+			if !ok {
+				// A closed channel here means the notification was already
+				// shown (addNotification succeeded above); this is an
+				// ambiguous delivery failure, not proof of no display.
+				return "", fmt.Errorf("portal signal channel closed")
+			}
+			if action, matched := decodePortalActionInvoked(sig, notificationID); matched {
+				return action, nil
+			}
+		case <-ctx.Done():
+			// Go's select can choose the ctx.Done() case even though a
+			// matching action was already delivered and buffered on sigCh
+			// before ctx ended; drain it non-blockingly before conceding no
+			// answer exists so a genuinely queued answer is never lost to
+			// this race.
+			if action, ok := drainQueuedPortalAction(sigCh, notificationID); ok {
+				return action, nil
+			}
+			return "", ctx.Err()
+		}
+	}
+}
+
+// drainQueuedPortalAction non-blockingly drains any ActionInvoked signals
+// already buffered on sigCh, looking for one matching notificationID. See
+// waitForPortalAction's ctx.Done() case for why this is needed.
+func drainQueuedPortalAction(sigCh <-chan *dbus.Signal, notificationID string) (string, bool) {
+	for {
+		select {
+		case sig, ok := <-sigCh:
+			if !ok {
+				return "", false
+			}
+			if action, matched := decodePortalActionInvoked(sig, notificationID); matched {
+				return action, true
+			}
+		default:
+			return "", false
+		}
+	}
+}
+
+func decodePortalActionInvoked(sig *dbus.Signal, notificationID string) (string, bool) {
+	if sig.Name != portalNotification+"."+portalActionInvoked {
+		return "", false
+	}
+	if len(sig.Body) < 2 {
+		return "", false
+	}
+	id, ok := sig.Body[0].(string)
+	if !ok || id != notificationID {
+		return "", false
+	}
+	action, ok := sig.Body[1].(string)
+	if !ok {
+		return "", false
+	}
+	return action, true
+}
+
+// portalFilterRule is one (type, glob) pair in a FileChooser filter group. The
+// zero value for Type (0) is a glob pattern per the portal specification.
+type portalFilterRule struct {
+	Type    uint32
+	Pattern string
+}
+
+// portalFilterGroup is one named group of filter rules. Marshalled together
+// as a slice, portalFilterGroup produces the "a(sa(us))" signature the
+// FileChooser "filters" option requires.
+type portalFilterGroup struct {
+	Name  string
+	Rules []portalFilterRule
+}
+
+// providerConfigFileFilters returns the FileChooser filters offered when
+// choosing a providers config file.
+func providerConfigFileFilters() []portalFilterGroup {
+	return []portalFilterGroup{
+		{
+			Name: "Provider config files",
+			Rules: []portalFilterRule{
+				{Pattern: "*.json"},
+				{Pattern: "*.yaml"},
+				{Pattern: "*.yml"},
+			},
+		},
+		{
+			Name:  "All files",
+			Rules: []portalFilterRule{{Pattern: "*"}},
+		},
+	}
+}
+
+// portalNotificationBody builds the required a{sv} fields of a portal
+// notification. Optional fields (default-action, buttons) are added by
+// callers that need them rather than populated here with incorrectly typed
+// zero values.
+func portalNotificationBody(title, body, priority string) map[string]dbus.Variant {
+	return map[string]dbus.Variant{
+		"title":    dbus.MakeVariant(title),
+		"body":     dbus.MakeVariant(body),
+		"priority": dbus.MakeVariant(priority),
+	}
+}
+
+// portalConfirmationButtons builds the aa{sv} button collection for a
+// confirmation notification, using non-reserved action keys.
+func portalConfirmationButtons(approveLabel, declineLabel string) []map[string]dbus.Variant {
+	return []map[string]dbus.Variant{
+		{"label": dbus.MakeVariant(approveLabel), "action": dbus.MakeVariant(portalActionApprove)},
+		{"label": dbus.MakeVariant(declineLabel), "action": dbus.MakeVariant(portalActionDecline)},
+	}
+}
+
+// portalConfirmationNotification builds the a{sv} notification dictionary
+// for a confirmation prompt: approve/decline buttons and deliberately no
+// default-action, so activating the notification body itself can never
+// approve. Only an explicit click on the approve button can approve; a body
+// click, dismissal, or a backend that never delivers a button action all
+// produce no ActionInvoked signal and therefore an eventual timeout decline.
+func portalConfirmationNotification(prompt confirmationPrompt) map[string]dbus.Variant {
+	notification := portalNotificationBody(prompt.Title, prompt.Message, portalPriorityNormal)
+	notification["buttons"] = dbus.MakeVariant(portalConfirmationButtons(prompt.ApproveLabel, prompt.DeclineLabel))
+	return notification
+}
+
+// portalOpenFile invokes FileChooser.OpenFile with the given handle_token and
+// provider filters and waits for its Request response.
+func portalOpenFile(ctx context.Context, conn portalConn, token string, predicted dbus.ObjectPath, title string) (portalResponse, error) {
+	return runPortalRequest(ctx, conn, predicted, func() (dbus.ObjectPath, error) {
+		options := map[string]dbus.Variant{
+			"handle_token": dbus.MakeVariant(token),
+			"modal":        dbus.MakeVariant(true),
+			"multiple":     dbus.MakeVariant(false),
+			"directory":    dbus.MakeVariant(false),
+			"filters":      dbus.MakeVariant(providerConfigFileFilters()),
+		}
+		body, err := conn.Call(ctx, portalBusName, portalObjectPath, portalFileChooser+".OpenFile", "", title, options)
+		if err != nil {
+			return "", err
+		}
+		if len(body) == 0 {
+			return "", fmt.Errorf("file chooser did not return a request handle")
+		}
+		handle, ok := body[0].(dbus.ObjectPath)
+		if !ok {
+			return "", fmt.Errorf("file chooser returned unexpected handle type %T", body[0])
+		}
+		return handle, nil
+	})
+}
+
+// decodePortalStringArray reads a string-array result out of a portal
+// Response's results dictionary.
+func decodePortalStringArray(results map[string]dbus.Variant, key string) ([]string, error) {
+	v, ok := results[key]
+	if !ok {
+		return nil, fmt.Errorf("portal response missing %q", key)
+	}
+	values, ok := v.Value().([]string)
+	if !ok {
+		return nil, fmt.Errorf("portal response %q has unexpected type %T", key, v.Value())
+	}
+	return values, nil
+}
+
+// decodePortalFileURI accepts a local absolute file:// URI (including
+// document-portal mount paths) and returns its decoded filesystem path. Other
+// schemes, remote authorities, malformed URIs, and relative paths are
+// rejected.
+func decodePortalFileURI(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse file uri %q: %w", raw, err)
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("unsupported file uri scheme %q", u.Scheme)
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return "", fmt.Errorf("unsupported file uri host %q", u.Host)
+	}
+	if u.Path == "" || !strings.HasPrefix(u.Path, "/") {
+		return "", fmt.Errorf("file uri %q is not an absolute local path", raw)
+	}
+	return u.Path, nil
+}
+
+// isSupportedOpenURIScheme reports whether rawURL is an HTTP(S) URL, the only
+// scheme forwarded to the portal OpenURI method.
+func isSupportedOpenURIScheme(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "http" || u.Scheme == "https"
+}
+
+// portalOpenURICall invokes OpenURI.OpenURI and awaits its Request response
+// using the same race-free lifecycle portalOpenFile uses. The method call
+// replying only means the request was accepted, not that opening succeeded;
+// the real outcome arrives asynchronously on Request.Response.
+func portalOpenURICall(ctx context.Context, conn portalConn, token string, predicted dbus.ObjectPath, activationToken, rawURL string) (portalResponse, error) {
+	return runPortalRequest(ctx, conn, predicted, func() (dbus.ObjectPath, error) {
+		options := map[string]dbus.Variant{
+			"handle_token": dbus.MakeVariant(token),
+			"ask":          dbus.MakeVariant(false),
+		}
+		if activationToken != "" {
+			options["activation_token"] = dbus.MakeVariant(activationToken)
+		}
+		body, err := conn.Call(ctx, portalBusName, portalObjectPath, portalOpenURI+".OpenURI", "", rawURL, options)
+		if err != nil {
+			return "", err
+		}
+		if len(body) == 0 {
+			return "", fmt.Errorf("open uri did not return a request handle")
+		}
+		handle, ok := body[0].(dbus.ObjectPath)
+		if !ok {
+			return "", fmt.Errorf("open uri returned unexpected handle type %T", body[0])
+		}
+		return handle, nil
+	})
+}
+
+// portalAddNotification invokes Notification.AddNotification with the given
+// priority.
+func portalAddNotification(ctx context.Context, conn portalConn, id, title, message, priority string) error {
+	notification := portalNotificationBody(title, message, priority)
+	_, err := conn.Call(ctx, portalBusName, portalObjectPath, portalNotification+".AddNotification", id, notification)
+	return err
+}
+
+// portalRemoveNotification invokes Notification.RemoveNotification best-effort.
+func portalRemoveNotification(ctx context.Context, conn portalConn, id string) {
+	_, _ = conn.Call(ctx, portalBusName, portalObjectPath, portalNotification+".RemoveNotification", id)
+}

--- a/cmd/menubar/portal_linux_test.go
+++ b/cmd/menubar/portal_linux_test.go
@@ -1,0 +1,797 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func TestPredictRequestPathUsesEscapedUniqueNameAndToken(t *testing.T) {
+	got := predictRequestPath(":1.23", "tok")
+	want := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/1_23/tok")
+	if got != want {
+		t.Fatalf("predictRequestPath() = %q, want %q", got, want)
+	}
+}
+
+var objectPathSafeToken = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+func TestNewPortalTokenIsObjectPathSafeAndDistinct(t *testing.T) {
+	first := newPortalToken("req")
+	second := newPortalToken("req")
+
+	if !objectPathSafeToken.MatchString(first) {
+		t.Fatalf("newPortalToken() = %q, want only object-path-safe characters", first)
+	}
+	if !objectPathSafeToken.MatchString(second) {
+		t.Fatalf("newPortalToken() = %q, want only object-path-safe characters", second)
+	}
+	if first == second {
+		t.Fatalf("newPortalToken() produced the same token twice: %q", first)
+	}
+}
+
+func TestProviderConfigFileFiltersMarshalAsArrayOfStructArrayOfStruct(t *testing.T) {
+	filters := providerConfigFileFilters()
+
+	if got := dbus.SignatureOf(filters).String(); got != "a(sa(us))" {
+		t.Fatalf("SignatureOf(providerConfigFileFilters()) = %q, want a(sa(us))", got)
+	}
+
+	var globs []string
+	for _, group := range filters {
+		for _, rule := range group.Rules {
+			globs = append(globs, rule.Pattern)
+		}
+	}
+	for _, want := range []string{"*.json", "*.yaml", "*.yml", "*"} {
+		found := false
+		for _, got := range globs {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("providerConfigFileFilters() globs = %v, missing %q", globs, want)
+		}
+	}
+}
+
+func TestPortalNotificationBodyOmitsOptionalFields(t *testing.T) {
+	body := portalNotificationBody("title", "message", portalPriorityUrgent)
+
+	if len(body) != 3 {
+		t.Fatalf("portalNotificationBody() = %v, want exactly title/body/priority", body)
+	}
+	for _, optional := range []string{"default-action", "buttons", "icon"} {
+		if _, ok := body[optional]; ok {
+			t.Fatalf("portalNotificationBody() unexpectedly set optional key %q", optional)
+		}
+	}
+}
+
+func TestPortalConfirmationButtonsMarshalAsArrayOfDictWithoutOptionalKeys(t *testing.T) {
+	buttons := portalConfirmationButtons("Approve", "Decline")
+
+	if got := dbus.SignatureOf(buttons).String(); got != "aa{sv}" {
+		t.Fatalf("SignatureOf(portalConfirmationButtons()) = %q, want aa{sv}", got)
+	}
+	if len(buttons) != 2 {
+		t.Fatalf("portalConfirmationButtons() returned %d buttons, want 2", len(buttons))
+	}
+	for _, button := range buttons {
+		if len(button) != 2 {
+			t.Fatalf("portal button = %v, want only label/action keys", button)
+		}
+	}
+	if action := buttons[0]["action"].Value(); action != portalActionApprove {
+		t.Fatalf("approve button action = %v, want %q", action, portalActionApprove)
+	}
+	if action := buttons[1]["action"].Value(); action != portalActionDecline {
+		t.Fatalf("decline button action = %v, want %q", action, portalActionDecline)
+	}
+}
+
+func TestPortalConfirmationNotificationHasNoDefaultActionAndOnlyApproveDeclineButtons(t *testing.T) {
+	notification := portalConfirmationNotification(confirmationPrompt{
+		Title: "Sign in", Message: "message", ApproveLabel: "Approve", DeclineLabel: "Decline",
+	})
+
+	if _, ok := notification["default-action"]; ok {
+		t.Fatal("portalConfirmationNotification() set default-action; activating the notification body must never approve")
+	}
+	buttonsVal, ok := notification["buttons"]
+	if !ok {
+		t.Fatal("portalConfirmationNotification() did not set buttons")
+	}
+	buttons, ok := buttonsVal.Value().([]map[string]dbus.Variant)
+	if !ok {
+		t.Fatalf("portalConfirmationNotification() buttons has unexpected type %T", buttonsVal.Value())
+	}
+	if len(buttons) != 2 {
+		t.Fatalf("portalConfirmationNotification() buttons = %d, want 2 (approve/decline only)", len(buttons))
+	}
+	if action := buttons[0]["action"].Value(); action != portalActionApprove {
+		t.Fatalf("first button action = %v, want %q", action, portalActionApprove)
+	}
+	if action := buttons[1]["action"].Value(); action != portalActionDecline {
+		t.Fatalf("second button action = %v, want %q", action, portalActionDecline)
+	}
+}
+
+func TestDecodePortalFileURIAcceptsPercentEncodedAndLocalhostPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"percent-encoded path", "file:///home/user/My%20Config.yaml", "/home/user/My Config.yaml"},
+		{"localhost authority", "file://localhost/etc/vekil/providers.yaml", "/etc/vekil/providers.yaml"},
+		{"document portal mount path", "file:///run/user/1000/doc/abcdef/providers.json", "/run/user/1000/doc/abcdef/providers.json"},
+	}
+	for _, c := range cases {
+		got, err := decodePortalFileURI(c.uri)
+		if err != nil {
+			t.Fatalf("%s: decodePortalFileURI(%q) error = %v", c.name, c.uri, err)
+		}
+		if got != c.want {
+			t.Fatalf("%s: decodePortalFileURI(%q) = %q, want %q", c.name, c.uri, got, c.want)
+		}
+	}
+}
+
+func TestDecodePortalFileURIRejectsNonFileRemoteMalformedAndRelativeURIs(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+	}{
+		{"non-file scheme", "https://example.com/providers.yaml"},
+		{"remote authority", "file://remotehost/etc/providers.yaml"},
+		{"malformed percent-encoding", "file://%zz/providers.yaml"},
+		{"relative (opaque) uri", "file:providers.yaml"},
+	}
+	for _, c := range cases {
+		if _, err := decodePortalFileURI(c.uri); err == nil {
+			t.Fatalf("%s: decodePortalFileURI(%q) error = nil, want rejection", c.name, c.uri)
+		}
+	}
+}
+
+func TestIsSupportedOpenURISchemeAcceptsOnlyHTTPAndHTTPS(t *testing.T) {
+	accepted := []string{"http://example.com", "https://example.com"}
+	for _, u := range accepted {
+		if !isSupportedOpenURIScheme(u) {
+			t.Fatalf("isSupportedOpenURIScheme(%q) = false, want true", u)
+		}
+	}
+	rejected := []string{"ftp://example.com", "file:///etc/passwd", "not a url"}
+	for _, u := range rejected {
+		if isSupportedOpenURIScheme(u) {
+			t.Fatalf("isSupportedOpenURIScheme(%q) = true, want false", u)
+		}
+	}
+}
+
+func TestRunPortalRequestRetainsResponseEmittedOnPredictedPathBeforeMethodReturns(t *testing.T) {
+	conn := newFakePortalConn(":1.1")
+	predicted := predictRequestPath(conn.unique, "tok")
+
+	call := func() (dbus.ObjectPath, error) {
+		conn.emit(&dbus.Signal{
+			Sender: portalBusName,
+			Path:   predicted,
+			Name:   portalRequestIface + "." + portalResponseName,
+			Body:   []any{uint32(0), map[string]dbus.Variant{"uris": dbus.MakeVariant([]string{"file:///a"})}},
+		})
+		return predicted, nil
+	}
+
+	resp, err := runPortalRequest(withPortalTestTimeout(t), conn, predicted, call)
+	if err != nil {
+		t.Fatalf("runPortalRequest() error = %v", err)
+	}
+	if resp.Code != 0 {
+		t.Fatalf("runPortalRequest() code = %d, want 0", resp.Code)
+	}
+	if conn.addMatchCalls() != 1 || conn.removeMatchCalls() != 1 {
+		t.Fatalf("runPortalRequest() match add/remove = %d/%d, want 1/1", conn.addMatchCalls(), conn.removeMatchCalls())
+	}
+}
+
+func TestRunPortalRequestRetainsResponseOnReturnedHandleDifferentFromPrediction(t *testing.T) {
+	conn := newFakePortalConn(":1.2")
+	predicted := predictRequestPath(conn.unique, "tok")
+	actualHandle := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/1_2/other_token")
+
+	call := func() (dbus.ObjectPath, error) {
+		conn.emit(&dbus.Signal{
+			Sender: portalBusName,
+			Path:   actualHandle,
+			Name:   portalRequestIface + "." + portalResponseName,
+			Body:   []any{uint32(1), map[string]dbus.Variant{}},
+		})
+		return actualHandle, nil
+	}
+
+	resp, err := runPortalRequest(withPortalTestTimeout(t), conn, predicted, call)
+	if err != nil {
+		t.Fatalf("runPortalRequest() error = %v", err)
+	}
+	if resp.Code != 1 {
+		t.Fatalf("runPortalRequest() code = %d, want 1 (retained despite handle/prediction mismatch)", resp.Code)
+	}
+}
+
+func TestRunPortalRequestIgnoresUnrelatedResponsePaths(t *testing.T) {
+	conn := newFakePortalConn(":1.3")
+	predicted := predictRequestPath(conn.unique, "tok")
+	unrelated := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/9_9/unrelated")
+
+	call := func() (dbus.ObjectPath, error) {
+		conn.emit(&dbus.Signal{
+			Sender: portalBusName,
+			Path:   unrelated,
+			Name:   portalRequestIface + "." + portalResponseName,
+			Body:   []any{uint32(0), map[string]dbus.Variant{}},
+		})
+		conn.emit(&dbus.Signal{
+			Sender: portalBusName,
+			Path:   predicted,
+			Name:   portalRequestIface + "." + portalResponseName,
+			Body:   []any{uint32(2), map[string]dbus.Variant{}},
+		})
+		return predicted, nil
+	}
+
+	resp, err := runPortalRequest(withPortalTestTimeout(t), conn, predicted, call)
+	if err != nil {
+		t.Fatalf("runPortalRequest() error = %v", err)
+	}
+	if resp.Code != 2 {
+		t.Fatalf("runPortalRequest() code = %d, want 2 (the response for our own path, not the unrelated one)", resp.Code)
+	}
+}
+
+func TestRunPortalRequestCancellationClosesRequestAndCleansUp(t *testing.T) {
+	conn := newFakePortalConn(":1.4")
+	predicted := predictRequestPath(conn.unique, "tok")
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	call := func() (dbus.ObjectPath, error) {
+		// No response is ever emitted, simulating an outstanding request.
+		// Cancellation happens only here, after subscribe+call setup has
+		// already completed successfully, to genuinely exercise wait-phase
+		// cancellation rather than a setup-time failure.
+		cancel()
+		return predicted, nil
+	}
+
+	_, err := runPortalRequest(ctx, conn, predicted, call)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runPortalRequest() error = %v, want context.Canceled", err)
+	}
+
+	closeCalls := conn.callsMatching(portalRequestIface + ".Close")
+	if len(closeCalls) != 1 {
+		t.Fatalf("runPortalRequest() Request.Close calls = %d, want 1", len(closeCalls))
+	}
+	if closeCalls[0].Path != predicted {
+		t.Fatalf("Request.Close path = %q, want %q", closeCalls[0].Path, predicted)
+	}
+	if conn.removeMatchCalls() != 1 {
+		t.Fatalf("runPortalRequest() left %d match subscriptions registered, want 0", conn.removeMatchCalls())
+	}
+	if conn.signalRegistered() {
+		t.Fatal("runPortalRequest() left the signal channel registered after cancellation")
+	}
+}
+
+func TestRunPortalRequestConcurrentOperationsDoNotConsumeEachOthersResponses(t *testing.T) {
+	const operations = 10
+
+	var wg sync.WaitGroup
+	errs := make([]error, operations)
+	codes := make([]uint32, operations)
+
+	for i := 0; i < operations; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			conn := newFakePortalConn(":1." + string(rune('a'+i)))
+			predicted := predictRequestPath(conn.unique, "tok")
+			wantCode := uint32(i)
+
+			call := func() (dbus.ObjectPath, error) {
+				conn.emit(&dbus.Signal{
+					Sender: portalBusName,
+					Path:   predicted,
+					Name:   portalRequestIface + "." + portalResponseName,
+					Body:   []any{wantCode, map[string]dbus.Variant{}},
+				})
+				return predicted, nil
+			}
+
+			resp, err := runPortalRequest(withPortalTestTimeout(t), conn, predicted, call)
+			errs[i] = err
+			codes[i] = resp.Code
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < operations; i++ {
+		if errs[i] != nil {
+			t.Fatalf("operation %d: runPortalRequest() error = %v", i, errs[i])
+		}
+		if codes[i] != uint32(i) {
+			t.Fatalf("operation %d: runPortalRequest() code = %d, want %d (no cross-operation consumption)", i, codes[i], i)
+		}
+	}
+}
+
+func TestRequestPathNamespaceUsesEscapedUniqueName(t *testing.T) {
+	got := requestPathNamespace(":1.23")
+	want := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/1_23")
+	if got != want {
+		t.Fatalf("requestPathNamespace() = %q, want %q", got, want)
+	}
+}
+
+func TestRunPortalRequestScopesMatchToOwnRequestPathNamespace(t *testing.T) {
+	conn := newFakePortalConn(":1.5")
+	predicted := predictRequestPath(conn.unique, "tok")
+
+	call := func() (dbus.ObjectPath, error) {
+		conn.emit(&dbus.Signal{
+			Sender: portalBusName,
+			Path:   predicted,
+			Name:   portalRequestIface + "." + portalResponseName,
+			Body:   []any{uint32(0), map[string]dbus.Variant{}},
+		})
+		return predicted, nil
+	}
+
+	if _, err := runPortalRequest(withPortalTestTimeout(t), conn, predicted, call); err != nil {
+		t.Fatalf("runPortalRequest() error = %v", err)
+	}
+
+	want := dbus.WithMatchPathNamespace(requestPathNamespace(conn.unique))
+	if !matchRuleContains(conn.lastMatchRule(), want) {
+		t.Fatalf("runPortalRequest() match options = %v, want a path_namespace scoped to this connection's own requests", conn.lastMatchRule())
+	}
+}
+
+// TestPortalErrorProvesNotShownClassifiesDBusErrorsByAllowlist exercises the
+// classifier directly against the exact allowlist from its doc comment, plus
+// every kind of error the design explicitly calls out as ambiguous.
+func TestPortalErrorProvesNotShownClassifiesDBusErrorsByAllowlist(t *testing.T) {
+	t.Run("safe: dbus.ErrClosed proves not shown", func(t *testing.T) {
+		if !portalErrorProvesNotShown(dbus.ErrClosed) {
+			t.Fatal("portalErrorProvesNotShown(dbus.ErrClosed) = false, want true")
+		}
+	})
+	t.Run("safe: wrapped dbus.ErrClosed still proves not shown", func(t *testing.T) {
+		wrapped := fmt.Errorf("call failed: %w", dbus.ErrClosed)
+		if !portalErrorProvesNotShown(wrapped) {
+			t.Fatal("portalErrorProvesNotShown(wrapped dbus.ErrClosed) = false, want true")
+		}
+	})
+
+	safeAllowlistedNames := []string{
+		"org.freedesktop.DBus.Error.ServiceUnknown",
+		"org.freedesktop.DBus.Error.NameHasNoOwner",
+		"org.freedesktop.DBus.Error.UnknownMethod",
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		"org.freedesktop.DBus.Error.UnknownObject",
+		"org.freedesktop.DBus.Error.Spawn.ServiceNotFound",
+		"org.freedesktop.DBus.Error.Spawn.ChildExited",
+	}
+	for _, name := range safeAllowlistedNames {
+		t.Run("safe: allowlisted D-Bus error name "+name, func(t *testing.T) {
+			err := dbus.Error{Name: name, Body: []any{"boom"}}
+			if !portalErrorProvesNotShown(err) {
+				t.Fatalf("portalErrorProvesNotShown(%v) = false, want true", err)
+			}
+		})
+	}
+
+	ambiguousCases := []struct {
+		name string
+		err  error
+	}{
+		{"D-Bus NoReply", dbus.Error{Name: "org.freedesktop.DBus.Error.NoReply", Body: []any{"boom"}}},
+		{"D-Bus Failed", dbus.Error{Name: "org.freedesktop.DBus.Error.Failed", Body: []any{"boom"}}},
+		{"D-Bus InvalidArgs", dbus.Error{Name: "org.freedesktop.DBus.Error.InvalidArgs", Body: []any{"boom"}}},
+		{"D-Bus AccessDenied", dbus.Error{Name: "org.freedesktop.DBus.Error.AccessDenied", Body: []any{"boom"}}},
+		{"context deadline exceeded", context.DeadlineExceeded},
+		{"context canceled", context.Canceled},
+		{"raw transport error", errors.New("write unix ->: broken pipe")},
+	}
+	for _, c := range ambiguousCases {
+		t.Run("ambiguous: "+c.name, func(t *testing.T) {
+			if portalErrorProvesNotShown(c.err) {
+				t.Fatalf("portalErrorProvesNotShown(%v) = true, want false (ambiguous)", c.err)
+			}
+		})
+	}
+}
+
+func TestWaitForPortalActionWrapsSubscribeFailureAsNotShown(t *testing.T) {
+	conn := newFakePortalConn(":1.20")
+	conn.addMatchErr = errors.New("subscribe failed")
+
+	_, err := waitForPortalAction(withPortalTestTimeout(t), conn, "id", func() error {
+		t.Fatal("addNotification should not be invoked when subscribing failed")
+		return nil
+	})
+
+	if !errors.Is(err, errPortalNotificationNotShown) {
+		t.Fatalf("waitForPortalAction() error = %v, want errors.Is(err, errPortalNotificationNotShown)", err)
+	}
+}
+
+func TestWaitForPortalActionWrapsAllowlistedAddNotificationFailureAsNotShown(t *testing.T) {
+	conn := newFakePortalConn(":1.21")
+	addNotificationErr := dbus.Error{Name: "org.freedesktop.DBus.Error.ServiceUnknown", Body: []any{"boom"}}
+
+	_, err := waitForPortalAction(withPortalTestTimeout(t), conn, "id", func() error {
+		return addNotificationErr
+	})
+
+	if !errors.Is(err, errPortalNotificationNotShown) {
+		t.Fatalf("waitForPortalAction() error = %v, want errors.Is(err, errPortalNotificationNotShown)", err)
+	}
+	// dbus.Error's Body field is a slice, so it is not comparable and cannot
+	// be used as an errors.Is target; use errors.As to confirm the
+	// underlying D-Bus error survived the wrap instead.
+	var gotDBusErr dbus.Error
+	if !errors.As(err, &gotDBusErr) || gotDBusErr.Name != addNotificationErr.Name {
+		t.Fatalf("waitForPortalAction() error = %v, want the underlying D-Bus error %v preserved", err, addNotificationErr)
+	}
+}
+
+func TestWaitForPortalActionDoesNotWrapAmbiguousAddNotificationFailureAsNotShown(t *testing.T) {
+	conn := newFakePortalConn(":1.22")
+	addNotificationErr := errors.New("add notification failed ambiguously")
+
+	_, err := waitForPortalAction(withPortalTestTimeout(t), conn, "id", func() error {
+		return addNotificationErr
+	})
+
+	if errors.Is(err, errPortalNotificationNotShown) {
+		t.Fatalf("waitForPortalAction() error = %v, want an ambiguous (non-NotShown) outcome, not errPortalNotificationNotShown", err)
+	}
+	if !errors.Is(err, addNotificationErr) {
+		t.Fatalf("waitForPortalAction() error = %v, want the underlying AddNotification error preserved", err)
+	}
+}
+
+func TestWaitForPortalActionDoesNotWrapWaitPhaseCancellationAsNotShown(t *testing.T) {
+	conn := newFakePortalConn(":1.23")
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	_, err := waitForPortalAction(ctx, conn, "id", func() error {
+		// AddNotification succeeds (the notification was shown), and only
+		// then does the caller's context end while still waiting for an
+		// action.
+		cancel()
+		return nil
+	})
+
+	if errors.Is(err, errPortalNotificationNotShown) {
+		t.Fatalf("waitForPortalAction() error = %v, want a wait-phase outcome, not errPortalNotificationNotShown", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForPortalAction() error = %v, want context.Canceled", err)
+	}
+}
+
+// TestWaitForPortalActionReturnsQueuedActionEvenWhenContextEndsSimultaneously
+// exercises the ctx.Done()-vs-buffered-signal race described in
+// waitForPortalAction's doc comment: the addNotification closure both emits
+// the matching action signal and cancels ctx before returning, so by the
+// time the select runs, both cases are ready and Go's pseudo-random choice
+// must never lose the already-queued answer. Looping drives both branches of
+// the race across ordinary (non -race) runs; `go test -race -count=10` adds
+// further assurance.
+func TestWaitForPortalActionReturnsQueuedActionEvenWhenContextEndsSimultaneously(t *testing.T) {
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
+		conn := newFakePortalConn(":1.30")
+		ctx, cancel := context.WithCancel(t.Context())
+
+		action, err := waitForPortalAction(ctx, conn, "id", func() error {
+			conn.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   portalObjectPath,
+				Name:   portalNotification + "." + portalActionInvoked,
+				Body:   []any{"id", portalActionApprove},
+			})
+			cancel()
+			return nil
+		})
+
+		if err != nil {
+			t.Fatalf("iteration %d: waitForPortalAction() error = %v, want the queued action honored despite simultaneous cancellation", i, err)
+		}
+		if action != portalActionApprove {
+			t.Fatalf("iteration %d: waitForPortalAction() = %q, want %q", i, action, portalActionApprove)
+		}
+	}
+}
+
+// TestWaitForPortalActionReturnsBufferedActionBeforeObservingChannelClose
+// confirms that when the signal channel is buffered with a matching action
+// and then closed (e.g. the underlying connection is torn down right after
+// delivering it), the ordinary Go receive semantics that drain a closed
+// channel's remaining buffered values before reporting ok == false are relied
+// on rather than any extra drain logic.
+func TestWaitForPortalActionReturnsBufferedActionBeforeObservingChannelClose(t *testing.T) {
+	conn := newFakePortalConn(":1.31")
+
+	action, err := waitForPortalAction(withPortalTestTimeout(t), conn, "id", func() error {
+		conn.emit(&dbus.Signal{
+			Sender: portalBusName,
+			Path:   portalObjectPath,
+			Name:   portalNotification + "." + portalActionInvoked,
+			Body:   []any{"id", portalActionApprove},
+		})
+		_ = conn.Close()
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("waitForPortalAction() error = %v, want the buffered action honored before the channel close is observed", err)
+	}
+	if action != portalActionApprove {
+		t.Fatalf("waitForPortalAction() = %q, want %q", action, portalActionApprove)
+	}
+}
+
+// TestWaitForPortalActionClosedChannelWithNoBufferedActionIsAmbiguous covers
+// the case where the connection is torn down after AddNotification succeeded
+// (the notification may already be displayed) but before any action ever
+// arrives: this must be an ordinary ambiguous decline, never
+// errPortalNotificationNotShown.
+func TestWaitForPortalActionClosedChannelWithNoBufferedActionIsAmbiguous(t *testing.T) {
+	conn := newFakePortalConn(":1.32")
+
+	_, err := waitForPortalAction(withPortalTestTimeout(t), conn, "id", func() error {
+		_ = conn.Close()
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("waitForPortalAction() error = nil, want a closed-channel error")
+	}
+	if errors.Is(err, errPortalNotificationNotShown) {
+		t.Fatalf("waitForPortalAction() error = %v, want an ambiguous decline, not errPortalNotificationNotShown (the notification was already shown)", err)
+	}
+}
+
+// fakePortalCall records one Call() invocation against a fakePortalConn.
+type fakePortalCall struct {
+	Dest   string
+	Path   dbus.ObjectPath
+	Method string
+	Args   []any
+}
+
+// fakePortalConn is a deterministic, in-memory portalConn used to drive the
+// request lifecycle, race, and cancellation tests above (and the dialog
+// policy tests in dialog_linux_test.go) without a live session bus. It
+// supports multiple concurrently registered signal channels (broadcasting
+// every emitted signal to all of them, matching godbus's own per-connection
+// fan-out) so it can model the shared Notification connection's concurrency
+// behavior, not just the one-registration-at-a-time per-call connections.
+type fakePortalConn struct {
+	unique string
+
+	mu            sync.Mutex
+	sigs          map[chan<- *dbus.Signal]struct{}
+	closed        bool
+	calls         []fakePortalCall
+	addMatchCount int
+	removeMatch   int
+	callFn        func(fakePortalCall) ([]any, error)
+	addMatchErr   error
+	matchRules    [][]dbus.MatchOption
+}
+
+func newFakePortalConn(unique string) *fakePortalConn {
+	return &fakePortalConn{unique: unique, sigs: make(map[chan<- *dbus.Signal]struct{})}
+}
+
+func (f *fakePortalConn) UniqueName() string { return f.unique }
+
+func (f *fakePortalConn) Call(ctx context.Context, dest string, path dbus.ObjectPath, method string, args ...any) ([]any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
+		return nil, dbus.ErrClosed
+	}
+	call := fakePortalCall{Dest: dest, Path: path, Method: method, Args: args}
+	f.calls = append(f.calls, call)
+	fn := f.callFn
+	f.mu.Unlock()
+	if fn == nil {
+		return nil, nil
+	}
+	return fn(call)
+}
+
+func (f *fakePortalConn) AddMatch(ctx context.Context, options ...dbus.MatchOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return dbus.ErrClosed
+	}
+	f.addMatchCount++
+	f.matchRules = append(f.matchRules, options)
+	return f.addMatchErr
+}
+
+func (f *fakePortalConn) RemoveMatch(context.Context, ...dbus.MatchOption) error {
+	f.mu.Lock()
+	f.removeMatch++
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakePortalConn) Signal(ch chan<- *dbus.Signal) {
+	f.mu.Lock()
+	f.sigs[ch] = struct{}{}
+	f.mu.Unlock()
+}
+
+// RemoveSignal removes ch by channel identity, leaving any other
+// concurrently registered channels (e.g. from a second in-flight operation
+// sharing this connection) untouched.
+func (f *fakePortalConn) RemoveSignal(ch chan<- *dbus.Signal) {
+	f.mu.Lock()
+	delete(f.sigs, ch)
+	f.mu.Unlock()
+}
+
+func (f *fakePortalConn) Connected() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return !f.closed
+}
+
+// Close idempotently closes every currently registered signal channel, then
+// marks the connection closed/disconnected. It holds the same mutex emit
+// sends under, so a send can never race a concurrent Close and panic on a
+// closed channel.
+func (f *fakePortalConn) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+	for ch := range f.sigs {
+		close(ch)
+	}
+	f.sigs = make(map[chan<- *dbus.Signal]struct{})
+	return nil
+}
+
+// emit delivers sig to every currently registered signal channel, if any,
+// mimicking a signal arriving from the bus (whether before or after the
+// triggering method call returns to the caller). It holds the same mutex
+// Close uses so it can never send on a channel Close is concurrently
+// closing.
+func (f *fakePortalConn) emit(sig *dbus.Signal) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return
+	}
+	for ch := range f.sigs {
+		ch <- sig
+	}
+}
+
+func (f *fakePortalConn) addMatchCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.addMatchCount
+}
+
+func (f *fakePortalConn) removeMatchCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.removeMatch
+}
+
+// signalRegistered reports whether any signal channel is currently
+// registered.
+func (f *fakePortalConn) signalRegistered() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sigs) > 0
+}
+
+func (f *fakePortalConn) callsMatching(method string) []fakePortalCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []fakePortalCall
+	for _, c := range f.calls {
+		if c.Method == method {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func (f *fakePortalConn) isClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+// lastMatchRule returns the options passed to the most recent AddMatch call.
+func (f *fakePortalConn) lastMatchRule() []dbus.MatchOption {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.matchRules) == 0 {
+		return nil
+	}
+	return f.matchRules[len(f.matchRules)-1]
+}
+
+// matchRuleContains reports whether opts contains want. dbus.MatchOption's
+// fields are unexported but comparable, so two options built from the same
+// constructor and arguments compare equal with ==.
+func matchRuleContains(opts []dbus.MatchOption, want dbus.MatchOption) bool {
+	for _, opt := range opts {
+		if opt == want {
+			return true
+		}
+	}
+	return false
+}
+
+// withPortalTestTimeout bounds a test context so a defect that hangs forever
+// fails the test instead of the suite.
+func withPortalTestTimeout(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// resetSharedPortalNotificationConnForTest clears the shared
+// Notification-interface connection holder between test cases so one test's
+// cached fake connection is never observed by another. Test-only: production
+// code never resets or closes this holder (portalNotificationConn.get() only
+// redials once godbus itself reports the cached peer disconnected). Callers
+// must ensure every goroutine spawned by the previous test case (e.g. an
+// emit(...) goroutine simulating a signal arriving after AddNotification
+// returns) has already joined before calling this: it is only safe to close
+// the evicted fake once nothing can still be sending on its channels.
+func resetSharedPortalNotificationConnForTest() {
+	sharedPortalNotificationConn.mu.Lock()
+	conn := sharedPortalNotificationConn.conn
+	sharedPortalNotificationConn.conn = nil
+	sharedPortalNotificationConn.mu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
+}

--- a/cmd/menubar/portal_linux_test.go
+++ b/cmd/menubar/portal_linux_test.go
@@ -205,6 +205,41 @@ func TestRunPortalRequestRetainsResponseEmittedOnPredictedPathBeforeMethodReturn
 	}
 }
 
+// TestRunPortalRequestReturnsQueuedResponseWhenContextEndsSimultaneously
+// exercises the ctx.Done()-vs-buffered-response race. The request call queues
+// the matching response and cancels ctx before returning, so both select cases
+// are ready when runPortalRequest begins waiting. The completed response must
+// always win and Request.Close must not run.
+func TestRunPortalRequestReturnsQueuedResponseWhenContextEndsSimultaneously(t *testing.T) {
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
+		conn := newFakePortalConn(":1.33")
+		predicted := predictRequestPath(conn.unique, "tok")
+		ctx, cancel := context.WithCancel(t.Context())
+
+		resp, err := runPortalRequest(ctx, conn, predicted, func() (dbus.ObjectPath, error) {
+			conn.emit(&dbus.Signal{
+				Sender: portalBusName,
+				Path:   predicted,
+				Name:   portalRequestIface + "." + portalResponseName,
+				Body:   []any{uint32(0), map[string]dbus.Variant{}},
+			})
+			cancel()
+			return predicted, nil
+		})
+
+		if err != nil {
+			t.Fatalf("iteration %d: runPortalRequest() error = %v, want queued response honored despite simultaneous cancellation", i, err)
+		}
+		if resp.Code != 0 {
+			t.Fatalf("iteration %d: runPortalRequest() code = %d, want 0", i, resp.Code)
+		}
+		if closeCalls := conn.callsMatching(portalRequestIface + ".Close"); len(closeCalls) != 0 {
+			t.Fatalf("iteration %d: runPortalRequest() Request.Close calls = %d, want 0 after completed response", i, len(closeCalls))
+		}
+	}
+}
+
 func TestRunPortalRequestRetainsResponseOnReturnedHandleDifferentFromPrediction(t *testing.T) {
 	conn := newFakePortalConn(":1.2")
 	predicted := predictRequestPath(conn.unique, "tok")

--- a/docs/menubar.md
+++ b/docs/menubar.md
@@ -74,11 +74,19 @@ GOARCH=arm64 make build-tray-linux
 
 Linux supports the same start/stop, status, auth, provider-config, and XDG autostart features as macOS. `Check for Updates…` is macOS-only.
 
-Dialogs, notifications, and sign-in use DBus directly when possible. Optional helpers improve desktop integration:
+Dialogs, notifications, and sign-in use `xdg-desktop-portal` D-Bus interfaces (`FileChooser.OpenFile`, `OpenURI.OpenURI`, `Notification.AddNotification`) rather than subprocess dialog tools. A portal backend (`xdg-desktop-portal-gtk`, `xdg-desktop-portal-kde`, or similar, matched to your X11 or Wayland desktop) is only strictly required for `Choose Providers Config…`, which has no other picker to fall back to. Sign-in confirmation and error/plain notifications prefer the portal but fall back to the legacy `org.freedesktop.Notifications` interface when it is unavailable.
 
-| Feature | Packages |
-|---------|----------|
-| Dialogs | `zenity` or `kdialog` for richer dialogs |
-| Clipboard | `wl-clipboard`, `xclip`, or `xsel` |
-| Open URLs | `xdg-open` |
-| Notifications | DBus notification daemon; `notify-send` fallback |
+Portal notifications are non-modal and may be grouped or suppressed by the desktop; there is no portal-provided generic modal dialog. Sign-in confirmation uses a notification with approve/decline action buttons and deliberately no default action, so only an explicit click on the approve button ever approves; clicking the notification body, dismissing it, letting it time out, or any other outcome declines. One two-minute budget covers the portal attempt and any legacy fallback together, so sign-in confirmation never shows more than one prompt. Error alerts and plain notifications are informational, non-interactive notifications with no buttons.
+
+Once a confirmation notification may have been displayed by either mechanism, a failure is never treated as reason to retry: the legacy fallback runs only when the portal attempt is provably certain to have never been shown (for example, the portal service is unreachable); any other failure, including an ambiguous delivery error where the notification may already be on screen, declines outright rather than risking a duplicate prompt.
+
+Fallback behavior when no portal is available:
+
+| Feature | Behavior without a portal |
+|---------|----------------------------|
+| Sign-in confirmation | Falls back to a legacy `org.freedesktop.Notifications` action prompt with approve/decline buttons on a plain notification daemon. If no notification mechanism responds at all, sign-in confirmation defaults to decline rather than proceeding unattended. |
+| Error alerts, notifications | Falls back to a plain legacy `org.freedesktop.Notifications` notification (no action buttons, no wait) on a plain notification daemon. |
+| Choose Providers Config… | No fallback; the menu action reports an actionable error naming `xdg-desktop-portal`. Pass `--providers-config` or edit the saved menubar config file directly instead. |
+| Open URLs (Open Dashboard, sign-in link) | Falls back to `xdg-open` when the portal method call cannot be made, the response wait fails or times out, or the portal reports an outcome other than success or a deliberate user cancellation. Both Open Dashboard and sign-in run this bounded portal wait on their own goroutine rather than the tray's single menu-dispatch loop, so other menu clicks stay responsive while it is pending. |
+
+Clipboard support is unchanged and does not use the portal (the portal's clipboard interface requires an active RemoteDesktop/InputCapture session, not a standalone API): `wl-clipboard`, `xclip`, or `xsel`.


### PR DESCRIPTION
## Summary

Replace direct subprocess calls to zenity, kdialog, and notify-send with D-Bus calls to the xdg-desktop-portal Notification, FileChooser, and OpenURI interfaces, eliminating subprocess dependencies for tray dialogs and notifications.

## Why This Change

Subprocess dialog tools (zenity/kdialog) and notify-send are:
- Optional desktop dependencies that may not be installed on every Linux system
- Lossy when parsing subprocess output for structured results
- Fragile across desktop environments and packagers (argument styles vary by kdialog version, output formats diverge)

The xdg-desktop-portal D-Bus specification provides a standard, desktop-agnostic API that:
- Works without subprocess dependencies (the portal backend is already required for app confinement)
- Delivers structured results directly via D-Bus signals
- Scales to concurrent calls without spawning multiple processes

## FileChooser Behavior

`chooseProvidersConfigPath()` calls `FileChooser.OpenFile` with provider config file filters. No subprocess fallback exists (no other picker API is available); on portal unavailability an actionable error names xdg-desktop-portal and directs users to pass `--providers-config` or edit the saved config file directly. Timeout: 5 minutes.

## OpenURI Behavior

`openURL()` checks `XDG_ACTIVATION_TOKEN` and calls `OpenURI.OpenURI` for HTTP(S) URLs only.
- Response code 0 (success) or 1 (user cancellation via an application chooser dismiss) are both final; no fallback.
- Any other response code, method call failure, or response wait timeout/cancellation invokes `xdg-open` as a fallback.
- Both `openURL()` invocations (Open Dashboard, GitHub sign-in link) run on their own goroutines, so the portal wait never blocks the tray's single menu-dispatch loop.
- Timeout: 15 seconds.

## Notification Behavior

`showErrorDialog()` and `showNotification()` call `Notification.AddNotification` with urgent or normal priority respectively.
- On success, fire and forget (no wait for response).
- On portal unavailability or any failure, silently fall back to legacy `org.freedesktop.Notifications` (a plain notification daemon).
- The shared connection persists across calls; transient AddNotification failures never evict it and never trigger a redial.
- Timeouts: 5 seconds per method call.

## Confirmation Behavior (Sign-In)

`confirmAction()` shows a portal confirmation notification with explicit approve/decline action buttons and no default action (body click cannot approve):

**Portal path:**
1. Subscribe to `Notification.ActionInvoked` signals.
2. Call `Notification.AddNotification` with the confirmation prompt and two action buttons.
3. Wait for the user's button click, timeout, or context cancellation.
4. Three outcomes: approved (user clicked approve button), declined (anything else: button click on decline, body click, timeout, dismissal), or not shown (proof the notification was never displayed).

**Fallback path:**
- Entered only when the portal attempt is provably certain never to have been shown (portal service unreachable, Subscribe failure, AddNotification failure from bus-level errors that prove the call never reached the portal).
- Falls back to legacy `org.freedesktop.Notifications` action prompt with two action buttons.

**At-most-once guarantee:**
- One shared, bounded 2-minute confirmation timeout covers both the portal attempt and any legacy fallback; the legacy prompt only runs if the portal is provably unavailable, never if AddNotification succeeded but the response took too long or was ambiguous.
- After the portal notification is (or may have been) shown, no second prompt is ever issued, even if the wait times out or fails: ambiguous failures decline outright.
- Shared notification connection isolation: a transient AddNotification failure on one concurrent call (e.g., a plain notification) never disrupts or evicts the shared connection of another concurrent in-flight confirmation; the notification operator only redials on genuine transport disconnect.

## Test Coverage

All changes are tested with a fake portal D-Bus connection mock (`fakePortalConn` in `portal_linux_test.go`):

**confirmAction tests:**
- Portal approval → approve (no fallback)
- Portal decline → decline (no fallback)  
- Portal timeout after AddNotification succeeds → decline (no fallback)
- Portal setup failure → fallback to legacy NotifyWithActions
- Legacy dismissal → decline
- Total UI unavailability → decline
- Parent context cancellation after portal accepted notification → decline (no fallback)
- Ambiguous AddNotification timeout → decline (no fallback)
- Legacy fallback receives bounded context with shared timeout
- Legacy fallback never runs when parent context already ended
- Legacy fallback never runs after NotShown when parent context already ended
- Shared notification connection reuse across multiple operations (showNotification, showErrorDialog, confirmAction) dials only once
- Transient AddNotification failure on shared connection doesn't evict it or trigger redial
- Shared connection redials only after genuine transport disconnect
- Concurrent transient AddNotification failure doesn't disrupt concurrent in-flight confirmation

**showErrorDialog / showNotification tests:**
- Portal success with urgent/normal priority respectively
- Portal failure falls back to legacy notify (never notify-send)

**chooseProvidersConfigPath tests:**
- Portal success with single file selection → decoded path
- Portal user cancel (response code 1) → errDialogCanceled
- Portal setup failure → actionable setup error (not errDialogCanceled)
- Missing URIs in success response → actionable error (not errDialogCanceled)
- Empty URIs in success response → actionable error (not errDialogCanceled)

**openURL tests:**
- Portal success (response code 0) doesn't invoke xdg-open
- Portal method call failure invokes xdg-open
- Portal user cancel (response code 1) doesn't invoke xdg-open
- Portal other response code invokes xdg-open
- Portal response wait setup failure invokes xdg-open

All tests pass: `make test` ✓