### PR TITLE
perf(proxy): reduce request-path overhead

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,11 @@ Schema version 2 is the complete explicit-routing format: it supports public and
 
 Native CLI and tray-app runs default to `127.0.0.1`. Container deployments that publish the proxy port must bind to `0.0.0.0`; the official image and sample Kubernetes manifest set `HOST=0.0.0.0` for that path.
 
+Serve mode defaults Go's garbage-collection target to `GOGC=200` to favor
+throughput while retaining a bounded memory footprint. Set a non-empty `GOGC`
+environment variable, including `GOGC=off`, to override that default with the
+standard Go runtime behavior requested by the operator.
+
 Policy `observe` and `enforce` are a v1 single-tenant feature. Loopback is the default supported topology. A non-loopback bind requires the explicit remote-single-tenant acknowledgement above, but that acknowledgement does not protect the proxy; put remote deployments behind a trusted external authentication and network boundary.
 
 ## Copilot Header Overrides

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -59,6 +59,11 @@ func NewWithWriter(level Level, w io.Writer) *Logger {
 	return &Logger{level: level, writer: w}
 }
 
+// Enabled reports whether a message at level would be emitted.
+func (l *Logger) Enabled(level Level) bool {
+	return l != nil && level >= l.level
+}
+
 func (l *Logger) log(level Level, msg string, fields map[string]interface{}) {
 	if level < l.level {
 		return
@@ -79,16 +84,25 @@ func (l *Logger) log(level Level, msg string, fields map[string]interface{}) {
 
 // Debug logs a message at debug level.
 func (l *Logger) Debug(msg string, fields ...Field) {
+	if !l.Enabled(LevelDebug) {
+		return
+	}
 	l.log(LevelDebug, msg, toMap(fields))
 }
 
 // Info logs a message at info level.
 func (l *Logger) Info(msg string, fields ...Field) {
+	if !l.Enabled(LevelInfo) {
+		return
+	}
 	l.log(LevelInfo, msg, toMap(fields))
 }
 
 // Error logs a message at error level.
 func (l *Logger) Error(msg string, fields ...Field) {
+	if !l.Enabled(LevelError) {
+		return
+	}
 	l.log(LevelError, msg, toMap(fields))
 }
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -628,6 +629,8 @@ func stopServeServer(srv serveLifecycleServer, log *logger.Logger) error {
 }
 
 func runServe() {
+	configureServeGC()
+
 	serve := registerServeFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -676,6 +679,18 @@ func runServe() {
 	if err := serveUntilContextDone(ctx, srv, authenticator, serveUsesCopilot(srv, providersCfg.UsesCopilot()), log); err != nil {
 		log.Fatal("serve error", logger.Err(err))
 	}
+}
+
+const defaultServeGCPercent = 200
+
+func configureServeGC() {
+	if shouldApplyServeGCDefault(os.Getenv("GOGC")) {
+		debug.SetGCPercent(defaultServeGCPercent)
+	}
+}
+
+func shouldApplyServeGCDefault(value string) bool {
+	return strings.TrimSpace(value) == ""
 }
 
 func getPolicyRoutingModeEnv() string {

--- a/main_test.go
+++ b/main_test.go
@@ -85,6 +85,25 @@ func TestGetEnvDuration(t *testing.T) {
 	}
 }
 
+func TestShouldApplyServeGCDefault(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "unset or empty", want: true},
+		{name: "whitespace", value: "  ", want: true},
+		{name: "explicit percent", value: "100", want: false},
+		{name: "disabled", value: "off", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldApplyServeGCDefault(tt.value); got != tt.want {
+				t.Fatalf("shouldApplyServeGCDefault(%q) = %t, want %t", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetEnvBool(t *testing.T) {
 	const envKey = "TEST_BOOL_VAR"
 
@@ -341,6 +360,11 @@ func TestServeFlagsResponsesWebSocketCanBeEnabled(t *testing.T) {
 }
 
 func TestServeUntilContextDoneCancelsActiveUpstreamWork(t *testing.T) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+	client := &http.Client{Transport: transport}
+	t.Cleanup(transport.CloseIdleConnections)
+
 	upstreamStarted := make(chan struct{})
 	upstreamCanceled := make(chan struct{})
 	releaseUpstream := make(chan struct{})
@@ -392,7 +416,7 @@ func TestServeUntilContextDoneCancelsActiveUpstreamWork(t *testing.T) {
 	for {
 		if addr := srv.Addr(); addr != "127.0.0.1:0" {
 			baseURL = "http://" + addr
-			resp, requestErr := http.Get(baseURL + "/healthz")
+			resp, requestErr := client.Get(baseURL + "/healthz")
 			if requestErr == nil {
 				_ = resp.Body.Close()
 				if resp.StatusCode == http.StatusOK {
@@ -418,7 +442,7 @@ func TestServeUntilContextDoneCancelsActiveUpstreamWork(t *testing.T) {
 	}
 	requestDone := make(chan requestResult, 1)
 	go func() {
-		resp, requestErr := http.Post(
+		resp, requestErr := client.Post(
 			baseURL+"/v1/chat/completions",
 			"application/json",
 			strings.NewReader(`{"model":"gpt-5","messages":[{"role":"user","content":"hello"}]}`),

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -238,7 +238,8 @@ func normalizeOpenAIChatCompletionResponse(body []byte, requestedModel string, n
 		payload["object"] = mustMarshalRaw(openAIChatCompletionObject)
 		changed = true
 	}
-	if !hasNonNullJSONField(payload, "created") {
+	created, createdOK := jsonRawNumberAsInt64(payload["created"])
+	if !hasNonNullJSONField(payload, "created") || createdOK && created == 0 {
 		created := now.Unix()
 		if created <= 0 {
 			created = time.Now().Unix()
@@ -349,7 +350,7 @@ func inspectCanonicalOpenAIChatCompletionResponseWithDecoder(body []byte, reques
 				return nil, false
 			}
 		case "created":
-			createdOK = decodeCanonicalNonNullScalar(decoder)
+			createdOK = decodeCanonicalCreated(decoder)
 			if !createdOK {
 				return nil, false
 			}
@@ -407,6 +408,22 @@ func decodeCanonicalNonNullScalar(decoder *json.Decoder) bool {
 	}
 	_, delimited := token.(json.Delim)
 	return !delimited
+}
+
+func decodeCanonicalCreated(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil || token == nil {
+		return false
+	}
+	if _, delimited := token.(json.Delim); delimited {
+		return false
+	}
+	number, ok := token.(json.Number)
+	if !ok {
+		return true
+	}
+	value, err := number.Int64()
+	return err != nil || value != 0
 }
 
 func inspectCanonicalOpenAIUsage(decoder *json.Decoder) (*models.OpenAIUsage, bool) {
@@ -474,7 +491,8 @@ func inspectCanonicalOpenAIUsage(decoder *json.Decoder) (*models.OpenAIUsage, bo
 	if delim, ok := end.(json.Delim); !ok || delim != '}' {
 		return nil, false
 	}
-	return usage, promptOK && completionOK && totalOK
+	canonicalTotal := usage.TotalTokens != 0 || usage.PromptTokens == 0 && usage.CompletionTokens == 0
+	return usage, promptOK && completionOK && totalOK && canonicalTotal
 }
 
 func decodeCanonicalInt(decoder *json.Decoder) (int, bool) {
@@ -486,11 +504,11 @@ func decodeCanonicalInt(decoder *json.Decoder) (int, bool) {
 	if !ok {
 		return 0, false
 	}
-	value, err := number.Int64()
-	if err != nil || int64(int(value)) != value {
+	value, err := strconv.Atoi(number.String())
+	if err != nil {
 		return 0, false
 	}
-	return int(value), true
+	return value, true
 }
 
 func inspectCanonicalOpenAIChatChoices(decoder *json.Decoder) bool {
@@ -870,7 +888,8 @@ func normalizeOpenAIChatCompletionUsage(raw json.RawMessage) (json.RawMessage, b
 		completion = 0
 		changed = true
 	}
-	if _, hasTotal := jsonRawNumberAsInt64(usage["total_tokens"]); !hasTotal {
+	total, hasTotal := jsonRawNumberAsInt64(usage["total_tokens"])
+	if !hasTotal || total == 0 && (prompt != 0 || completion != 0) {
 		if hasPrompt || hasCompletion {
 			usage["total_tokens"] = json.RawMessage(strconv.FormatInt(prompt+completion, 10))
 		} else {

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -284,6 +285,342 @@ func normalizeOpenAIChatCompletionResponse(body []byte, requestedModel string, n
 		return nil, false, err
 	}
 	return out, true, nil
+}
+
+// inspectCanonicalOpenAIChatCompletionResponse recognizes the common case where
+// an upstream already returned a complete Chat Completions response. It uses an
+// exact-key token walk so it preserves the map-based normalizer's casing and
+// duplicate-key semantics while avoiding nested map allocations. Any ambiguous
+// or provider-specific shape falls back to the full normalizer.
+func inspectCanonicalOpenAIChatCompletionResponse(body []byte, requestedModel string) (models.OpenAIUsage, bool) {
+	if usage, ok := inspectCanonicalOpenAIChatCompletionResponseFast(body, requestedModel); ok {
+		return usage, true
+	}
+	usage, ok := inspectCanonicalOpenAIChatCompletionResponseWithDecoder(body, requestedModel)
+	if !ok || usage == nil {
+		return models.OpenAIUsage{}, false
+	}
+	return *usage, true
+}
+
+func inspectCanonicalOpenAIChatCompletionResponseWithDecoder(body []byte, requestedModel string) (*models.OpenAIUsage, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	root, err := decoder.Token()
+	if err != nil {
+		return nil, false
+	}
+	if delim, ok := root.(json.Delim); !ok || delim != '{' {
+		return nil, false
+	}
+
+	idOK := false
+	objectOK := false
+	createdOK := false
+	modelOK := strings.TrimSpace(requestedModel) == ""
+	choicesOK := false
+	usageOK := false
+	var usage *models.OpenAIUsage
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, false
+		}
+
+		switch key {
+		case "error":
+			// Successful 2xx error envelopes deliberately bypass normalization.
+			// They are uncommon and retain the existing map-based path.
+			return nil, false
+		case "id":
+			idOK = decodeCanonicalNonEmptyString(decoder)
+			if !idOK {
+				return nil, false
+			}
+		case "object":
+			objectOK = decodeCanonicalNonEmptyString(decoder)
+			if !objectOK {
+				return nil, false
+			}
+		case "created":
+			createdOK = decodeCanonicalNonNullScalar(decoder)
+			if !createdOK {
+				return nil, false
+			}
+		case "model":
+			modelOK = decodeCanonicalNonEmptyString(decoder)
+			if !modelOK {
+				return nil, false
+			}
+		case "choices":
+			choicesOK = inspectCanonicalOpenAIChatChoices(decoder)
+			if !choicesOK {
+				return nil, false
+			}
+		case "usage":
+			usage, usageOK = inspectCanonicalOpenAIUsage(decoder)
+			if !usageOK {
+				return nil, false
+			}
+		default:
+			if err := skipJSONValue(decoder); err != nil {
+				return nil, false
+			}
+		}
+	}
+
+	end, err := decoder.Token()
+	if err != nil {
+		return nil, false
+	}
+	if delim, ok := end.(json.Delim); !ok || delim != '}' {
+		return nil, false
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return nil, false
+	}
+	if !idOK || !objectOK || !createdOK || !modelOK || !choicesOK || !usageOK {
+		return nil, false
+	}
+	return usage, true
+}
+
+func decodeCanonicalNonEmptyString(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	value, ok := token.(string)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func decodeCanonicalNonNullScalar(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil || token == nil {
+		return false
+	}
+	_, delimited := token.(json.Delim)
+	return !delimited
+}
+
+func inspectCanonicalOpenAIUsage(decoder *json.Decoder) (*models.OpenAIUsage, bool) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, false
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return nil, false
+	}
+
+	usage := &models.OpenAIUsage{}
+	promptOK := false
+	completionOK := false
+	totalOK := false
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, false
+		}
+
+		switch key {
+		case "prompt_tokens":
+			usage.PromptTokens, promptOK = decodeCanonicalInt(decoder)
+			if !promptOK {
+				return nil, false
+			}
+		case "completion_tokens":
+			usage.CompletionTokens, completionOK = decodeCanonicalInt(decoder)
+			if !completionOK {
+				return nil, false
+			}
+		case "total_tokens":
+			usage.TotalTokens, totalOK = decodeCanonicalInt(decoder)
+			if !totalOK {
+				return nil, false
+			}
+		case "prompt_tokens_details":
+			var details *models.OpenAIPromptTokensDetails
+			if err := decoder.Decode(&details); err != nil {
+				return nil, false
+			}
+			usage.PromptTokensDetails = details
+		case "completion_tokens_details":
+			var details *models.OpenAICompletionTokensDetails
+			if err := decoder.Decode(&details); err != nil {
+				return nil, false
+			}
+			usage.CompletionTokensDetails = details
+		default:
+			if err := skipJSONValue(decoder); err != nil {
+				return nil, false
+			}
+		}
+	}
+
+	end, err := decoder.Token()
+	if err != nil {
+		return nil, false
+	}
+	if delim, ok := end.(json.Delim); !ok || delim != '}' {
+		return nil, false
+	}
+	return usage, promptOK && completionOK && totalOK
+}
+
+func decodeCanonicalInt(decoder *json.Decoder) (int, bool) {
+	token, err := decoder.Token()
+	if err != nil {
+		return 0, false
+	}
+	number, ok := token.(json.Number)
+	if !ok {
+		return 0, false
+	}
+	value, err := number.Int64()
+	if err != nil || int64(int(value)) != value {
+		return 0, false
+	}
+	return int(value), true
+}
+
+func inspectCanonicalOpenAIChatChoices(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '[' {
+		return false
+	}
+
+	for decoder.More() {
+		choiceToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		if delim, ok := choiceToken.(json.Delim); !ok || delim != '{' {
+			return false
+		}
+
+		indexOK := false
+		finishReasonOK := false
+		messageOK := false
+		providerToolShape := false
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return false
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return false
+			}
+
+			switch key {
+			case "index":
+				indexOK = decodeCanonicalNonNullScalar(decoder)
+				if !indexOK {
+					return false
+				}
+			case "finish_reason":
+				finishReasonOK = decodeCanonicalNonEmptyString(decoder)
+				if !finishReasonOK {
+					return false
+				}
+			case "message":
+				messageOK = inspectCanonicalOpenAIChatMessage(decoder)
+				if !messageOK {
+					return false
+				}
+			case "tool_calls", "function_call":
+				providerToolShape = true
+				if err := skipJSONValue(decoder); err != nil {
+					return false
+				}
+			default:
+				if err := skipJSONValue(decoder); err != nil {
+					return false
+				}
+			}
+		}
+
+		end, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		if delim, ok := end.(json.Delim); !ok || delim != '}' {
+			return false
+		}
+		if !indexOK || !finishReasonOK || !messageOK || providerToolShape {
+			return false
+		}
+	}
+
+	end, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	if delim, ok := end.(json.Delim); !ok || delim != ']' {
+		return false
+	}
+	return true
+}
+
+func inspectCanonicalOpenAIChatMessage(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return false
+	}
+
+	roleOK := false
+	contentOK := false
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		switch key {
+		case "role":
+			roleOK = decodeCanonicalNonEmptyString(decoder)
+			if !roleOK {
+				return false
+			}
+		case "content":
+			contentOK = decodeCanonicalNonNullScalar(decoder)
+			if !contentOK {
+				return false
+			}
+		default:
+			if err := skipJSONValue(decoder); err != nil {
+				return false
+			}
+		}
+	}
+
+	end, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	if delim, ok := end.(json.Delim); !ok || delim != '}' {
+		return false
+	}
+	return roleOK && contentOK
 }
 
 func normalizeOpenAIChatCompletionStruct(resp *models.OpenAIResponse, requestedModel string) {

--- a/proxy/chat_execution.go
+++ b/proxy/chat_execution.go
@@ -38,7 +38,6 @@ type chatExecutionOptions struct {
 	ResponsesMinimumOutputTokens int
 	ResponsesDropSamplingParams  bool
 	ResponsesUsageOnly           bool
-	MutableRequestBody           bool
 }
 
 type chatExecutionResult struct {
@@ -69,7 +68,7 @@ func (h *ProxyHandler) executeChatCompletions(ctx context.Context, chatBody []by
 	}
 	var result chatExecutionResult
 	if route.backend == chatBackendNativeChat {
-		result, err = h.executeResolvedNativeChat(ctx, route, chatBody, options)
+		result, err = h.executeResolvedNativeChat(ctx, route, chatBody)
 	} else {
 		result, err = h.executeResolvedResponsesChat(ctx, route, chatBody, options)
 	}
@@ -96,7 +95,7 @@ func chatRequestContainsResponsesReplayID(body []byte) bool {
 	// Replay IDs are proxy-owned and always carry this literal prefix. Avoid
 	// decoding the full message tree on ordinary Chat requests, which make up the
 	// overwhelmingly common native-Chat path.
-	if !bytes.Contains(body, []byte(responsesChatReplayCallIDPrefix)) {
+	if !bytes.Contains(body, []byte(responsesChatReplayCallIDPrefix)) && !bytes.Contains(body, []byte(`\u`)) {
 		return false
 	}
 
@@ -153,8 +152,8 @@ func chatRequestContainsResponsesReplayID(body []byte) bool {
 	return false
 }
 
-func (h *ProxyHandler) executeResolvedNativeChat(ctx context.Context, route resolvedChatRoute, chatBody []byte, options chatExecutionOptions) (chatExecutionResult, error) {
-	resp, err := h.postResolvedProviderRequestForModelWithOwnership(ctx, route.provider, route.owner, providerEndpointChatCompletions, chatBody, nil, route.publicModel, options.MutableRequestBody)
+func (h *ProxyHandler) executeResolvedNativeChat(ctx context.Context, route resolvedChatRoute, chatBody []byte) (chatExecutionResult, error) {
+	resp, err := h.postResolvedProviderRequestForModel(ctx, route.provider, route.owner, providerEndpointChatCompletions, chatBody, nil, route.publicModel)
 	if err != nil {
 		return chatExecutionResult{}, err
 	}
@@ -169,7 +168,7 @@ func (h *ProxyHandler) retryResolvedNativeChat(ctx context.Context, prior chatEx
 	if prior.Backend != chatBackendNativeChat || prior.route.backend != chatBackendNativeChat || prior.route.provider == nil {
 		return chatExecutionResult{}, fmt.Errorf("native Chat retry requires a captured native Chat route")
 	}
-	return h.executeResolvedNativeChat(ctx, prior.route, chatBody, chatExecutionOptions{})
+	return h.executeResolvedNativeChat(ctx, prior.route, chatBody)
 }
 
 func (h *ProxyHandler) executeResolvedResponsesChat(ctx context.Context, route resolvedChatRoute, chatBody []byte, options chatExecutionOptions) (chatExecutionResult, error) {

--- a/proxy/chat_execution.go
+++ b/proxy/chat_execution.go
@@ -38,6 +38,7 @@ type chatExecutionOptions struct {
 	ResponsesMinimumOutputTokens int
 	ResponsesDropSamplingParams  bool
 	ResponsesUsageOnly           bool
+	MutableRequestBody           bool
 }
 
 type chatExecutionResult struct {
@@ -92,6 +93,13 @@ func rawJSONFieldsExactOrFold(object map[string]json.RawMessage, name string) []
 }
 
 func chatRequestContainsResponsesReplayID(body []byte) bool {
+	// Replay IDs are proxy-owned and always carry this literal prefix. Avoid
+	// decoding the full message tree on ordinary Chat requests, which make up the
+	// overwhelmingly common native-Chat path.
+	if !bytes.Contains(body, []byte(responsesChatReplayCallIDPrefix)) {
+		return false
+	}
+
 	var request map[string]json.RawMessage
 	if json.Unmarshal(body, &request) != nil {
 		return false
@@ -146,13 +154,12 @@ func chatRequestContainsResponsesReplayID(body []byte) bool {
 }
 
 func (h *ProxyHandler) executeResolvedNativeChat(ctx context.Context, route resolvedChatRoute, chatBody []byte, options chatExecutionOptions) (chatExecutionResult, error) {
-	resp, err := h.postResolvedProviderRequest(ctx, route.provider, route.owner, providerEndpointChatCompletions, chatBody, nil)
+	resp, err := h.postResolvedProviderRequestForModelWithOwnership(ctx, route.provider, route.owner, providerEndpointChatCompletions, chatBody, nil, route.publicModel, options.MutableRequestBody)
 	if err != nil {
 		return chatExecutionResult{}, err
 	}
 	return chatExecutionResult{
 		Response: resp,
-		Headers:  convertedChatSafeHeaders(resp.Header),
 		Backend:  chatBackendNativeChat,
 		route:    route,
 	}, nil
@@ -389,6 +396,16 @@ func convertedChatSafeHeaders(src http.Header) http.Header {
 		return nil
 	}
 	return dst
+}
+
+func chatExecutionUpstreamHeaders(result chatExecutionResult) http.Header {
+	if len(result.Headers) > 0 {
+		return result.Headers
+	}
+	if result.Response != nil {
+		return result.Response.Header
+	}
+	return nil
 }
 
 func (h *ProxyHandler) routeChatExecutionResult(

--- a/proxy/chat_execution_test.go
+++ b/proxy/chat_execution_test.go
@@ -183,6 +183,11 @@ func TestChatRequestContainsResponsesReplayIDCaseInsensitiveFallback(t *testing.
 			body: `{"messages":[{"role":"user","content":"hello"}],"MESSAGES":[{"role":"tool","tool_call_id":"call_vekil_AAAAAAAAAAAAAAAAAAAAAA"}]}`,
 			want: false,
 		},
+		{
+			name: "unicode-escaped replay prefix",
+			body: `{"messages":[{"role":"tool","tool_call_id":"call\u005fvekil\u005fAAAAAAAAAAAAAAAAAAAAAA"}]}`,
+			want: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -1308,7 +1308,7 @@ func (h *ProxyHandler) executeChatCompletionsForRequestedModel(ctx context.Conte
 
 	var result chatExecutionResult
 	if route.backend == chatBackendNativeChat {
-		result, err = h.executeResolvedNativeChat(ctx, route, body, options)
+		result, err = h.executeResolvedNativeChat(ctx, route, body)
 	} else {
 		result, err = h.executeResolvedResponsesChat(ctx, route, body, options)
 	}
@@ -3245,8 +3245,13 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	}
 
 	responseModel := explicitRoutePublicModel(route, publicModel)
-	mutableRequestBody := pooledBody != nil && len(bodyBytes) > 0 && len(*pooledBody) > 0 && &bodyBytes[0] == &(*pooledBody)[0]
-	result, err := h.executeRoutedChatCompletions(upstreamCtx, bodyBytes, mode, chatExecutionOptions{MutableRequestBody: mutableRequestBody}, requestedModel)
+	// RoundTripper may finish closing or reading a request body asynchronously
+	// after RoundTrip returns. Detach a borrowed inbound buffer before handing it
+	// to upstream code so the handler can safely return that buffer to its pool.
+	if pooledBody != nil && len(bodyBytes) > 0 && len(*pooledBody) > 0 && &bodyBytes[0] == &(*pooledBody)[0] {
+		bodyBytes = bytes.Clone(bodyBytes)
+	}
+	result, err := h.executeRoutedChatCompletions(upstreamCtx, bodyBytes, mode, chatExecutionOptions{}, requestedModel)
 	if err != nil {
 		if h.handleShutdownError(w, r, upstreamCtx, err) {
 			return

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -22,6 +22,7 @@ type chatCompletionsMode struct {
 	clientRequestedStream      bool
 	clientRequestedStreamUsage bool
 	forceUpstreamStream        bool
+	requestHasTools            bool
 	// injectedStreamUsage is true when the proxy added stream_options.include_usage
 	// to a streamed upstream request. If a strict OpenAI-compatible provider rejects
 	// that optional field with 400, the request can be retried once without it.
@@ -31,6 +32,14 @@ type chatCompletionsMode struct {
 	// in. On the verbatim OpenAI passthrough the resulting upstream usage-only
 	// chunk must be dropped from the client stream (it never requested it).
 	injectedClientStreamUsage bool
+}
+
+type openAIChatRequestInspection struct {
+	modelRaw []byte
+	message  string
+	param    string
+	invalid  bool
+	mode     chatCompletionsMode
 }
 
 type chatCompletionsResponseHandlers struct {
@@ -1430,6 +1439,20 @@ func (h *ProxyHandler) aggregateExplicitRoutedChatExecution(ctx context.Context,
 }
 
 func parseOpenAIChatCompletionsMode(body []byte) chatCompletionsMode {
+	if mode, ok := parseOpenAIChatCompletionsModeFast(body); ok {
+		return mode
+	}
+	return parseOpenAIChatCompletionsModeWithJSON(body)
+}
+
+func parseOpenAIChatCompletionsModeValidated(body []byte) chatCompletionsMode {
+	if mode, ok := parseOpenAIChatCompletionsModeFastValidated(body); ok {
+		return mode
+	}
+	return parseOpenAIChatCompletionsModeWithJSON(body)
+}
+
+func parseOpenAIChatCompletionsModeWithJSON(body []byte) chatCompletionsMode {
 	var partial struct {
 		Stream        *bool                 `json:"stream,omitempty"`
 		StreamOptions *models.StreamOptions `json:"stream_options,omitempty"`
@@ -1441,15 +1464,258 @@ func parseOpenAIChatCompletionsMode(body []byte) chatCompletionsMode {
 	_ = json.Unmarshal(body, &partial)
 
 	clientRequestedStream := partial.Stream != nil && *partial.Stream
+	requestHasTools := hasNonEmptyTools(partial.Tools)
 	return chatCompletionsMode{
 		clientRequestedStream:      clientRequestedStream,
 		clientRequestedStreamUsage: clientRequestedStream && partial.StreamOptions != nil && partial.StreamOptions.IncludeUsage,
-		forceUpstreamStream:        !clientRequestedStream && hasNonEmptyTools(partial.Tools),
+		forceUpstreamStream:        !clientRequestedStream && requestHasTools,
+		requestHasTools:            requestHasTools,
+	}
+}
+
+func parseOpenAIChatCompletionsModeFast(body []byte) (chatCompletionsMode, bool) {
+	if !json.Valid(body) {
+		return chatCompletionsMode{}, false
+	}
+	return parseOpenAIChatCompletionsModeFastValidated(body)
+}
+
+func parseOpenAIChatCompletionsModeFastValidated(body []byte) (chatCompletionsMode, bool) {
+	object, ok := newRawJSONObjectScanner(body)
+	if !ok {
+		return chatCompletionsMode{}, false
+	}
+	var stream, streamOptions, tools []byte
+	var streamSeen, streamOptionsSeen, toolsSeen bool
+	for {
+		key, start, end, done, scanOK := object.next()
+		if !scanOK {
+			return chatCompletionsMode{}, false
+		}
+		if done {
+			break
+		}
+		switch {
+		case rawJSONKeyEqual(key, "stream"):
+			if streamSeen {
+				return chatCompletionsMode{}, false
+			}
+			streamSeen = true
+			stream = body[start:end]
+		case rawJSONKeyEqual(key, "stream_options"):
+			if streamOptionsSeen {
+				return chatCompletionsMode{}, false
+			}
+			streamOptionsSeen = true
+			streamOptions = body[start:end]
+		case rawJSONKeyEqual(key, "tools"):
+			if toolsSeen {
+				return chatCompletionsMode{}, false
+			}
+			toolsSeen = true
+			tools = body[start:end]
+		default:
+			// encoding/json struct fields match case-insensitively. Preserve that
+			// uncommon compatibility behavior through the existing decoder path.
+			if rawJSONKeyEqualFold(key, "stream") || rawJSONKeyEqualFold(key, "stream_options") || rawJSONKeyEqualFold(key, "tools") {
+				return chatCompletionsMode{}, false
+			}
+		}
+	}
+
+	return parseOpenAIChatCompletionsModeRaw(stream, streamOptions, tools)
+}
+
+func parseOpenAIChatCompletionsModeRaw(stream, streamOptions, tools []byte) (chatCompletionsMode, bool) {
+	clientRequestedStream := false
+	if len(stream) > 0 {
+		switch string(bytes.TrimSpace(stream)) {
+		case "true":
+			clientRequestedStream = true
+		case "false", "null":
+		default:
+			return chatCompletionsMode{}, false
+		}
+	}
+	requestHasTools := false
+	if len(tools) > 0 {
+		requestHasTools, _ = rawJSONHasNonEmptyArrayFast(tools)
+	}
+	includeUsage := false
+	if clientRequestedStream && len(streamOptions) > 0 {
+		var streamOptionsOK bool
+		includeUsage, streamOptionsOK = rawJSONStreamOptionsIncludeUsageFast(streamOptions)
+		if !streamOptionsOK {
+			return chatCompletionsMode{}, false
+		}
+	}
+	return chatCompletionsMode{
+		clientRequestedStream:      clientRequestedStream,
+		clientRequestedStreamUsage: clientRequestedStream && includeUsage,
+		forceUpstreamStream:        !clientRequestedStream && requestHasTools,
+		requestHasTools:            requestHasTools,
+	}, true
+}
+
+func inspectOpenAIChatRequestFast(body []byte) (openAIChatRequestInspection, bool) {
+	object, ok := newStrictRawJSONObjectScanner(body)
+	if !ok {
+		return openAIChatRequestInspection{}, false
+	}
+	return inspectOpenAIChatRequestFastWithScanner(body, &object)
+}
+
+func inspectOpenAIChatRequestFastValidated(body []byte) (openAIChatRequestInspection, bool) {
+	object, ok := newRawJSONObjectScanner(body)
+	if !ok {
+		return openAIChatRequestInspection{}, false
+	}
+	return inspectOpenAIChatRequestFastWithScanner(body, &object)
+}
+
+func inspectOpenAIChatRequestFastWithScanner(body []byte, object *rawJSONObjectScanner) (openAIChatRequestInspection, bool) {
+	var model, messages, toolChoice, tools, responseFormat, stream, streamOptions []byte
+	var streamSeen, streamOptionsSeen, toolsSeen bool
+	for {
+		key, start, end, done, scanOK := object.next()
+		if !scanOK {
+			return openAIChatRequestInspection{}, false
+		}
+		if done {
+			break
+		}
+		value := body[start:end]
+		switch {
+		case rawJSONKeyEqual(key, "model"):
+			model = value
+		case rawJSONKeyEqual(key, "messages"):
+			messages = value
+		case rawJSONKeyEqual(key, "tool_choice"):
+			toolChoice = value
+		case rawJSONKeyEqual(key, "tools"):
+			if toolsSeen {
+				return openAIChatRequestInspection{}, false
+			}
+			toolsSeen = true
+			tools = value
+		case rawJSONKeyEqual(key, "response_format"):
+			responseFormat = value
+		case rawJSONKeyEqual(key, "stream"):
+			if streamSeen {
+				return openAIChatRequestInspection{}, false
+			}
+			streamSeen = true
+			stream = value
+		case rawJSONKeyEqual(key, "stream_options"):
+			if streamOptionsSeen {
+				return openAIChatRequestInspection{}, false
+			}
+			streamOptionsSeen = true
+			streamOptions = value
+		default:
+			if rawJSONKeyEqualFold(key, "stream") || rawJSONKeyEqualFold(key, "stream_options") || rawJSONKeyEqualFold(key, "tools") {
+				return openAIChatRequestInspection{}, false
+			}
+		}
+	}
+
+	mode, ok := parseOpenAIChatCompletionsModeRaw(stream, streamOptions, tools)
+	if !ok {
+		return openAIChatRequestInspection{}, false
+	}
+	message, param, invalid := validateOpenAIChatRequestRaw(messages, toolChoice, tools, responseFormat)
+	return openAIChatRequestInspection{
+		modelRaw: model,
+		message:  message,
+		param:    param,
+		invalid:  invalid,
+		mode:     mode,
+	}, true
+}
+
+func decodeOpenAIChatRequestModelRaw(raw []byte) string {
+	raw = bytes.TrimSpace(raw)
+	contentStart, contentEnd, end, escaped, ok := scanRawJSONString(raw, 0)
+	if !ok || end != len(raw) {
+		return ""
+	}
+	if !escaped {
+		return strings.TrimSpace(string(raw[contentStart:contentEnd]))
+	}
+	var model string
+	if err := json.Unmarshal(raw, &model); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(model)
+}
+
+func (h *ProxyHandler) decodeInternedOpenAIChatRequestModelRaw(raw []byte) string {
+	raw = bytes.TrimSpace(raw)
+	contentStart, contentEnd, end, escaped, ok := scanRawJSONString(raw, 0)
+	if !ok || end != len(raw) {
+		return ""
+	}
+	if escaped {
+		return decodeOpenAIChatRequestModelRaw(raw)
+	}
+	content := bytes.TrimSpace(raw[contentStart:contentEnd])
+	if len(content) == 0 {
+		return ""
+	}
+	if model, ok := h.providerSetup().internExactPublicModel(content); ok {
+		return model
+	}
+	return string(content)
+}
+
+func rawJSONStreamOptionsIncludeUsageFast(raw []byte) (bool, bool) {
+	raw = bytes.TrimSpace(raw)
+	if bytes.Equal(raw, []byte("null")) {
+		return false, true
+	}
+	object, ok := newRawJSONObjectScanner(raw)
+	if !ok {
+		return false, false
+	}
+	var includeUsage []byte
+	includeUsageSeen := false
+	for {
+		key, start, end, done, scanOK := object.next()
+		if !scanOK {
+			return false, false
+		}
+		if done {
+			break
+		}
+		if rawJSONKeyEqual(key, "include_usage") {
+			if includeUsageSeen {
+				return false, false
+			}
+			includeUsageSeen = true
+			includeUsage = raw[start:end]
+		} else if rawJSONKeyEqualFold(key, "include_usage") {
+			return false, false
+		}
+	}
+	if len(includeUsage) == 0 {
+		return false, true
+	}
+	switch string(bytes.TrimSpace(includeUsage)) {
+	case "true":
+		return true, true
+	case "false", "null":
+		return false, true
+	default:
+		return false, false
 	}
 }
 
 func prepareOpenAIChatCompletionsRequest(body []byte) ([]byte, chatCompletionsMode) {
-	return prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body, chatParallelToolCallsDefault)
+	return prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body, chatParallelToolCallsDefault, false)
+}
+
+func prepareOpenAIChatCompletionsRequestValidated(body []byte) ([]byte, chatCompletionsMode) {
+	return prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body, chatParallelToolCallsDefault, true)
 }
 
 type chatParallelToolCallsPreparation uint8
@@ -1461,7 +1727,11 @@ const (
 )
 
 func preparePolicyOpenAIChatCompletionsRequest(body []byte, contract publicModelContract, terminalParallelToolCalls *bool) ([]byte, chatCompletionsMode) {
-	return prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body, policyParallelToolCallsPreparation(contract, terminalParallelToolCalls))
+	return prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body, policyParallelToolCallsPreparation(contract, terminalParallelToolCalls), false)
+}
+
+func preparePolicyOpenAIChatCompletionsRequestValidated(body []byte, contract publicModelContract, terminalParallelToolCalls *bool) ([]byte, chatCompletionsMode) {
+	return prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body, policyParallelToolCallsPreparation(contract, terminalParallelToolCalls), true)
 }
 
 func applyPolicyOpenAIChatParallelToolCalls(body []byte, contract publicModelContract, terminalParallelToolCalls *bool) []byte {
@@ -1486,15 +1756,26 @@ func policyParallelToolCallsPreparation(contract publicModelContract, terminalPa
 	return preparation
 }
 
-func prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body []byte, preparation chatParallelToolCallsPreparation) ([]byte, chatCompletionsMode) {
-	mode := parseOpenAIChatCompletionsMode(body)
+func prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body []byte, preparation chatParallelToolCallsPreparation, validated bool) ([]byte, chatCompletionsMode) {
+	var mode chatCompletionsMode
+	if validated {
+		mode = parseOpenAIChatCompletionsModeValidated(body)
+	} else {
+		mode = parseOpenAIChatCompletionsMode(body)
+	}
+	return prepareOpenAIChatCompletionsRequestWithMode(body, preparation, mode)
+}
+
+func prepareOpenAIChatCompletionsRequestWithMode(body []byte, preparation chatParallelToolCallsPreparation, mode chatCompletionsMode) ([]byte, chatCompletionsMode) {
 	switch preparation {
 	case chatParallelToolCallsForceFalse:
 		body = enforceParallelToolCallsFalse(body)
 	case chatParallelToolCallsOmit:
 		body = omitParallelToolCalls(body)
 	default:
-		body = injectParallelToolCalls(body)
+		if mode.requestHasTools {
+			body = injectParallelToolCalls(body)
+		}
 	}
 	if mode.forceUpstreamStream {
 		body = injectForceStream(body)
@@ -1517,6 +1798,20 @@ func prepareOpenAIChatCompletionsRequestWithParallelToolCalls(body []byte, prepa
 // semantics used by chat preparation: when a request contains duplicate model
 // keys, the last occurrence is the decoded value.
 func extractOpenAIChatCompletionsRequestModel(body []byte) string {
+	if model, _, ok := extractTopLevelJSONStringFast(body, "model", true); ok {
+		return model
+	}
+	return extractOpenAIChatCompletionsRequestModelWithJSON(body)
+}
+
+func extractOpenAIChatCompletionsRequestModelValidated(body []byte) string {
+	if model, _, ok := extractTopLevelJSONStringFastValidated(body, "model", true); ok {
+		return model
+	}
+	return extractOpenAIChatCompletionsRequestModelWithJSON(body)
+}
+
+func extractOpenAIChatCompletionsRequestModelWithJSON(body []byte) string {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return ""
@@ -1720,8 +2015,8 @@ func (h *ProxyHandler) postAnthropicMessagesCountTokensForModel(ctx context.Cont
 		}
 	}
 
-	return h.doWithRetry(func() (*http.Request, error) {
-		return h.newProviderJSONRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "", owner)
+	return h.doInferenceWithRetry(func() (*http.Request, error) {
+		return h.newProviderJSONInferenceRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "", owner)
 	})
 }
 
@@ -2128,7 +2423,7 @@ func (h *ProxyHandler) HandleAnthropicMessages(w http.ResponseWriter, r *http.Re
 
 	result, oaiBody, mode = h.retryRoutedChatExecutionWithoutInjectedStreamOptions(upstreamCtx, result, oaiBody, mode, providerModel)
 	observeChatExecutionRoute(r.Context(), result)
-	observeUpstreamHeaders(r.Context(), result.Headers)
+	observeUpstreamHeaders(r.Context(), chatExecutionUpstreamHeaders(result))
 	if result.Backend == chatBackendResponses && len(result.Headers) > 0 {
 		if policyPlan.valid() {
 			result.Headers = policyChatSafeHeaders(result.Headers, publicModel)
@@ -2805,7 +3100,10 @@ func writePolicyChatTerminalError(w http.ResponseWriter, resp *http.Response, pu
 // HandleOpenAIChatCompletions handles POST /v1/chat/completions by forwarding the
 // request to Copilot with only auth headers injected (near zero-copy passthrough).
 func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *http.Request) {
-	bodyBytes, err := readBody(r)
+	bodyBytes, pooledBody, err := readBodyBorrowed(r)
+	if pooledBody != nil {
+		defer releaseSmallRequestBodyBuffer(pooledBody)
+	}
 	if err != nil {
 		if h.handleShutdownError(w, r, nil, err) {
 			return
@@ -2815,7 +3113,22 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
-	requestedModel := extractOpenAIChatCompletionsRequestModel(bodyBytes)
+	requestInspection, requestInspectionOK := inspectOpenAIChatRequestFast(bodyBytes)
+	requestJSONValid := requestInspectionOK
+	var requestedModel string
+	if !requestInspectionOK {
+		requestJSONValid = json.Valid(bodyBytes)
+		if requestJSONValid {
+			requestInspection, requestInspectionOK = inspectOpenAIChatRequestFastValidated(bodyBytes)
+		}
+	}
+	if requestInspectionOK {
+		requestedModel = h.decodeInternedOpenAIChatRequestModelRaw(requestInspection.modelRaw)
+	} else if requestJSONValid {
+		requestedModel = extractOpenAIChatCompletionsRequestModelValidated(bodyBytes)
+	} else {
+		requestedModel = extractOpenAIChatCompletionsRequestModel(bodyBytes)
+	}
 	h.observePolicyRequestSummary(r.Context(), "openai_chat", requestedModel, false)
 	publicModel := requestedModel
 	admissionCtx, admittedOperation, _, err := h.withAdmittedExplicitRouteOperation(r.Context(), r.Context(), requestedModel, providerEndpointChatCompletions)
@@ -2833,7 +3146,16 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if message, param, ok := validateOpenAIChatRequest(bodyBytes); ok {
+	var message, param string
+	var invalid bool
+	if requestInspectionOK {
+		message, param, invalid = requestInspection.message, requestInspection.param, requestInspection.invalid
+	} else if requestJSONValid {
+		message, param, invalid = validateOpenAIChatRequestValidated(bodyBytes)
+	} else {
+		message, param, invalid = validateOpenAIChatRequest(bodyBytes)
+	}
+	if invalid {
 		writeOpenAIErrorWithDetails(w, http.StatusBadRequest, message, "invalid_request_error", param, "")
 		return
 	}
@@ -2873,9 +3195,21 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	scope := chatToolExecutionScopeFromHeaders(r.Header)
 	var mode chatCompletionsMode
 	if policyPlan.valid() {
-		bodyBytes, mode = preparePolicyOpenAIChatCompletionsRequest(bodyBytes, policyPlan.contract, terminalParallelToolCalls)
+		if requestInspectionOK {
+			bodyBytes, mode = prepareOpenAIChatCompletionsRequestWithMode(bodyBytes, policyParallelToolCallsPreparation(policyPlan.contract, terminalParallelToolCalls), requestInspection.mode)
+		} else if requestJSONValid {
+			bodyBytes, mode = preparePolicyOpenAIChatCompletionsRequestValidated(bodyBytes, policyPlan.contract, terminalParallelToolCalls)
+		} else {
+			bodyBytes, mode = preparePolicyOpenAIChatCompletionsRequest(bodyBytes, policyPlan.contract, terminalParallelToolCalls)
+		}
 	} else {
-		bodyBytes, mode = prepareOpenAIChatCompletionsRequest(bodyBytes)
+		if requestInspectionOK {
+			bodyBytes, mode = prepareOpenAIChatCompletionsRequestWithMode(bodyBytes, chatParallelToolCallsDefault, requestInspection.mode)
+		} else if requestJSONValid {
+			bodyBytes, mode = prepareOpenAIChatCompletionsRequestValidated(bodyBytes)
+		} else {
+			bodyBytes, mode = prepareOpenAIChatCompletionsRequest(bodyBytes)
+		}
 	}
 	h.observeRequestSummary(r.Context(), "openai_chat", publicModel, mode.clientRequestedStream, providerEndpointChatCompletions)
 	bodyBytes = h.rewriteOpenAIChatRequestBodyWithToolOptimizers(r.Context(), bodyBytes, h.toolContexts, scope)
@@ -2911,7 +3245,8 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 	}
 
 	responseModel := explicitRoutePublicModel(route, publicModel)
-	result, err := h.executeRoutedChatCompletions(upstreamCtx, bodyBytes, mode, chatExecutionOptions{}, requestedModel)
+	mutableRequestBody := pooledBody != nil && len(bodyBytes) > 0 && len(*pooledBody) > 0 && &bodyBytes[0] == &(*pooledBody)[0]
+	result, err := h.executeRoutedChatCompletions(upstreamCtx, bodyBytes, mode, chatExecutionOptions{MutableRequestBody: mutableRequestBody}, requestedModel)
 	if err != nil {
 		if h.handleShutdownError(w, r, upstreamCtx, err) {
 			return
@@ -2949,7 +3284,7 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 
 	result, bodyBytes, mode = h.retryRoutedChatExecutionWithoutInjectedStreamOptions(upstreamCtx, result, bodyBytes, mode, requestedModel)
 	observeChatExecutionRoute(r.Context(), result)
-	observeUpstreamHeaders(r.Context(), result.Headers)
+	observeUpstreamHeaders(r.Context(), chatExecutionUpstreamHeaders(result))
 	if policyPlan.valid() && result.Backend == chatBackendResponses && len(result.Headers) > 0 {
 		// routeChatExecutionResult merges Responses-backed headers before its
 		// protocol-specific callbacks run. Replace them with the policy allowlist
@@ -3130,6 +3465,71 @@ func (h *ProxyHandler) HandleOpenAIChatCompletions(w http.ResponseWriter, r *htt
 }
 
 func validateOpenAIChatRequest(body []byte) (string, string, bool) {
+	if message, param, invalid, ok := validateOpenAIChatRequestFast(body); ok {
+		return message, param, invalid
+	}
+	return validateOpenAIChatRequestWithJSON(body)
+}
+
+func validateOpenAIChatRequestValidated(body []byte) (string, string, bool) {
+	if message, param, invalid, ok := validateOpenAIChatRequestFastValidated(body); ok {
+		return message, param, invalid
+	}
+	return validateOpenAIChatRequestWithJSON(body)
+}
+
+func validateOpenAIChatRequestFast(body []byte) (message, param string, invalid, ok bool) {
+	if !json.Valid(body) {
+		return "", "", false, false
+	}
+	return validateOpenAIChatRequestFastValidated(body)
+}
+
+func validateOpenAIChatRequestFastValidated(body []byte) (message, param string, invalid, ok bool) {
+	object, scanOK := newRawJSONObjectScanner(body)
+	if !scanOK {
+		return "", "", false, false
+	}
+	var messages, toolChoice, tools, responseFormat []byte
+	for {
+		key, start, end, done, fieldOK := object.next()
+		if !fieldOK {
+			return "", "", false, false
+		}
+		if done {
+			break
+		}
+		switch {
+		case rawJSONKeyEqual(key, "messages"):
+			messages = body[start:end]
+		case rawJSONKeyEqual(key, "tool_choice"):
+			toolChoice = body[start:end]
+		case rawJSONKeyEqual(key, "tools"):
+			tools = body[start:end]
+		case rawJSONKeyEqual(key, "response_format"):
+			responseFormat = body[start:end]
+		}
+	}
+	message, param, invalid = validateOpenAIChatRequestRaw(messages, toolChoice, tools, responseFormat)
+	return message, param, invalid, true
+}
+
+func validateOpenAIChatRequestRaw(messages, toolChoice, tools, responseFormat []byte) (message, param string, invalid bool) {
+	messagesPresent, _ := rawJSONHasNonEmptyArrayFast(messages)
+	if !messagesPresent {
+		return "messages must be a non-empty array", "messages", true
+	}
+	toolsPresent, _ := rawJSONHasNonEmptyArrayFast(tools)
+	if len(toolChoice) > 0 && openAIToolChoiceRequiresTools(toolChoice) && !toolsPresent {
+		return "tool_choice requires non-empty tools", "tool_choice", true
+	}
+	if len(responseFormat) > 0 && responseFormatMissingJSONSchema(responseFormat) {
+		return "response_format json_schema requires json_schema.schema", "response_format.json_schema.schema", true
+	}
+	return "", "", false
+}
+
+func validateOpenAIChatRequestWithJSON(body []byte) (string, string, bool) {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return "", "", false

--- a/proxy/chat_handlers_test.go
+++ b/proxy/chat_handlers_test.go
@@ -15,6 +15,50 @@ import (
 	"github.com/sozercan/vekil/models"
 )
 
+func TestDecodeInternedOpenAIChatRequestModelRawReturnsStableStrings(t *testing.T) {
+	handler, err := NewProxyHandler(
+		auth.NewTestAuthenticator("test-token"),
+		logger.NewWithWriter(logger.LevelError, io.Discard),
+		WithProvidersConfig(ProvidersConfig{Providers: []ProviderConfig{{
+			ID:             "local-openai",
+			Type:           string(providerTypeOpenAICompatible),
+			Default:        true,
+			BaseURL:        "http://upstream.test/v1",
+			AuthType:       string(providerAuthTypeNone),
+			ModelDiscovery: string(providerModelDiscoveryStatic),
+			Models: []ProviderModelConfig{{
+				PublicID: "claude-sonnet-4.5",
+			}},
+		}}}),
+	)
+	if err != nil {
+		t.Fatalf("NewProxyHandler() error = %v", err)
+	}
+
+	for _, tt := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "exact configured id", raw: `"claude-sonnet-4.5"`, want: "claude-sonnet-4.5"},
+		{name: "trimmed configured id", raw: `"  claude-sonnet-4.5  "`, want: "claude-sonnet-4.5"},
+		{name: "normalized alias fallback", raw: `"claude-sonnet-4-5"`, want: "claude-sonnet-4-5"},
+		{name: "escaped id fallback", raw: `"claude-sonnet-4\u002e5"`, want: "claude-sonnet-4.5"},
+		{name: "unknown id fallback", raw: `"unknown-model"`, want: "unknown-model"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte(tt.raw)
+			got := handler.decodeInternedOpenAIChatRequestModelRaw(raw)
+			for i := range raw {
+				raw[i] = 'x'
+			}
+			if got != tt.want {
+				t.Fatalf("decoded model = %q after source mutation, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandleAnthropicMessages_CopilotNativeMessages(t *testing.T) {
 	t.Run("a model advertising native Messages preserves the Anthropic request", func(t *testing.T) {
 		var modelFetches, messagesPosts, chatPosts int
@@ -288,6 +332,43 @@ func TestPrepareOpenAIChatCompletionsRequest_ClientStreamOptionsPreserved(t *tes
 	}
 	if mode.injectedClientStreamUsage {
 		t.Fatal("injectedClientStreamUsage = true, want false when client supplied stream_options")
+	}
+}
+
+func TestParseOpenAIChatCompletionsModePreservesCaseInsensitiveJSONFields(t *testing.T) {
+	input := []byte(`{"STREAM":true,"STREAM_OPTIONS":{"INCLUDE_USAGE":true},"TOOLS":[{"type":"function"}]}`)
+	mode := parseOpenAIChatCompletionsMode(input)
+	if !mode.clientRequestedStream {
+		t.Fatal("clientRequestedStream = false, want true")
+	}
+	if !mode.clientRequestedStreamUsage {
+		t.Fatal("clientRequestedStreamUsage = false, want true")
+	}
+	if !mode.requestHasTools {
+		t.Fatal("requestHasTools = false, want true")
+	}
+	if mode.forceUpstreamStream {
+		t.Fatal("forceUpstreamStream = true, want false for client streaming")
+	}
+}
+
+func TestParseOpenAIChatCompletionsModePreservesDuplicateTypeErrorSemantics(t *testing.T) {
+	tests := []string{
+		`{"stream":1,"stream":true,"messages":[{"role":"user","content":"hi"}]}`,
+		`{"stream":true,"stream_options":1,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`,
+		`{"stream":true,"stream_options":{"include_usage":1,"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`,
+		`{"tools":1,"tools":[{"type":"function"}],"messages":[{"role":"user","content":"hi"}]}`,
+	}
+	for _, input := range tests {
+		input := []byte(input)
+		if _, ok := parseOpenAIChatCompletionsModeFast(input); ok {
+			t.Fatalf("fast parser accepted duplicate tracked fields: %s", input)
+		}
+		got := parseOpenAIChatCompletionsMode(input)
+		want := parseOpenAIChatCompletionsModeWithJSON(input)
+		if got != want {
+			t.Fatalf("mode = %#v, want encoding/json result %#v for %s", got, want, input)
+		}
 	}
 }
 

--- a/proxy/chat_operation_plan.go
+++ b/proxy/chat_operation_plan.go
@@ -168,6 +168,7 @@ func (p chatOperationPlan) routeSnapshot() *modelRoute {
 func cloneTargetBindings(candidates []targetBinding) []targetBinding {
 	cloned := append([]targetBinding(nil), candidates...)
 	for index := range cloned {
+		cloned[index].upstreamModelJSON = append([]byte(nil), cloned[index].upstreamModelJSON...)
 		cloned[index].wirePolicy.parallelToolCalls = cloneBoolPtr(cloned[index].wirePolicy.parallelToolCalls)
 		cloned[index].legacyOwner = cloneProviderModelForRoute(cloned[index].legacyOwner)
 	}

--- a/proxy/chat_route.go
+++ b/proxy/chat_route.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,6 +28,14 @@ type resolvedChatRoute struct {
 }
 
 func chooseChatRoute(provider *providerRuntime, owner providerModel, known bool, model string) (resolvedChatRoute, error) {
+	return chooseChatRouteWithOwner(provider, owner, known, model, false)
+}
+
+func chooseChatRouteFromSnapshot(provider *providerRuntime, owner providerModel, known bool, model string) (resolvedChatRoute, error) {
+	return chooseChatRouteWithOwner(provider, owner, known, model, true)
+}
+
+func chooseChatRouteWithOwner(provider *providerRuntime, owner providerModel, known bool, model string, ownerSnapshot bool) (resolvedChatRoute, error) {
 	model = strings.TrimSpace(model)
 	if provider == nil {
 		return resolvedChatRoute{}, &providerRequestError{
@@ -36,10 +45,10 @@ func chooseChatRoute(provider *providerRuntime, owner providerModel, known bool,
 	}
 
 	if chatRouteAllowsEndpoint(provider, owner, known, providerEndpointChatCompletions) {
-		return newResolvedChatRoute(provider, owner, known, model, providerEndpointChatCompletions, chatBackendNativeChat), nil
+		return newResolvedChatRouteWithOwner(provider, owner, known, model, providerEndpointChatCompletions, chatBackendNativeChat, ownerSnapshot), nil
 	}
 	if chatRouteAllowsEndpoint(provider, owner, known, providerEndpointResponses) {
-		return newResolvedChatRoute(provider, owner, known, model, providerEndpointResponses, chatBackendResponses), nil
+		return newResolvedChatRouteWithOwner(provider, owner, known, model, providerEndpointResponses, chatBackendResponses, ownerSnapshot), nil
 	}
 
 	return resolvedChatRoute{}, unsupportedChatRouteError(provider, model)
@@ -56,7 +65,13 @@ func chatRouteAllowsEndpoint(provider *providerRuntime, owner providerModel, kno
 }
 
 func newResolvedChatRoute(provider *providerRuntime, owner providerModel, known bool, publicModel, endpoint string, backend chatBackend) resolvedChatRoute {
-	owner = cloneProviderModelForRoute(owner)
+	return newResolvedChatRouteWithOwner(provider, owner, known, publicModel, endpoint, backend, false)
+}
+
+func newResolvedChatRouteWithOwner(provider *providerRuntime, owner providerModel, known bool, publicModel, endpoint string, backend chatBackend, ownerSnapshot bool) resolvedChatRoute {
+	if !ownerSnapshot {
+		owner = cloneProviderModelForRoute(owner)
+	}
 	upstreamModel := strings.TrimSpace(owner.upstreamModel)
 	if upstreamModel == "" {
 		upstreamModel = strings.TrimSpace(publicModel)
@@ -75,6 +90,11 @@ func newResolvedChatRoute(provider *providerRuntime, owner providerModel, known 
 func cloneProviderModelForRoute(model providerModel) providerModel {
 	model.supportedEndpoints = append([]string(nil), model.supportedEndpoints...)
 	model.parallelToolCalls = cloneBoolPtr(model.parallelToolCalls)
+	if len(model.upstreamModelJSON) == 0 {
+		model.upstreamModelJSON = encodeProviderModelJSON(model.upstreamModel)
+	} else {
+		model.upstreamModelJSON = append(json.RawMessage(nil), model.upstreamModelJSON...)
+	}
 	model.raw = append([]byte(nil), model.raw...)
 	return model
 }

--- a/proxy/chat_route_discovery.go
+++ b/proxy/chat_route_discovery.go
@@ -52,6 +52,16 @@ func (h *ProxyHandler) resolveChatRoute(ctx context.Context, model string) (reso
 	if !h.modelAllowedForRequest(model, providerEndpointChatCompletions) {
 		return resolvedChatRoute{}, modelNotAllowedRequestError(model)
 	}
+	if route, known := h.resolveModelRouteForRequest(model, providerEndpointChatCompletions); known && route != nil && route.legacy {
+		target, ok := route.primaryTarget()
+		if !ok || target.provider == nil {
+			return resolvedChatRoute{}, &providerRequestError{
+				statusCode: http.StatusInternalServerError,
+				err:        fmt.Errorf("no provider available for endpoint %s", providerEndpointChatCompletions),
+			}
+		}
+		return chooseChatRouteFromSnapshot(target.provider, providerModelFromRouteTarget(route, target), true, model)
+	}
 	provider, owner, known := h.resolveProviderModelForRequest(model, providerEndpointChatCompletions)
 	if provider == nil && !known && h.hasClosedConfiguredModelRegistry() {
 		return resolvedChatRoute{}, &providerRequestError{

--- a/proxy/dashboard_review_fixes_test.go
+++ b/proxy/dashboard_review_fixes_test.go
@@ -161,6 +161,17 @@ func TestNewInferenceUpstreamContextPropagatesTrackedMarker(t *testing.T) {
 	}
 }
 
+func TestRetryStatsTrackedUsesExistingRequestSummaryContext(t *testing.T) {
+	ctx, summary := WithRequestSummary(context.Background())
+	tracked := markRetryStatsTracked(ctx)
+	if tracked != ctx {
+		t.Fatal("markRetryStatsTracked added a context layer despite an existing request summary")
+	}
+	if !isRetryStatsTracked(tracked) || !summary.retryStatsTracked.Load() {
+		t.Fatal("request summary did not retain the retry-stats marker")
+	}
+}
+
 // TestMarkRetryStatsTrackedIfInference covers that only inference routes acquire
 // the marker through the middleware helper.
 func TestMarkRetryStatsTrackedIfInference(t *testing.T) {

--- a/proxy/gemini_handler.go
+++ b/proxy/gemini_handler.go
@@ -277,7 +277,7 @@ func (h *ProxyHandler) handleGeminiGenerateContent(w http.ResponseWriter, r *htt
 
 	result, oaiBody, mode = h.retryChatExecutionWithoutInjectedStreamOptions(upstreamCtx, result, oaiBody, mode)
 	observeChatExecutionRoute(r.Context(), result)
-	observeUpstreamHeaders(r.Context(), result.Headers)
+	observeUpstreamHeaders(r.Context(), chatExecutionUpstreamHeaders(result))
 	if result.Backend == chatBackendResponses && len(result.Headers) > 0 {
 		mergeHeaderValues(w.Header(), result.Headers)
 	}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -258,12 +258,15 @@ type ProxyHandler struct {
 	draining                         atomic.Bool
 	lifecycleOnce                    sync.Once
 	lifecycleCtx                     context.Context
+	retryTrackedLifecycleCtx         context.Context
 	lifecycleCancel                  context.CancelCauseFunc
 	shutdownSequenceOnce             sync.Once
 	shutdownSequence                 atomic.Uint64
 	lifecycleWorkersMu               sync.Mutex
 	lifecycleWorkers                 sync.WaitGroup
 	lifecycleWorkersActive           int
+	lifecycleRequestBodiesMu         sync.Mutex
+	lifecycleRequestBodies           map[*lifecycleRequestBody]struct{}
 	startupAuthenticationPending     atomic.Bool
 	dynamicProviderValidationPending atomic.Bool
 	azureIdentityTokenSourceFactory  azureIdentityTokenSourceFactory
@@ -314,6 +317,7 @@ func (h *ProxyHandler) initializeLifecycle() {
 	}
 	h.lifecycleOnce.Do(func() {
 		h.lifecycleCtx, h.lifecycleCancel = context.WithCancelCause(context.Background())
+		h.retryTrackedLifecycleCtx = context.WithValue(h.lifecycleCtx, retryStatsTrackedContextKey{}, true)
 	})
 }
 
@@ -323,6 +327,14 @@ func (h *ProxyHandler) lifecycleContext() context.Context {
 	}
 	h.initializeLifecycle()
 	return h.lifecycleCtx
+}
+
+func (h *ProxyHandler) lifecycleContextForRetryStats(tracked bool) context.Context {
+	if !tracked || h == nil {
+		return h.lifecycleContext()
+	}
+	h.initializeLifecycle()
+	return h.retryTrackedLifecycleCtx
 }
 
 func (h *ProxyHandler) responsesChatReplayStore() *responsesChatReplayStore {
@@ -366,6 +378,7 @@ func (h *ProxyHandler) BeginShutdown() {
 		})
 	})
 	h.draining.Store(true)
+	h.cancelLifecycleRequestBodies()
 	h.initializeLifecycle()
 	h.lifecycleCancel(errProxyLifecycleShutdown)
 	if h.client != nil {
@@ -383,53 +396,100 @@ func (h *ProxyHandler) upstreamShutdownStarted() bool {
 	return h.ShuttingDown()
 }
 
+var lifecycleRequestBodyPool = sync.Pool{New: func() any {
+	return new(lifecycleRequestBody)
+}}
+
 // BindRequestBodyToLifecycle makes a request body read interruptible by proxy
-// shutdown without changing the inbound request context. The separate cause
-// context preserves whether client cancellation or lifecycle shutdown happened
+// shutdown without changing the inbound request context. A small atomic cause
+// state preserves whether client cancellation or lifecycle shutdown happened
 // first, so a client disconnect racing shutdown is not rewritten as a local 503.
-func (h *ProxyHandler) BindRequestBodyToLifecycle(r *http.Request, forceClose func()) func() {
+func (h *ProxyHandler) BindRequestBodyToLifecycle(r *http.Request, forceClose io.Closer) RequestBodyLifecycleBinding {
 	if h == nil || r == nil || r.Body == nil || r.Body == http.NoBody {
-		return func() {}
+		return RequestBodyLifecycleBinding{}
 	}
 
-	causeCtx, cancelCause := context.WithCancelCause(r.Context())
-	body := &lifecycleRequestBody{ReadCloser: r.Body, causeCtx: causeCtx}
+	body := lifecycleRequestBodyPool.Get().(*lifecycleRequestBody)
+	*body = lifecycleRequestBody{
+		ReadCloser: r.Body,
+		requestCtx: r.Context(),
+		owner:      h,
+		forceClose: forceClose,
+	}
 	r.Body = body
-
-	cancelForShutdown := func() {
-		cancelCause(errProxyLifecycleShutdown)
-		if !body.complete.Load() && forceClose != nil {
-			forceClose()
-			return
-		}
-		_ = body.Close()
+	if !h.registerLifecycleRequestBody(body) {
+		body.cancelForShutdown()
 	}
-	stopLifecycle := context.AfterFunc(h.lifecycleContext(), cancelForShutdown)
-	if h.ShuttingDown() {
-		cancelForShutdown()
-	}
+	return RequestBodyLifecycleBinding{body: body}
+}
 
-	return func() {
-		stopLifecycle()
-		cancelCause(context.Canceled)
+// RequestBodyLifecycleBinding releases a request body from shutdown tracking.
+// The value handle avoids allocating a closure on every admitted HTTP request.
+type RequestBodyLifecycleBinding struct {
+	body *lifecycleRequestBody
+}
+
+// Release stops lifecycle tracking without closing the underlying request body.
+func (b RequestBodyLifecycleBinding) Release() {
+	if b.body != nil {
+		b.body.release()
 	}
 }
 
+// ReleaseAndRecycle finishes server-owned request-body tracking after the
+// handler has returned. It restores the original body on the request before
+// pooling the wrapper so net/http can retain its ordinary body-close behavior.
+// A wrapper captured by the shutdown cancellation snapshot is deliberately not
+// pooled because that snapshot may still call cancelForShutdown asynchronously.
+func (b RequestBodyLifecycleBinding) ReleaseAndRecycle(r *http.Request) {
+	body := b.body
+	if body == nil {
+		return
+	}
+	if r != nil && r.Body == body {
+		r.Body = body.ReadCloser
+	}
+	body.release()
+	if body.shutdownScheduled.Load() || !body.recycled.CompareAndSwap(false, true) {
+		return
+	}
+	*body = lifecycleRequestBody{}
+	lifecycleRequestBodyPool.Put(body)
+}
+
+type lifecycleRequestBodyCause uint32
+
+const (
+	lifecycleRequestBodyCauseOpen lifecycleRequestBodyCause = iota
+	lifecycleRequestBodyCauseOther
+	lifecycleRequestBodyCauseShutdown
+)
+
 type lifecycleRequestBody struct {
 	io.ReadCloser
-	causeCtx context.Context
-	closeMu  sync.Mutex
-	closed   bool
-	closeErr error
-	complete atomic.Bool
+	requestCtx        context.Context
+	owner             *ProxyHandler
+	forceClose        io.Closer
+	closeMu           sync.Mutex
+	closed            bool
+	closeErr          error
+	complete          atomic.Bool
+	released          atomic.Bool
+	recycled          atomic.Bool
+	shutdownScheduled atomic.Bool
+	cause             atomic.Uint32
 }
 
 func (b *lifecycleRequestBody) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
 	if errors.Is(err, io.EOF) {
 		b.complete.Store(true)
+		b.release()
 	}
-	if err != nil && b.causeCtx != nil && errors.Is(context.Cause(b.causeCtx), errProxyLifecycleShutdown) {
+	if err != nil {
+		b.recordClientCancellation()
+	}
+	if err != nil && lifecycleRequestBodyCause(b.cause.Load()) == lifecycleRequestBodyCauseShutdown {
 		return n, errProxyLifecycleShutdown
 	}
 	return n, err
@@ -440,12 +500,93 @@ func (b *lifecycleRequestBody) Close() error {
 		return nil
 	}
 	b.closeMu.Lock()
-	defer b.closeMu.Unlock()
 	if !b.closed {
 		b.closed = true
 		b.closeErr = b.ReadCloser.Close()
 	}
-	return b.closeErr
+	err := b.closeErr
+	b.closeMu.Unlock()
+	b.release()
+	return err
+}
+
+func (b *lifecycleRequestBody) release() {
+	if b == nil || !b.released.CompareAndSwap(false, true) {
+		return
+	}
+	b.cause.CompareAndSwap(uint32(lifecycleRequestBodyCauseOpen), uint32(lifecycleRequestBodyCauseOther))
+	if b.owner != nil {
+		b.owner.unregisterLifecycleRequestBody(b)
+	}
+}
+
+func (b *lifecycleRequestBody) recordClientCancellation() {
+	if b == nil || b.requestCtx == nil || b.requestCtx.Err() == nil {
+		return
+	}
+	b.cause.CompareAndSwap(uint32(lifecycleRequestBodyCauseOpen), uint32(lifecycleRequestBodyCauseOther))
+}
+
+func (b *lifecycleRequestBody) cancelForShutdown() {
+	if b == nil {
+		return
+	}
+	b.shutdownScheduled.Store(true)
+	if b.released.Load() {
+		return
+	}
+	b.recordClientCancellation()
+	b.cause.CompareAndSwap(uint32(lifecycleRequestBodyCauseOpen), uint32(lifecycleRequestBodyCauseShutdown))
+	if b.released.Load() {
+		return
+	}
+	if !b.complete.Load() && b.forceClose != nil {
+		_ = b.forceClose.Close()
+		return
+	}
+	_ = b.Close()
+}
+
+func (h *ProxyHandler) registerLifecycleRequestBody(body *lifecycleRequestBody) bool {
+	if h == nil || body == nil {
+		return false
+	}
+	h.lifecycleRequestBodiesMu.Lock()
+	defer h.lifecycleRequestBodiesMu.Unlock()
+	if h.ShuttingDown() {
+		return false
+	}
+	if h.lifecycleRequestBodies == nil {
+		h.lifecycleRequestBodies = make(map[*lifecycleRequestBody]struct{})
+	}
+	h.lifecycleRequestBodies[body] = struct{}{}
+	return true
+}
+
+func (h *ProxyHandler) unregisterLifecycleRequestBody(body *lifecycleRequestBody) {
+	if h == nil || body == nil {
+		return
+	}
+	h.lifecycleRequestBodiesMu.Lock()
+	delete(h.lifecycleRequestBodies, body)
+	h.lifecycleRequestBodiesMu.Unlock()
+}
+
+func (h *ProxyHandler) cancelLifecycleRequestBodies() {
+	if h == nil {
+		return
+	}
+	h.lifecycleRequestBodiesMu.Lock()
+	bodies := make([]*lifecycleRequestBody, 0, len(h.lifecycleRequestBodies))
+	for body := range h.lifecycleRequestBodies {
+		body.shutdownScheduled.Store(true)
+		bodies = append(bodies, body)
+	}
+	h.lifecycleRequestBodies = nil
+	h.lifecycleRequestBodiesMu.Unlock()
+	for _, body := range bodies {
+		body.cancelForShutdown()
+	}
 }
 
 func (h *ProxyHandler) beginLifecycleWorker() bool {
@@ -1088,8 +1229,12 @@ func sanitizeProxySummaryText(text string) string {
 }
 
 func copyPassthroughHeaders(dst, src http.Header) {
-	connectionTokens := make(map[string]struct{})
-	for _, value := range src.Values("Connection") {
+	var connectionTokens map[string]struct{}
+	connectionValues := src.Values("Connection")
+	if len(connectionValues) > 0 {
+		connectionTokens = make(map[string]struct{})
+	}
+	for _, value := range connectionValues {
 		for _, token := range strings.Split(value, ",") {
 			token = http.CanonicalHeaderKey(strings.TrimSpace(token))
 			if token != "" {
@@ -1106,10 +1251,14 @@ func copyPassthroughHeaders(dst, src http.Header) {
 		if _, skip := connectionTokens[canonicalKey]; skip {
 			continue
 		}
-		dst.Del(key)
-		for _, value := range values {
-			dst.Add(key, value)
+		if len(values) == 0 {
+			delete(dst, canonicalKey)
+			continue
 		}
+		// Upstream response headers are immutable after receipt. Borrow their
+		// value slices with capped capacity so a later Header.Add allocates instead
+		// of modifying the upstream slice in place.
+		dst[canonicalKey] = values[:len(values):len(values)]
 	}
 }
 
@@ -2024,6 +2173,83 @@ func writeOpenAIErrorWithDetails(w http.ResponseWriter, status int, message, err
 // the limit, it returns an error so callers can return HTTP 413.
 func readBody(r *http.Request) ([]byte, error) {
 	return readBodyWithLimit(r, maxRequestBodySize)
+}
+
+const (
+	tinyRequestBodyBufferSize  = 512
+	smallRequestBodyBufferSize = 4 << 10
+)
+
+var tinyRequestBodyBufferPool = sync.Pool{New: func() any {
+	buffer := make([]byte, tinyRequestBodyBufferSize)
+	return &buffer
+}}
+
+var smallRequestBodyBufferPool = sync.Pool{New: func() any {
+	buffer := make([]byte, smallRequestBodyBufferSize)
+	return &buffer
+}}
+
+// readBodyBorrowed reads an ordinary small request into a pooled buffer. The
+// caller must release a non-nil pooled buffer only after it has finished using
+// body. Unknown-length, compressed, and larger requests retain the general
+// bounded reader below.
+func readBodyBorrowed(r *http.Request) ([]byte, *[]byte, error) {
+	if r == nil || r.Body == nil || r.Header.Get("Content-Encoding") != "" ||
+		r.ContentLength < 0 || r.ContentLength >= smallRequestBodyBufferSize ||
+		r.ContentLength > maxRequestBodySize {
+		body, err := readBody(r)
+		return body, nil, err
+	}
+
+	var pooled *[]byte
+	if r.ContentLength < tinyRequestBodyBufferSize {
+		pooled = tinyRequestBodyBufferPool.Get().(*[]byte)
+	} else {
+		pooled = smallRequestBodyBufferPool.Get().(*[]byte)
+	}
+	buffer := (*pooled)[:int(r.ContentLength)+1]
+	n, err := io.ReadFull(r.Body, buffer)
+	switch err {
+	case nil:
+		// The body exceeded its advertised length. Continue through the normal
+		// request cap so a mismatched Content-Length cannot truncate it.
+		remaining := maxRequestBodySize + 1 - int64(len(buffer))
+		rest, readErr := io.ReadAll(io.LimitReader(r.Body, remaining))
+		body := append(buffer, rest...)
+		if readErr != nil {
+			return nil, pooled, &requestBodyError{statusCode: http.StatusBadRequest, err: readErr}
+		}
+		if int64(len(body)) > maxRequestBodySize {
+			return nil, pooled, &requestBodyError{
+				statusCode: http.StatusRequestEntityTooLarge,
+				err:        fmt.Errorf("request body too large (max %d bytes)", maxRequestBodySize),
+			}
+		}
+		return body, pooled, nil
+	case io.EOF, io.ErrUnexpectedEOF:
+		return buffer[:n], pooled, nil
+	default:
+		return nil, pooled, &requestBodyError{statusCode: http.StatusBadRequest, err: err}
+	}
+}
+
+func releaseSmallRequestBodyBuffer(buffer *[]byte) {
+	if buffer == nil {
+		return
+	}
+	switch cap(*buffer) {
+	case tinyRequestBodyBufferSize:
+		full := (*buffer)[:tinyRequestBodyBufferSize]
+		clear(full)
+		*buffer = full
+		tinyRequestBodyBufferPool.Put(buffer)
+	case smallRequestBodyBufferSize:
+		full := (*buffer)[:smallRequestBodyBufferSize]
+		clear(full)
+		*buffer = full
+		smallRequestBodyBufferPool.Put(buffer)
+	}
 }
 
 // readBodyWithLimit reads and transparently decompresses the request body up to

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -40,6 +40,127 @@ func newTestProxyHandler(t testing.TB, backend http.HandlerFunc) *ProxyHandler {
 	return h
 }
 
+func TestCopyPassthroughHeadersBorrowsImmutableValues(t *testing.T) {
+	src := http.Header{
+		"Connection":   []string{"X-Hop"},
+		"Content-Type": []string{"application/json"},
+		"X-Hop":        []string{"secret"},
+		"X-Multi":      []string{"one", "two"},
+	}
+	dst := http.Header{
+		"X-Local": []string{"keep"},
+		"X-Multi": []string{"stale"},
+	}
+
+	copyPassthroughHeaders(dst, src)
+	if got := dst.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	if got := dst.Get("X-Hop"); got != "" {
+		t.Fatalf("hop-by-hop nominated header leaked: %q", got)
+	}
+	if got := dst.Get("X-Local"); got != "keep" {
+		t.Fatalf("proxy-owned header = %q, want keep", got)
+	}
+	dst.Add("X-Multi", "three")
+	if got := src.Values("X-Multi"); !reflect.DeepEqual(got, []string{"one", "two"}) {
+		t.Fatalf("adding a downstream value mutated upstream headers: %v", got)
+	}
+	dst.Set("Content-Type", "text/plain")
+	if got := src.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("setting a downstream value mutated upstream headers: %q", got)
+	}
+}
+
+func TestReadBodyBorrowedUsesSmallKnownLengthBuffer(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"test","messages":[]}`))
+	body, pooled, err := readBodyBorrowed(req)
+	if err != nil {
+		t.Fatalf("readBodyBorrowed() error = %v", err)
+	}
+	if pooled == nil {
+		t.Fatal("readBodyBorrowed() did not borrow a small known-length buffer")
+	}
+	defer releaseSmallRequestBodyBuffer(pooled)
+	if got, want := cap(*pooled), tinyRequestBodyBufferSize; got != want {
+		t.Fatalf("pooled buffer capacity = %d, want tiny tier %d", got, want)
+	}
+	if got, want := string(body), `{"model":"test","messages":[]}`; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
+func TestReadBodyBorrowedUsesFourKiBTier(t *testing.T) {
+	bodyText := strings.Repeat("x", tinyRequestBodyBufferSize)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(bodyText))
+	body, pooled, err := readBodyBorrowed(req)
+	if err != nil {
+		t.Fatalf("readBodyBorrowed() error = %v", err)
+	}
+	if pooled == nil {
+		t.Fatal("readBodyBorrowed() did not borrow a small known-length buffer")
+	}
+	defer releaseSmallRequestBodyBuffer(pooled)
+	if got, want := cap(*pooled), smallRequestBodyBufferSize; got != want {
+		t.Fatalf("pooled buffer capacity = %d, want small tier %d", got, want)
+	}
+	if got := string(body); got != bodyText {
+		t.Fatalf("body length = %d, want %d", len(got), len(bodyText))
+	}
+}
+
+func TestReadBodyBorrowedFallsBackForUnknownLengthAndCompression(t *testing.T) {
+	t.Run("unknown-length", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"test"}`))
+		req.ContentLength = -1
+		body, pooled, err := readBodyBorrowed(req)
+		if err != nil {
+			t.Fatalf("readBodyBorrowed() error = %v", err)
+		}
+		if pooled != nil {
+			t.Fatal("unknown-length body unexpectedly used the small buffer pool")
+		}
+		if got, want := string(body), `{"model":"test"}`; got != want {
+			t.Fatalf("body = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("compressed", func(t *testing.T) {
+		var compressed bytes.Buffer
+		writer := gzip.NewWriter(&compressed)
+		_, _ = writer.Write([]byte(`{"model":"test"}`))
+		_ = writer.Close()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", &compressed)
+		req.Header.Set("Content-Encoding", "gzip")
+		body, pooled, err := readBodyBorrowed(req)
+		if err != nil {
+			t.Fatalf("readBodyBorrowed() error = %v", err)
+		}
+		if pooled != nil {
+			t.Fatal("compressed body unexpectedly used the small buffer pool")
+		}
+		if got, want := string(body), `{"model":"test"}`; got != want {
+			t.Fatalf("body = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestReadBodyBorrowedDoesNotTrustShortContentLength(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Body = io.NopCloser(strings.NewReader("abcdef"))
+	req.ContentLength = 3
+	body, pooled, err := readBodyBorrowed(req)
+	if pooled != nil {
+		defer releaseSmallRequestBodyBuffer(pooled)
+	}
+	if err != nil {
+		t.Fatalf("readBodyBorrowed() error = %v", err)
+	}
+	if got, want := string(body), "abcdef"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -40,6 +40,12 @@ func newTestProxyHandler(t testing.TB, backend http.HandlerFunc) *ProxyHandler {
 	return h
 }
 
+type handlerTestRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f handlerTestRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestCopyPassthroughHeadersBorrowsImmutableValues(t *testing.T) {
 	src := http.Header{
 		"Connection":   []string{"X-Hop"},
@@ -6909,6 +6915,44 @@ func TestHandleOpenAIChatCompletions_RetriesWithoutInjectedStreamOptions(t *test
 	}
 }
 
+func TestHandleOpenAIChatCompletionsDetachesBorrowedBodyBeforeUpstream(t *testing.T) {
+	const responseBody = `{"id":"chatcmpl-native","object":"chat.completion","created":1,"model":"gpt-upstream","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	capturedBody := make(chan io.ReadCloser, 1)
+	h := newChatExecutionTestHandler(t, "http://upstream.example", []string{providerEndpointChatCompletions})
+	h.client = &http.Client{Transport: handlerTestRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedBody <- req.Body
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": []string{"application/json"}},
+			Body:          io.NopCloser(strings.NewReader(responseBody)),
+			ContentLength: int64(len(responseBody)),
+			Request:       req,
+		}, nil
+	})}
+
+	reqBody := `{"model":"gpt-public","messages":[{"role":"user","content":"hello"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	h.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	upstreamBody := <-capturedBody
+	defer func() { _ = upstreamBody.Close() }()
+	gotBody, err := io.ReadAll(upstreamBody)
+	if err != nil {
+		t.Fatalf("read asynchronously retained upstream body: %v", err)
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("upstream body was recycled before asynchronous close: %q: %v", gotBody, err)
+	}
+	if got := rawJSONString(payload["model"]); got != "gpt-upstream" {
+		t.Fatalf("upstream model = %q, want gpt-upstream; body=%s", got, gotBody)
+	}
+}
+
 func TestHandleOpenAIChatCompletionsUpstreamError(t *testing.T) {
 	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -12863,6 +12907,34 @@ func TestOpenAIChatCompletionsNormalizesMissingTopLevelFields(t *testing.T) {
 
 	if _, ok := raw["copilot_usage"]; !ok {
 		t.Fatal("copilot_usage was not preserved")
+	}
+}
+
+func TestOpenAIChatCompletionsRepairsZeroCreatedAndTotalTokens(t *testing.T) {
+	handler := newTestProxyHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-zeroes","object":"chat.completion","created":0,"model":"gpt-4","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":0}}`)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}`))
+	w := httptest.NewRecorder()
+	handler.HandleOpenAIChatCompletions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Created int64              `json:"created"`
+		Usage   models.OpenAIUsage `json:"usage"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Created == 0 {
+		t.Fatal("created = 0, want normalized timestamp")
+	}
+	if response.Usage.PromptTokens != 2 || response.Usage.CompletionTokens != 3 || response.Usage.TotalTokens != 5 {
+		t.Fatalf("usage = %+v, want 2/3/5", response.Usage)
 	}
 }
 

--- a/proxy/lifecycle_test.go
+++ b/proxy/lifecycle_test.go
@@ -28,11 +28,79 @@ func TestNewProxyHandlerInitializesLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProxyHandler() error = %v", err)
 	}
-	if handler.lifecycleCtx == nil || handler.lifecycleCancel == nil {
+	if handler.lifecycleCtx == nil || handler.retryTrackedLifecycleCtx == nil || handler.lifecycleCancel == nil {
 		t.Fatal("NewProxyHandler() did not initialize the lifecycle context")
 	}
 	if err := handler.lifecycleCtx.Err(); err != nil {
 		t.Fatalf("new lifecycle context error = %v, want active context", err)
+	}
+	if !isRetryStatsTracked(handler.retryTrackedLifecycleCtx) {
+		t.Fatal("tracked lifecycle context is missing its retry-stats marker")
+	}
+}
+
+func TestRequestBodyLifecycleBindingPreservesFirstCause(t *testing.T) {
+	t.Run("client cancellation before shutdown", func(t *testing.T) {
+		handler := &ProxyHandler{}
+		ctx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+		req.Body = &fixedErrorReadCloser{err: context.Canceled}
+		binding := handler.BindRequestBodyToLifecycle(req, nil)
+		defer binding.Release()
+
+		cancel()
+		handler.BeginShutdown()
+		_, err := req.Body.Read(make([]byte, 1))
+		if !errors.Is(err, context.Canceled) || errors.Is(err, errProxyLifecycleShutdown) {
+			t.Fatalf("Read() error = %v, want client context cancellation", err)
+		}
+	})
+
+	t.Run("shutdown before client cancellation", func(t *testing.T) {
+		handler := &ProxyHandler{}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+		req.Body = &fixedErrorReadCloser{err: context.Canceled}
+		binding := handler.BindRequestBodyToLifecycle(req, nil)
+		defer binding.Release()
+
+		handler.BeginShutdown()
+		cancel()
+		_, err := req.Body.Read(make([]byte, 1))
+		if !errors.Is(err, errProxyLifecycleShutdown) {
+			t.Fatalf("Read() error = %v, want lifecycle shutdown cause", err)
+		}
+	})
+
+	t.Run("completed binding before shutdown", func(t *testing.T) {
+		handler := &ProxyHandler{}
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		req.Body = &fixedErrorReadCloser{err: context.Canceled}
+		binding := handler.BindRequestBodyToLifecycle(req, nil)
+		binding.Release()
+
+		handler.BeginShutdown()
+		_, err := req.Body.Read(make([]byte, 1))
+		if !errors.Is(err, context.Canceled) || errors.Is(err, errProxyLifecycleShutdown) {
+			t.Fatalf("Read() error = %v, want completed binding to retain original error", err)
+		}
+	})
+}
+
+func TestRequestBodyLifecycleBindingReleaseAndRecycleRestoresOriginalBody(t *testing.T) {
+	handler := &ProxyHandler{}
+	original := io.NopCloser(strings.NewReader("request body"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Body = original
+	binding := handler.BindRequestBodyToLifecycle(req, nil)
+	if req.Body == original {
+		t.Fatal("BindRequestBodyToLifecycle() did not install a wrapper")
+	}
+
+	binding.ReleaseAndRecycle(req)
+	if req.Body != original {
+		t.Fatal("ReleaseAndRecycle() did not restore the original request body")
 	}
 }
 

--- a/proxy/model_routes.go
+++ b/proxy/model_routes.go
@@ -33,11 +33,12 @@ type providerRequestPolicy struct {
 }
 
 type targetBinding struct {
-	id            string
-	provider      *providerRuntime
-	upstreamModel string
-	wirePolicy    providerRequestPolicy
-	legacyOwner   providerModel
+	id                string
+	provider          *providerRuntime
+	upstreamModel     string
+	upstreamModelJSON json.RawMessage
+	wirePolicy        providerRequestPolicy
+	legacyOwner       providerModel
 }
 
 type routePolicy struct {
@@ -203,6 +204,29 @@ func (r *modelRouteRegistry) lookupPublicModelEntry(model string) (*publicModelE
 		return nil, false
 	}
 	return r.publicEntries.lookup(model)
+}
+
+// internExactPublicModel returns immutable registry storage for an exact public
+// model ID. Converting raw bytes directly in the map lookup does not allocate;
+// normalized aliases and unknown IDs deliberately retain their owned-string
+// fallback at the request boundary.
+func (ps *providerSetup) internExactPublicModel(raw []byte) (string, bool) {
+	if ps == nil || len(raw) == 0 {
+		return "", false
+	}
+	registry := ps.routeRegistry()
+	if registry == nil {
+		return "", false
+	}
+	snapshot := registry.load()
+	if snapshot == nil || snapshot.publicEntries == nil {
+		return "", false
+	}
+	entry, ok := snapshot.publicEntries.byID[string(raw)]
+	if !ok || entry == nil || entry.id == "" {
+		return "", false
+	}
+	return entry.id, true
 }
 
 func (r *modelRouteRegistry) lookupTerminalRoute(routeID string) (*modelRoute, bool) {
@@ -433,16 +457,20 @@ func compileLegacyModelRoute(model providerModel, provider *providerRuntime) (*m
 			},
 		},
 		targets: []targetBinding{{
-			id:            targetID,
-			provider:      provider,
-			upstreamModel: model.upstreamModel,
+			id:                targetID,
+			provider:          provider,
+			upstreamModel:     model.upstreamModel,
+			upstreamModelJSON: encodeProviderModelJSON(model.upstreamModel),
 			wirePolicy: providerRequestPolicy{
 				parallelToolCalls:      cloneBoolPtr(model.parallelToolCalls),
 				dropSamplingParams:     model.dropSamplingParams,
 				dropStopSequences:      model.dropStopSequences,
 				useMaxCompletionTokens: model.useMaxCompletionTokens,
 			},
-			legacyOwner: model,
+			// Seal catalog-owned slices and pointers once when the immutable
+			// registry snapshot is built. Request routing can then reuse this
+			// owner without cloning it on every native Chat request.
+			legacyOwner: cloneProviderModelForRoute(model),
 		}},
 		policy: routePolicy{
 			mode:              routeModePrimaryOnly,
@@ -530,6 +558,12 @@ func providerModelFromRouteTarget(route *modelRoute, target targetBinding) provi
 		if owner.upstreamModel == "" {
 			owner.upstreamModel = target.upstreamModel
 		}
+		if len(owner.upstreamModelJSON) == 0 {
+			owner.upstreamModelJSON = target.upstreamModelJSON
+			if len(owner.upstreamModelJSON) == 0 {
+				owner.upstreamModelJSON = encodeProviderModelJSON(owner.upstreamModel)
+			}
+		}
 		return owner
 	}
 	parallelToolCalls := route.public.policy.parallelToolCalls
@@ -539,6 +573,7 @@ func providerModelFromRouteTarget(route *modelRoute, target targetBinding) provi
 	owner := providerModel{
 		publicID:               route.public.id,
 		upstreamModel:          target.upstreamModel,
+		upstreamModelJSON:      target.upstreamModelJSON,
 		supportedEndpoints:     append([]string(nil), route.public.endpoints...),
 		parallelToolCalls:      cloneBoolPtr(parallelToolCalls),
 		dropSamplingParams:     route.public.policy.dropSamplingParams,

--- a/proxy/model_routes_config.go
+++ b/proxy/model_routes_config.go
@@ -1208,9 +1208,10 @@ func compileExplicitModelRoutes(cfg ProvidersConfig, providers map[string]*provi
 				return nil, configPathError(fmt.Sprintf("model_routes[%d].targets[%d].provider", routeIndex, targetIndex), "references unknown provider %q", targetCfg.Provider)
 			}
 			targets = append(targets, targetBinding{
-				id:            targetCfg.ID,
-				provider:      provider,
-				upstreamModel: targetCfg.UpstreamModel,
+				id:                targetCfg.ID,
+				provider:          provider,
+				upstreamModel:     targetCfg.UpstreamModel,
+				upstreamModelJSON: encodeProviderModelJSON(targetCfg.UpstreamModel),
 				wirePolicy: providerRequestPolicy{
 					useMaxCompletionTokens: targetCfg.UseMaxCompletionTokens != nil && *targetCfg.UseMaxCompletionTokens,
 				},

--- a/proxy/policy_responses.go
+++ b/proxy/policy_responses.go
@@ -110,7 +110,8 @@ func (h *ProxyHandler) handlePolicyResponses(w http.ResponseWriter, r *http.Requ
 		writePolicyResponsesExecutionError(w, err, publicModel)
 		return
 	}
-	observeUpstreamHeaders(r.Context(), result.Headers)
+	upstreamHeaders := chatExecutionUpstreamHeaders(result)
+	observeUpstreamHeaders(r.Context(), upstreamHeaders)
 	completion.Model = publicModel
 	observeOpenAIUsage(r.Context(), completion.Usage)
 	h.maybeRewriteOrCaptureOpenAIChatToolCommands(r.Context(), completion, h.toolContexts, toolScope, false)
@@ -120,7 +121,7 @@ func (h *ProxyHandler) handlePolicyResponses(w http.ResponseWriter, r *http.Requ
 		writeOpenAIError(w, http.StatusBadGateway, "failed to translate policy response", "server_error")
 		return
 	}
-	if safeHeaders := policyChatSafeHeaders(result.Headers, publicModel); len(safeHeaders) > 0 {
+	if safeHeaders := policyChatSafeHeaders(upstreamHeaders, publicModel); len(safeHeaders) > 0 {
 		mergeHeaderValues(w.Header(), safeHeaders)
 	}
 	if err := writePolicyResponsesResult(w, response, translated.Stream); err != nil && h.log != nil {

--- a/proxy/policy_responses_ingress_test.go
+++ b/proxy/policy_responses_ingress_test.go
@@ -141,12 +141,14 @@ func TestPolicyResponsesIngressAllowsResolvedPolicyAliasWithinLaunchScope(t *tes
 	}
 
 	recorder := httptest.NewRecorder()
-	h.HandleResponses(recorder, httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+	ctx, summary := WithRequestSummary(t.Context())
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
 		"model":"coding-economy-20260717",
 		"input":"say ok",
 		"store":false,
 		"stream":false
-	}`)))
+	}`)).WithContext(ctx)
+	h.HandleResponses(recorder, request)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
 	}
@@ -158,6 +160,12 @@ func TestPolicyResponsesIngressAllowsResolvedPolicyAliasWithinLaunchScope(t *tes
 	}
 	if response.Model != "coding-economy-20260717" {
 		t.Fatalf("response model=%q, want canonical policy id", response.Model)
+	}
+	summary.mu.Lock()
+	upstreamRequestID := summary.upstreamRequestID
+	summary.mu.Unlock()
+	if upstreamRequestID != "terminal-provider-region-request" {
+		t.Fatalf("upstream request ID = %q, want terminal-provider-region-request", upstreamRequestID)
 	}
 }
 

--- a/proxy/policy_routing.go
+++ b/proxy/policy_routing.go
@@ -911,7 +911,7 @@ func newRoutePolicyClassifier(h *ProxyHandler, route *modelRoute, profile Policy
 }
 
 func (h *ProxyHandler) sendPolicyClassifierNativeChat(ctx context.Context, target targetBinding, owner providerModel, body []byte, headers http.Header) (policyClassifierHTTPResponse, error) {
-	req, err := h.newProviderJSONRequest(ctx, target.provider, http.MethodPost, providerEndpointChatCompletions, body, headers, "", owner)
+	req, err := h.newProviderJSONInferenceRequest(ctx, target.provider, http.MethodPost, providerEndpointChatCompletions, body, headers, "", owner)
 	if err != nil {
 		return policyClassifierHTTPResponse{}, newPolicyClassifierSendError(err, true)
 	}
@@ -960,7 +960,7 @@ func (h *ProxyHandler) sendPolicyClassifierOverResponses(ctx context.Context, ro
 	if err := validatePolicyClassifierNoStore(requestBody, target.provider); err != nil {
 		return policyClassifierHTTPResponse{}, err
 	}
-	req, err := h.newProviderJSONRequest(ctx, target.provider, http.MethodPost, providerEndpointResponses, requestBody, headers, "", owner)
+	req, err := h.newProviderJSONInferenceRequest(ctx, target.provider, http.MethodPost, providerEndpointResponses, requestBody, headers, "", owner)
 	if err != nil {
 		return policyClassifierHTTPResponse{}, newPolicyClassifierSendError(err, true)
 	}

--- a/proxy/provider_endpoint_policy.go
+++ b/proxy/provider_endpoint_policy.go
@@ -15,6 +15,13 @@ type providerEndpointPolicy struct {
 	allowAnyDiscoveredModelEntry bool
 }
 
+var (
+	providerEndpointsResponsesOnly = []string{providerEndpointResponses}
+	providerEndpointsChatOnly      = []string{providerEndpointChatCompletions}
+	providerEndpointsMessagesOnly  = []string{providerEndpointMessages}
+	providerEndpointsOpenAI        = []string{providerEndpointChatCompletions, providerEndpointResponses}
+)
+
 func providerEndpointPolicyFor(kind providerType) providerEndpointPolicy {
 	paths := providerEndpointPaths{
 		chatCompletions: providerEndpointChatCompletions,
@@ -29,34 +36,34 @@ func providerEndpointPolicyFor(kind providerType) providerEndpointPolicy {
 		paths.messages = ""
 		return providerEndpointPolicy{
 			defaultPaths:             paths,
-			staticModelEndpoints:     endpointList(providerEndpointResponses),
-			dynamicModelEndpoints:    endpointList(providerEndpointResponses),
-			routedRequestEndpoints:   endpointList(providerEndpointResponses),
-			unknownModelEndpoints:    endpointList(providerEndpointResponses),
-			discoveredModelEndpoints: endpointList(providerEndpointResponses),
+			staticModelEndpoints:     providerEndpointsResponsesOnly,
+			dynamicModelEndpoints:    providerEndpointsResponsesOnly,
+			routedRequestEndpoints:   providerEndpointsResponsesOnly,
+			unknownModelEndpoints:    providerEndpointsResponsesOnly,
+			discoveredModelEndpoints: providerEndpointsResponsesOnly,
 		}
 	case providerTypeOpenAICompatible:
 		return providerEndpointPolicy{
 			defaultPaths:                 paths,
-			staticModelEndpoints:         endpointList(providerEndpointChatCompletions),
-			dynamicModelEndpoints:        endpointList(providerEndpointChatCompletions),
-			routedRequestEndpoints:       endpointList(providerEndpointChatCompletions, providerEndpointResponses),
-			unknownModelEndpoints:        endpointList(providerEndpointChatCompletions),
+			staticModelEndpoints:         providerEndpointsChatOnly,
+			dynamicModelEndpoints:        providerEndpointsChatOnly,
+			routedRequestEndpoints:       providerEndpointsOpenAI,
+			unknownModelEndpoints:        providerEndpointsChatOnly,
 			allowAnyDiscoveredModelEntry: true,
 		}
 	case providerTypeAnthropicCompatible:
 		return providerEndpointPolicy{
 			defaultPaths:             paths,
-			staticModelEndpoints:     endpointList(providerEndpointMessages),
-			dynamicModelEndpoints:    endpointList(providerEndpointMessages),
-			routedRequestEndpoints:   endpointList(providerEndpointMessages),
-			unknownModelEndpoints:    endpointList(providerEndpointMessages),
-			discoveredModelEndpoints: endpointList(providerEndpointMessages),
+			staticModelEndpoints:     providerEndpointsMessagesOnly,
+			dynamicModelEndpoints:    providerEndpointsMessagesOnly,
+			routedRequestEndpoints:   providerEndpointsMessagesOnly,
+			unknownModelEndpoints:    providerEndpointsMessagesOnly,
+			discoveredModelEndpoints: providerEndpointsMessagesOnly,
 		}
 	case providerTypeCopilot:
 		return providerEndpointPolicy{
 			defaultPaths:                 paths,
-			staticModelEndpoints:         endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			staticModelEndpoints:         providerEndpointsOpenAI,
 			allowAnyRoutedRequest:        true,
 			allowAnyUnknownModel:         true,
 			allowAnyDiscoveredModelEntry: true,
@@ -64,7 +71,7 @@ func providerEndpointPolicyFor(kind providerType) providerEndpointPolicy {
 	case providerTypeAzureOpenAI:
 		return providerEndpointPolicy{
 			defaultPaths:                 paths,
-			staticModelEndpoints:         endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			staticModelEndpoints:         providerEndpointsOpenAI,
 			allowAnyRoutedRequest:        true,
 			allowAnyUnknownModel:         true,
 			allowAnyDiscoveredModelEntry: true,
@@ -72,7 +79,7 @@ func providerEndpointPolicyFor(kind providerType) providerEndpointPolicy {
 	default:
 		return providerEndpointPolicy{
 			defaultPaths:                 paths,
-			staticModelEndpoints:         endpointList(providerEndpointChatCompletions, providerEndpointResponses),
+			staticModelEndpoints:         providerEndpointsOpenAI,
 			allowAnyRoutedRequest:        true,
 			allowAnyUnknownModel:         true,
 			allowAnyDiscoveredModelEntry: true,

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -139,6 +139,7 @@ type providerRuntime struct {
 	authType                   providerAuthType
 	authHeader                 string
 	authPrefix                 string
+	authValue                  string
 	extraHeaders               http.Header
 	paths                      providerEndpointPaths
 	modelDiscovery             providerModelDiscovery
@@ -150,6 +151,8 @@ type providerRuntime struct {
 	staticModels               map[string]providerModel
 	staticConfigs              map[string]ProviderModelConfig
 	staticOrder                []string
+	postRequestTemplates       map[string]*http.Request
+	postRequestAutoGzip        bool
 	codexAuth                  *openAICodexAuth
 	headerProfiles             CopilotHeaderProfilesConfig
 }
@@ -164,6 +167,7 @@ type providerEndpointPaths struct {
 type providerModel struct {
 	publicID               string
 	upstreamModel          string
+	upstreamModelJSON      json.RawMessage
 	providerID             string
 	supportedEndpoints     []string
 	parallelToolCalls      *bool
@@ -1324,6 +1328,7 @@ func buildProviderRuntimeForProvidersConfig(cfg ProviderConfig, defaultCopilotUR
 		runtime.authHeader = authHeader
 		runtime.authPrefix = authPrefix
 		runtime.apiKey = apiKey
+		runtime.authValue = genericProviderAuthValue(authPrefix, apiKey)
 		runtime.extraHeaders = extraHeaders
 		runtime.modelDiscovery = modelDiscovery
 
@@ -1335,6 +1340,9 @@ func buildProviderRuntimeForProvidersConfig(cfg ProviderConfig, defaultCopilotUR
 		}
 	}
 
+	if err := sealProviderRequestTemplates(runtime); err != nil {
+		return nil, err
+	}
 	return runtime, nil
 }
 
@@ -1726,6 +1734,7 @@ func buildStaticProviderModel(providerID string, cfg ProviderModelConfig, defaul
 	return providerModel{
 		publicID:               publicID,
 		upstreamModel:          upstreamModel,
+		upstreamModelJSON:      encodeProviderModelJSON(upstreamModel),
 		providerID:             providerID,
 		supportedEndpoints:     endpoints,
 		parallelToolCalls:      cloneBoolPtr(cfg.ParallelToolCalls),
@@ -2153,6 +2162,10 @@ func rewriteRequestModelForProvider(body []byte, upstreamModel string) ([]byte, 
 }
 
 func rewriteRequestModelForProviderFromModel(body []byte, currentModel string, upstreamModel string) ([]byte, bool, error) {
+	return rewriteRequestModelForProviderFromModelJSON(body, currentModel, upstreamModel, nil)
+}
+
+func rewriteRequestModelForProviderFromModelJSON(body []byte, currentModel string, upstreamModel string, rawModel json.RawMessage) ([]byte, bool, error) {
 	upstreamModel = strings.TrimSpace(upstreamModel)
 	if upstreamModel == "" {
 		return body, false, nil
@@ -2162,10 +2175,33 @@ func rewriteRequestModelForProviderFromModel(body []byte, currentModel string, u
 	if currentModel == "" || currentModel == upstreamModel {
 		return body, false, nil
 	}
+	if len(rawModel) == 0 {
+		var err error
+		rawModel, err = json.Marshal(upstreamModel)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	if rewritten, ok := replaceSingleTopLevelRawJSONField(body, "model", rawModel); ok {
+		return rewritten, true, nil
+	}
 	return rewriteResponsesRequestModel(body, upstreamModel)
 }
 
+func encodeProviderModelJSON(model string) json.RawMessage {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	raw, _ := json.Marshal(model)
+	return raw
+}
+
 func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string, extraQuery string, owners ...providerModel) (string, error) {
+	return buildProviderRequestURL(provider, path, extraQuery, owners...)
+}
+
+func buildProviderRequestURL(provider *providerRuntime, path string, extraQuery string, owners ...providerModel) (string, error) {
 	if provider == nil {
 		return "", fmt.Errorf("provider is required")
 	}
@@ -2203,6 +2239,126 @@ func (h *ProxyHandler) providerRequestURL(provider *providerRuntime, path string
 		return appendRawQuery(fullURL, extraQuery), nil
 	}
 	return appendRawQuery(fullURL, appendQuery("api-version="+url.QueryEscape(provider.apiVersion), extraQuery)), nil
+}
+
+func sealProviderRequestTemplates(provider *providerRuntime) error {
+	if provider == nil || (provider.kind != providerTypeOpenAICompatible && provider.kind != providerTypeAnthropicCompatible) {
+		return nil
+	}
+	headers, err := sealedGenericProviderJSONHeaders(provider)
+	if err != nil {
+		return err
+	}
+	autoGzip := headers.Get("Accept-Encoding") == ""
+	if autoGzip {
+		headers["Accept-Encoding"] = []string{"gzip"}
+	}
+	templates := make(map[string]*http.Request, 4)
+	for _, endpoint := range []string{
+		providerEndpointChatCompletions,
+		providerEndpointResponses,
+		providerEndpointMessages,
+		providerEndpointMessagesCount,
+	} {
+		fullURL, err := buildProviderRequestURL(provider, endpoint, "")
+		if err != nil {
+			return err
+		}
+		template, err := http.NewRequest(http.MethodPost, fullURL, nil)
+		if err != nil {
+			return fmt.Errorf("provider %q build request template for %s: %w", provider.id, endpoint, err)
+		}
+		template.Header = headers
+		templates[endpoint] = template
+	}
+	provider.postRequestTemplates = templates
+	provider.postRequestAutoGzip = autoGzip
+	return nil
+}
+
+func sealedGenericProviderJSONHeaders(provider *providerRuntime) (http.Header, error) {
+	headers := make(http.Header, len(provider.extraHeaders)+3)
+	for key, values := range provider.extraHeaders {
+		cloned := append([]string(nil), values...)
+		headers[key] = cloned[:len(cloned):len(cloned)]
+	}
+	switch provider.authType {
+	case providerAuthTypeNone, "":
+	case providerAuthTypeBearer, providerAuthTypeAPIKeyHeader:
+		if strings.TrimSpace(provider.apiKey) == "" {
+			return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no API key configured", provider.id)}
+		}
+		header := strings.TrimSpace(provider.authHeader)
+		if header == "" {
+			return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no auth header configured", provider.id)}
+		}
+		headers.Set(header, provider.authValue)
+	default:
+		return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("unsupported auth type %q", provider.authType)}
+	}
+	headers.Set("Content-Type", "application/json")
+	return headers, nil
+}
+
+func shallowCloneHeader(src http.Header) http.Header {
+	dst := make(http.Header, len(src))
+	for key, values := range src {
+		dst[key] = values
+	}
+	return dst
+}
+
+type providerRequestBody struct {
+	bytes.Reader
+	route              providerRouteInfo
+	autoDecompressGzip bool
+}
+
+func newProviderRequestBody(body []byte, route providerRouteInfo, autoDecompressGzip bool) *providerRequestBody {
+	reader := &providerRequestBody{route: route, autoDecompressGzip: autoDecompressGzip}
+	reader.Reset(body)
+	return reader
+}
+
+func (*providerRequestBody) Close() error {
+	return nil
+}
+
+func requestFromProviderTemplate(ctx context.Context, template *http.Request, body []byte, reuseSealedHeaders bool, route providerRouteInfo, autoDecompressGzip bool) *http.Request {
+	req := template.WithContext(ctx)
+	if !reuseSealedHeaders {
+		req.Header = shallowCloneHeader(template.Header)
+	}
+	if len(body) == 0 {
+		if autoDecompressGzip {
+			if reuseSealedHeaders {
+				req.Header = shallowCloneHeader(template.Header)
+			}
+			req.Header.Del("Accept-Encoding")
+		}
+		return req
+	}
+	reader := newProviderRequestBody(body, route, autoDecompressGzip)
+	req.Body = reader
+	req.ContentLength = int64(len(body))
+	if reuseSealedHeaders {
+		// Inference retries rebuild the whole request through their factory. Keep
+		// GetBody nil so net/http cannot create an unbudgeted transparent replay.
+		return req
+	}
+	snapshot := reader.Reader
+	req.GetBody = func() (io.ReadCloser, error) {
+		return &providerRequestBody{Reader: snapshot, route: route, autoDecompressGzip: autoDecompressGzip}, nil
+	}
+	return req
+}
+
+func providerRequestAutoDecompressGzip(req *http.Request) bool {
+	if req == nil || req.Body == nil {
+		return false
+	}
+	body, ok := req.Body.(*providerRequestBody)
+	return ok && body != nil && body.autoDecompressGzip
 }
 
 func azureClassicOpenAIBaseURL(baseURL string, baseKind azureBaseURLKind) string {
@@ -2401,15 +2557,23 @@ func applyGenericProviderAuth(req *http.Request, provider *providerRuntime) erro
 		if header == "" {
 			return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider %q has no auth header configured", provider.id)}
 		}
-		value := provider.apiKey
-		if prefix := strings.TrimSpace(provider.authPrefix); prefix != "" {
-			value = prefix + " " + value
+		value := provider.authValue
+		if value == "" {
+			value = genericProviderAuthValue(provider.authPrefix, provider.apiKey)
 		}
 		req.Header.Set(header, value)
 		return nil
 	default:
 		return &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("unsupported auth type %q", provider.authType)}
 	}
+}
+
+func genericProviderAuthValue(prefix, apiKey string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return apiKey
+	}
+	return prefix + " " + apiKey
 }
 
 type providerRouteContextKey struct{}
@@ -2457,27 +2621,62 @@ func providerRouteFromResponse(resp *http.Response) (providerRouteInfo, bool) {
 	if resp == nil || resp.Request == nil {
 		return providerRouteInfo{}, false
 	}
-	route, ok := resp.Request.Context().Value(providerRouteContextKey{}).(providerRouteInfo)
+	return providerRouteFromRequest(resp.Request)
+}
+
+func providerRouteFromRequest(req *http.Request) (providerRouteInfo, bool) {
+	if req == nil {
+		return providerRouteInfo{}, false
+	}
+	if body, ok := req.Body.(*providerRequestBody); ok && body != nil && body.route.id != "" {
+		return body.route, true
+	}
+	route, ok := req.Context().Value(providerRouteContextKey{}).(providerRouteInfo)
 	return route, ok && route.id != ""
 }
 
 func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, owners ...providerModel) (*http.Request, error) {
+	return h.newProviderJSONRequestWithTemplateHeaders(ctx, provider, method, path, body, extraHeaders, extraQuery, false, owners...)
+}
+
+// newProviderJSONInferenceRequest may reuse the immutable header map sealed on
+// a configured generic provider's request template. RoundTripper implementations
+// must not mutate requests, and inference retries call the factory again, so the
+// common path does not need a per-attempt header-map clone.
+func (h *ProxyHandler) newProviderJSONInferenceRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, owners ...providerModel) (*http.Request, error) {
+	return h.newProviderJSONRequestWithTemplateHeaders(ctx, provider, method, path, body, extraHeaders, extraQuery, true, owners...)
+}
+
+func (h *ProxyHandler) newProviderJSONRequestWithTemplateHeaders(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, reuseSealedHeaders bool, owners ...providerModel) (*http.Request, error) {
 	route := providerRouteInfo{id: provider.id, kind: string(provider.kind)}
 	// Route selection has already happened before URL construction or provider
 	// authentication. Publish it now so failures in either step retain the actual
 	// provider attribution even if the dynamic model catalog changes afterward.
 	publishProviderRoute(ctx, route)
+	if method == http.MethodPost && len(extraHeaders) == 0 && extraQuery == "" {
+		if template := provider.postRequestTemplates[path]; template != nil {
+			// Inference sends go directly through the RoundTripper, which preserves
+			// the request body object on resp.Request. Store route attribution there
+			// and avoid a separate context layer on this common path. General Client
+			// requests retain the context fallback because redirect bookkeeping may
+			// wrap or replace their bodies.
+			if reuseSealedHeaders && len(body) > 0 {
+				return requestFromProviderTemplate(ctx, template, body, reuseSealedHeaders, route, provider.postRequestAutoGzip), nil
+			}
+			ctx = context.WithValue(ctx, providerRouteContextKey{}, route)
+			return requestFromProviderTemplate(ctx, template, body, reuseSealedHeaders, route, provider.postRequestAutoGzip), nil
+		}
+	}
+	ctx = context.WithValue(ctx, providerRouteContextKey{}, route)
+
 	fullURL, err := h.providerRequestURL(provider, path, extraQuery, owners...)
 	if err != nil {
 		return nil, err
 	}
-
 	var bodyReader io.Reader
 	if len(body) > 0 {
 		bodyReader = bytes.NewReader(body)
 	}
-
-	ctx = context.WithValue(ctx, providerRouteContextKey{}, route)
 	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
 	if err != nil {
 		return nil, err

--- a/proxy/providers.go
+++ b/proxy/providers.go
@@ -2644,7 +2644,14 @@ func (h *ProxyHandler) newProviderJSONRequest(ctx context.Context, provider *pro
 // must not mutate requests, and inference retries call the factory again, so the
 // common path does not need a per-attempt header-map clone.
 func (h *ProxyHandler) newProviderJSONInferenceRequest(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, owners ...providerModel) (*http.Request, error) {
-	return h.newProviderJSONRequestWithTemplateHeaders(ctx, provider, method, path, body, extraHeaders, extraQuery, true, owners...)
+	req, err := h.newProviderJSONRequestWithTemplateHeaders(ctx, provider, method, path, body, extraHeaders, extraQuery, true, owners...)
+	if err == nil && req != nil {
+		// Inference retries reserve every physical send explicitly. Disable the
+		// transparent transport replay that NewRequest enables for byte readers,
+		// including fallback paths that cannot use a sealed request template.
+		req.GetBody = nil
+	}
+	return req, err
 }
 
 func (h *ProxyHandler) newProviderJSONRequestWithTemplateHeaders(ctx context.Context, provider *providerRuntime, method, path string, body []byte, extraHeaders http.Header, extraQuery string, reuseSealedHeaders bool, owners ...providerModel) (*http.Request, error) {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -691,6 +691,25 @@ func TestBuildProvidersGenericOpenAICompatibleConfig(t *testing.T) {
 	if err != nil || !reflect.DeepEqual(inferenceBody, body) {
 		t.Fatalf("inference body = %q, %v; want %q", inferenceBody, err, body)
 	}
+	fallbackInference, err := handler.newProviderJSONInferenceRequest(
+		context.Background(),
+		provider,
+		http.MethodPost,
+		providerEndpointChatCompletions,
+		body,
+		http.Header{"Idempotency-Key": []string{"request-1"}},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("fallback newProviderJSONInferenceRequest() error = %v", err)
+	}
+	if fallbackInference.GetBody != nil {
+		t.Fatal("fallback inference request GetBody is non-nil; transport replay must remain disabled")
+	}
+	if got := fallbackInference.Header.Get("Idempotency-Key"); got != "request-1" {
+		t.Fatalf("fallback inference Idempotency-Key = %q, want request-1", got)
+	}
+	_ = fallbackInference.Body.Close()
 
 	bodyless, err := handler.newProviderJSONInferenceRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, nil, nil, "")
 	if err != nil {

--- a/proxy/providers_config_test.go
+++ b/proxy/providers_config_test.go
@@ -610,6 +610,9 @@ func TestBuildProvidersGenericOpenAICompatibleConfig(t *testing.T) {
 	if provider.apiKey != "generic-key" {
 		t.Fatalf("apiKey = %q, want generic-key", provider.apiKey)
 	}
+	if provider.authValue != "Token generic-key" {
+		t.Fatalf("authValue = %q, want Token generic-key", provider.authValue)
+	}
 	if got := provider.extraHeaders.Get("X-Provider"); got != "local" {
 		t.Fatalf("extra header X-Provider = %q, want local", got)
 	}
@@ -619,6 +622,12 @@ func TestBuildProvidersGenericOpenAICompatibleConfig(t *testing.T) {
 	if provider.modelDiscovery != providerModelDiscoveryOllama {
 		t.Fatalf("modelDiscovery = %q, want ollama", provider.modelDiscovery)
 	}
+	if !provider.postRequestAutoGzip {
+		t.Fatal("postRequestAutoGzip = false, want automatic gzip for sealed provider requests")
+	}
+	if got := provider.postRequestTemplates[providerEndpointChatCompletions].Header.Get("Accept-Encoding"); got != "gzip" {
+		t.Fatalf("sealed request Accept-Encoding = %q, want gzip", got)
+	}
 
 	model := provider.staticModels["local-chat"]
 	if model.publicID != "local-chat" || model.upstreamModel != "llama3.2:latest" {
@@ -626,6 +635,116 @@ func TestBuildProvidersGenericOpenAICompatibleConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(model.supportedEndpoints, []string{"/chat/completions"}) {
 		t.Fatalf("default openai-compatible endpoints = %v, want [/chat/completions]", model.supportedEndpoints)
+	}
+
+	body := []byte(`{"model":"local-chat"}`)
+	first, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, body, nil, "")
+	if err != nil {
+		t.Fatalf("newProviderJSONRequest() error = %v", err)
+	}
+	if got := first.URL.String(); got != "http://localhost:1234/v1/chat/completions" {
+		t.Fatalf("request URL = %q, want configured Chat URL", got)
+	}
+	if got := first.Header.Get("X-Api-Key"); got != "Token generic-key" {
+		t.Fatalf("request X-Api-Key = %q, want Token generic-key", got)
+	}
+	if got := first.Header.Get("X-Provider"); got != "local" {
+		t.Fatalf("request X-Provider = %q, want local", got)
+	}
+	if first.GetBody == nil {
+		t.Fatal("request GetBody = nil, want replayable configured-provider body")
+	}
+	replay, err := first.GetBody()
+	if err != nil {
+		t.Fatalf("request GetBody() error = %v", err)
+	}
+	replayed, err := io.ReadAll(replay)
+	_ = replay.Close()
+	if err != nil || !reflect.DeepEqual(replayed, body) {
+		t.Fatalf("replayed body = %q, %v; want %q", replayed, err, body)
+	}
+
+	first.Header.Set("X-Api-Key", "mutated")
+	second, err := handler.newProviderJSONRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, body, nil, "")
+	if err != nil {
+		t.Fatalf("second newProviderJSONRequest() error = %v", err)
+	}
+	if got := second.Header.Get("X-Api-Key"); got != "Token generic-key" {
+		t.Fatalf("second request X-Api-Key = %q after first mutation, want Token generic-key", got)
+	}
+
+	inference, err := handler.newProviderJSONInferenceRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, body, nil, "")
+	if err != nil {
+		t.Fatalf("newProviderJSONInferenceRequest() error = %v", err)
+	}
+	if got := inference.Header.Get("Accept-Encoding"); got != "gzip" {
+		t.Fatalf("inference Accept-Encoding = %q, want gzip", got)
+	}
+	if !providerRequestAutoDecompressGzip(inference) {
+		t.Fatal("inference request did not retain automatic gzip response marker")
+	}
+	if inference.GetBody != nil {
+		t.Fatal("inference request GetBody is non-nil; transport replay must remain disabled")
+	}
+	inferenceBody, err := io.ReadAll(inference.Body)
+	_ = inference.Body.Close()
+	if err != nil || !reflect.DeepEqual(inferenceBody, body) {
+		t.Fatalf("inference body = %q, %v; want %q", inferenceBody, err, body)
+	}
+
+	bodyless, err := handler.newProviderJSONInferenceRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, nil, nil, "")
+	if err != nil {
+		t.Fatalf("bodyless newProviderJSONInferenceRequest() error = %v", err)
+	}
+	if got := bodyless.Header.Get("Accept-Encoding"); got != "" {
+		t.Fatalf("bodyless inference Accept-Encoding = %q, want transport-managed encoding", got)
+	}
+	if bodyless.Body != nil || bodyless.ContentLength != 0 || providerRequestAutoDecompressGzip(bodyless) {
+		t.Fatalf("bodyless inference = Body %T, ContentLength %d, auto-gzip %t; want nil, 0, false", bodyless.Body, bodyless.ContentLength, providerRequestAutoDecompressGzip(bodyless))
+	}
+	if got := provider.postRequestTemplates[providerEndpointChatCompletions].Header.Get("Accept-Encoding"); got != "gzip" {
+		t.Fatalf("bodyless request mutated sealed template Accept-Encoding to %q", got)
+	}
+}
+
+func TestBuildProvidersGenericRequestPreservesOperatorAcceptEncoding(t *testing.T) {
+	handler := &ProxyHandler{copilotURL: "https://copilot.example.com"}
+	providers, _, _, err := handler.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:             "operator-encoding",
+			Type:           "openai-compatible",
+			Default:        true,
+			BaseURL:        "http://localhost:1234",
+			AuthType:       "none",
+			ExtraHeaders:   map[string]string{"Accept-Encoding": "identity"},
+			ModelDiscovery: "static",
+			Models: []ProviderModelConfig{{
+				PublicID: "local-chat",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["operator-encoding"]
+	if provider == nil {
+		t.Fatal("expected operator-encoding provider")
+	}
+	if provider.postRequestAutoGzip {
+		t.Fatal("postRequestAutoGzip = true with operator-supplied Accept-Encoding")
+	}
+
+	for _, body := range [][]byte{[]byte(`{"model":"local-chat"}`), nil} {
+		req, err := handler.newProviderJSONInferenceRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, body, nil, "")
+		if err != nil {
+			t.Fatalf("newProviderJSONInferenceRequest(body=%q) error = %v", body, err)
+		}
+		if got := req.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Fatalf("Accept-Encoding = %q, want operator value identity", got)
+		}
+		if providerRequestAutoDecompressGzip(req) {
+			t.Fatal("operator-supplied encoding enabled proxy gzip decompression")
+		}
 	}
 }
 

--- a/proxy/raw_json_fast.go
+++ b/proxy/raw_json_fast.go
@@ -1,0 +1,1003 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/sozercan/vekil/models"
+)
+
+type rawJSONObjectScanner struct {
+	data   []byte
+	pos    int
+	first  bool
+	done   bool
+	strict bool
+}
+
+// rawJSONObjectCursor exposes each value start without first walking to its
+// end. Specialized inspectors can consume known nested values directly and
+// then advance the cursor, avoiding the generic skip-then-rescan pattern used
+// by rawJSONObjectScanner.
+type rawJSONObjectCursor struct {
+	data   []byte
+	pos    int
+	first  bool
+	done   bool
+	strict bool
+}
+
+func newRawJSONObjectCursor(data []byte, pos int) (rawJSONObjectCursor, bool) {
+	pos = skipRawJSONSpace(data, pos)
+	if pos >= len(data) || data[pos] != '{' {
+		return rawJSONObjectCursor{}, false
+	}
+	return rawJSONObjectCursor{data: data, pos: pos + 1, first: true}, true
+}
+
+func (s *rawJSONObjectCursor) next() (key []byte, valueStart int, done, ok bool) {
+	if s == nil || s.done {
+		return nil, 0, true, s != nil
+	}
+	pos := skipRawJSONSpace(s.data, s.pos)
+	if pos >= len(s.data) {
+		return nil, 0, false, false
+	}
+	if s.data[pos] == '}' {
+		s.done = true
+		s.pos = pos + 1
+		return nil, 0, true, true
+	}
+	if !s.first {
+		if s.data[pos] != ',' {
+			return nil, 0, false, false
+		}
+		pos = skipRawJSONSpace(s.data, pos+1)
+	}
+	var contentStart, contentEnd, afterKey int
+	var escaped, scanOK bool
+	if s.strict {
+		contentStart, contentEnd, afterKey, escaped, scanOK = scanStrictRawJSONString(s.data, pos)
+	} else {
+		contentStart, contentEnd, afterKey, escaped, scanOK = scanRawJSONString(s.data, pos)
+	}
+	if !scanOK || escaped {
+		return nil, 0, false, false
+	}
+	pos = skipRawJSONSpace(s.data, afterKey)
+	if pos >= len(s.data) || s.data[pos] != ':' {
+		return nil, 0, false, false
+	}
+	return s.data[contentStart:contentEnd], skipRawJSONSpace(s.data, pos+1), false, true
+}
+
+func (s *rawJSONObjectCursor) advance(valueEnd int) bool {
+	if s == nil || s.done || valueEnd <= s.pos || valueEnd > len(s.data) {
+		return false
+	}
+	s.pos = valueEnd
+	s.first = false
+	return true
+}
+
+type rawJSONArrayCursor struct {
+	data  []byte
+	pos   int
+	first bool
+	done  bool
+}
+
+func newRawJSONArrayCursor(data []byte, pos int) (rawJSONArrayCursor, bool) {
+	pos = skipRawJSONSpace(data, pos)
+	if pos >= len(data) || data[pos] != '[' {
+		return rawJSONArrayCursor{}, false
+	}
+	return rawJSONArrayCursor{data: data, pos: pos + 1, first: true}, true
+}
+
+func (s *rawJSONArrayCursor) next() (valueStart int, done, ok bool) {
+	if s == nil || s.done {
+		return 0, true, s != nil
+	}
+	pos := skipRawJSONSpace(s.data, s.pos)
+	if pos >= len(s.data) {
+		return 0, false, false
+	}
+	if s.data[pos] == ']' {
+		s.done = true
+		s.pos = pos + 1
+		return 0, true, true
+	}
+	if !s.first {
+		if s.data[pos] != ',' {
+			return 0, false, false
+		}
+		pos = skipRawJSONSpace(s.data, pos+1)
+	}
+	return pos, false, true
+}
+
+func (s *rawJSONArrayCursor) advance(valueEnd int) bool {
+	if s == nil || s.done || valueEnd <= s.pos || valueEnd > len(s.data) {
+		return false
+	}
+	s.pos = valueEnd
+	s.first = false
+	return true
+}
+
+type rawJSONSingleWalkMode struct {
+	strict bool
+	depth  int
+}
+
+func (m rawJSONSingleWalkMode) object(data []byte, pos int) (rawJSONObjectCursor, bool) {
+	object, ok := newRawJSONObjectCursor(data, pos)
+	if ok {
+		object.strict = m.strict
+	}
+	return object, ok
+}
+
+func (m rawJSONSingleWalkMode) array(data []byte, pos int) (rawJSONArrayCursor, bool) {
+	return newRawJSONArrayCursor(data, pos)
+}
+
+func (m rawJSONSingleWalkMode) valueEnd(data []byte, pos int) (int, bool) {
+	if m.strict {
+		return scanStrictRawJSONValue(data, pos, m.depth)
+	}
+	return skipRawJSONValue(data, pos)
+}
+
+func (m rawJSONSingleWalkMode) child() (rawJSONSingleWalkMode, bool) {
+	if m.strict && m.depth >= maxFastRawJSONNestingDepth {
+		return rawJSONSingleWalkMode{}, false
+	}
+	m.depth++
+	return m, true
+}
+
+func newRawJSONObjectScanner(data []byte) (rawJSONObjectScanner, bool) {
+	pos := skipRawJSONSpace(data, 0)
+	if pos >= len(data) || data[pos] != '{' {
+		return rawJSONObjectScanner{}, false
+	}
+	return rawJSONObjectScanner{data: data, pos: pos + 1, first: true}, true
+}
+
+func newStrictRawJSONObjectScanner(data []byte) (rawJSONObjectScanner, bool) {
+	scanner, ok := newRawJSONObjectScanner(data)
+	if !ok {
+		return rawJSONObjectScanner{}, false
+	}
+	scanner.strict = true
+	return scanner, true
+}
+
+func (s *rawJSONObjectScanner) next() (key []byte, valueStart, valueEnd int, done, ok bool) {
+	if s == nil || s.done {
+		return nil, 0, 0, true, s != nil
+	}
+	pos := skipRawJSONSpace(s.data, s.pos)
+	if pos >= len(s.data) {
+		return nil, 0, 0, false, false
+	}
+	if s.data[pos] == '}' {
+		pos = skipRawJSONSpace(s.data, pos+1)
+		if pos != len(s.data) {
+			return nil, 0, 0, false, false
+		}
+		s.done = true
+		s.pos = pos
+		return nil, 0, 0, true, true
+	}
+	if !s.first {
+		if s.data[pos] != ',' {
+			return nil, 0, 0, false, false
+		}
+		pos = skipRawJSONSpace(s.data, pos+1)
+	}
+	var contentStart, contentEnd, afterKey int
+	var escaped, scanOK bool
+	if s.strict {
+		contentStart, contentEnd, afterKey, escaped, scanOK = scanStrictRawJSONString(s.data, pos)
+	} else {
+		contentStart, contentEnd, afterKey, escaped, scanOK = scanRawJSONString(s.data, pos)
+	}
+	if !scanOK || escaped {
+		return nil, 0, 0, false, false
+	}
+	pos = skipRawJSONSpace(s.data, afterKey)
+	if pos >= len(s.data) || s.data[pos] != ':' {
+		return nil, 0, 0, false, false
+	}
+	valueStart = skipRawJSONSpace(s.data, pos+1)
+	if s.strict {
+		valueEnd, ok = scanStrictRawJSONValue(s.data, valueStart, 1)
+	} else {
+		valueEnd, ok = skipRawJSONValue(s.data, valueStart)
+	}
+	if !ok {
+		return nil, 0, 0, false, false
+	}
+	s.pos = valueEnd
+	s.first = false
+	return s.data[contentStart:contentEnd], valueStart, valueEnd, false, true
+}
+
+type rawJSONArrayScanner struct {
+	data  []byte
+	pos   int
+	first bool
+	done  bool
+}
+
+func newRawJSONArrayScanner(data []byte) (rawJSONArrayScanner, bool) {
+	pos := skipRawJSONSpace(data, 0)
+	if pos >= len(data) || data[pos] != '[' {
+		return rawJSONArrayScanner{}, false
+	}
+	return rawJSONArrayScanner{data: data, pos: pos + 1, first: true}, true
+}
+
+func (s *rawJSONArrayScanner) next() (valueStart, valueEnd int, done, ok bool) {
+	if s == nil || s.done {
+		return 0, 0, true, s != nil
+	}
+	pos := skipRawJSONSpace(s.data, s.pos)
+	if pos >= len(s.data) {
+		return 0, 0, false, false
+	}
+	if s.data[pos] == ']' {
+		pos = skipRawJSONSpace(s.data, pos+1)
+		if pos != len(s.data) {
+			return 0, 0, false, false
+		}
+		s.done = true
+		s.pos = pos
+		return 0, 0, true, true
+	}
+	if !s.first {
+		if s.data[pos] != ',' {
+			return 0, 0, false, false
+		}
+		pos = skipRawJSONSpace(s.data, pos+1)
+	}
+	valueStart = pos
+	valueEnd, ok = skipRawJSONValue(s.data, valueStart)
+	if !ok {
+		return 0, 0, false, false
+	}
+	s.pos = valueEnd
+	s.first = false
+	return valueStart, valueEnd, false, true
+}
+
+func skipRawJSONSpace(data []byte, pos int) int {
+	for pos < len(data) {
+		switch data[pos] {
+		case ' ', '\t', '\n', '\r':
+			pos++
+		default:
+			return pos
+		}
+	}
+	return pos
+}
+
+func scanRawJSONString(data []byte, pos int) (contentStart, contentEnd, end int, escaped, ok bool) {
+	if pos >= len(data) || data[pos] != '"' {
+		return 0, 0, 0, false, false
+	}
+	contentStart = pos + 1
+	for pos = contentStart; pos < len(data); pos++ {
+		switch data[pos] {
+		case '\\':
+			escaped = true
+			pos++
+			if pos >= len(data) {
+				return 0, 0, 0, false, false
+			}
+		case '"':
+			return contentStart, pos, pos + 1, escaped, true
+		}
+	}
+	return 0, 0, 0, false, false
+}
+
+const maxFastRawJSONNestingDepth = 64
+
+func scanStrictRawJSONString(data []byte, pos int) (contentStart, contentEnd, end int, escaped, ok bool) {
+	if pos >= len(data) || data[pos] != '"' {
+		return 0, 0, 0, false, false
+	}
+	contentStart = pos + 1
+	for pos = contentStart; pos < len(data); pos++ {
+		switch data[pos] {
+		case '\\':
+			escaped = true
+			pos++
+			if pos >= len(data) {
+				return 0, 0, 0, false, false
+			}
+			switch data[pos] {
+			case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
+			case 'u':
+				if pos+4 >= len(data) {
+					return 0, 0, 0, false, false
+				}
+				for i := 1; i <= 4; i++ {
+					if !isRawJSONHex(data[pos+i]) {
+						return 0, 0, 0, false, false
+					}
+				}
+				pos += 4
+			default:
+				return 0, 0, 0, false, false
+			}
+		case '"':
+			return contentStart, pos, pos + 1, escaped, true
+		default:
+			if data[pos] < 0x20 {
+				return 0, 0, 0, false, false
+			}
+		}
+	}
+	return 0, 0, 0, false, false
+}
+
+func isRawJSONHex(value byte) bool {
+	return value >= '0' && value <= '9' || value >= 'a' && value <= 'f' || value >= 'A' && value <= 'F'
+}
+
+// scanStrictRawJSONValue validates one JSON value without allocating. It is
+// deliberately bounded more tightly than encoding/json: unusually deep valid
+// inputs fall back to the standard decoder instead of growing the Go stack on
+// the request hot path.
+func scanStrictRawJSONValue(data []byte, pos, depth int) (int, bool) {
+	pos = skipRawJSONSpace(data, pos)
+	if pos >= len(data) {
+		return 0, false
+	}
+	switch data[pos] {
+	case '"':
+		_, _, end, _, ok := scanStrictRawJSONString(data, pos)
+		return end, ok
+	case '{':
+		if depth >= maxFastRawJSONNestingDepth {
+			return 0, false
+		}
+		return scanStrictRawJSONObject(data, pos, depth+1)
+	case '[':
+		if depth >= maxFastRawJSONNestingDepth {
+			return 0, false
+		}
+		return scanStrictRawJSONArray(data, pos, depth+1)
+	case 't':
+		return scanStrictRawJSONLiteral(data, pos, "true")
+	case 'f':
+		return scanStrictRawJSONLiteral(data, pos, "false")
+	case 'n':
+		return scanStrictRawJSONLiteral(data, pos, "null")
+	default:
+		return scanStrictRawJSONNumber(data, pos)
+	}
+}
+
+func scanStrictRawJSONObject(data []byte, pos, depth int) (int, bool) {
+	pos = skipRawJSONSpace(data, pos+1)
+	if pos >= len(data) {
+		return 0, false
+	}
+	if data[pos] == '}' {
+		return pos + 1, true
+	}
+	for {
+		_, _, afterKey, _, ok := scanStrictRawJSONString(data, pos)
+		if !ok {
+			return 0, false
+		}
+		pos = skipRawJSONSpace(data, afterKey)
+		if pos >= len(data) || data[pos] != ':' {
+			return 0, false
+		}
+		pos, ok = scanStrictRawJSONValue(data, pos+1, depth)
+		if !ok {
+			return 0, false
+		}
+		pos = skipRawJSONSpace(data, pos)
+		if pos >= len(data) {
+			return 0, false
+		}
+		switch data[pos] {
+		case '}':
+			return pos + 1, true
+		case ',':
+			pos = skipRawJSONSpace(data, pos+1)
+		default:
+			return 0, false
+		}
+	}
+}
+
+func scanStrictRawJSONArray(data []byte, pos, depth int) (int, bool) {
+	pos = skipRawJSONSpace(data, pos+1)
+	if pos >= len(data) {
+		return 0, false
+	}
+	if data[pos] == ']' {
+		return pos + 1, true
+	}
+	for {
+		var ok bool
+		pos, ok = scanStrictRawJSONValue(data, pos, depth)
+		if !ok {
+			return 0, false
+		}
+		pos = skipRawJSONSpace(data, pos)
+		if pos >= len(data) {
+			return 0, false
+		}
+		switch data[pos] {
+		case ']':
+			return pos + 1, true
+		case ',':
+			pos = skipRawJSONSpace(data, pos+1)
+		default:
+			return 0, false
+		}
+	}
+}
+
+func scanStrictRawJSONLiteral(data []byte, pos int, literal string) (int, bool) {
+	if len(data)-pos < len(literal) {
+		return 0, false
+	}
+	for i := range literal {
+		if data[pos+i] != literal[i] {
+			return 0, false
+		}
+	}
+	return pos + len(literal), true
+}
+
+func scanStrictRawJSONNumber(data []byte, pos int) (int, bool) {
+	if pos >= len(data) {
+		return 0, false
+	}
+	if data[pos] == '-' {
+		pos++
+		if pos >= len(data) {
+			return 0, false
+		}
+	}
+	switch {
+	case data[pos] == '0':
+		pos++
+	case data[pos] >= '1' && data[pos] <= '9':
+		for pos < len(data) && data[pos] >= '0' && data[pos] <= '9' {
+			pos++
+		}
+	default:
+		return 0, false
+	}
+	if pos < len(data) && data[pos] == '.' {
+		pos++
+		start := pos
+		for pos < len(data) && data[pos] >= '0' && data[pos] <= '9' {
+			pos++
+		}
+		if pos == start {
+			return 0, false
+		}
+	}
+	if pos < len(data) && (data[pos] == 'e' || data[pos] == 'E') {
+		pos++
+		if pos < len(data) && (data[pos] == '+' || data[pos] == '-') {
+			pos++
+		}
+		start := pos
+		for pos < len(data) && data[pos] >= '0' && data[pos] <= '9' {
+			pos++
+		}
+		if pos == start {
+			return 0, false
+		}
+	}
+	return pos, true
+}
+
+func skipRawJSONValue(data []byte, pos int) (int, bool) {
+	pos = skipRawJSONSpace(data, pos)
+	if pos >= len(data) {
+		return 0, false
+	}
+	switch data[pos] {
+	case '"':
+		_, _, end, _, ok := scanRawJSONString(data, pos)
+		return end, ok
+	case '{', '[':
+		depth := 0
+		for i := pos; i < len(data); i++ {
+			switch data[i] {
+			case '"':
+				_, _, end, _, ok := scanRawJSONString(data, i)
+				if !ok {
+					return 0, false
+				}
+				i = end - 1
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+				if depth == 0 {
+					return i + 1, true
+				}
+			}
+		}
+		return 0, false
+	default:
+		for i := pos; i < len(data); i++ {
+			switch data[i] {
+			case ',', '}', ']', ' ', '\t', '\n', '\r':
+				return i, i > pos
+			}
+		}
+		return len(data), true
+	}
+}
+
+func rawJSONKeyEqual(key []byte, want string) bool {
+	if len(key) != len(want) {
+		return false
+	}
+	for i := range key {
+		if key[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func rawJSONKeyEqualFold(key []byte, want string) bool {
+	if len(key) != len(want) {
+		return false
+	}
+	for i := range key {
+		left := key[i]
+		right := want[i]
+		if left >= 'A' && left <= 'Z' {
+			left += 'a' - 'A'
+		}
+		if right >= 'A' && right <= 'Z' {
+			right += 'a' - 'A'
+		}
+		if left != right {
+			return false
+		}
+	}
+	return true
+}
+
+func rawJSONNonEmptyString(raw []byte) bool {
+	raw = bytes.TrimSpace(raw)
+	contentStart, contentEnd, end, escaped, ok := scanRawJSONString(raw, 0)
+	if !ok || escaped || end != len(raw) {
+		return false
+	}
+	return len(bytes.TrimSpace(raw[contentStart:contentEnd])) > 0
+}
+
+func rawJSONNonNull(raw []byte) bool {
+	raw = bytes.TrimSpace(raw)
+	return len(raw) > 0 && !bytes.Equal(raw, []byte("null"))
+}
+
+func rawJSONHasNonEmptyArrayFast(raw []byte) (bool, bool) {
+	array, ok := newRawJSONArrayScanner(raw)
+	if !ok {
+		return false, false
+	}
+	_, _, done, ok := array.next()
+	if !ok {
+		return false, false
+	}
+	return !done, true
+}
+
+func rawJSONInt(raw []byte) (int, bool) {
+	raw = bytes.TrimSpace(raw)
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	if err != nil || int64(int(value)) != value {
+		return 0, false
+	}
+	return int(value), true
+}
+
+// extractTopLevelJSONStringFast returns an exact top-level string field without
+// allocating a map for the entire object. lastMatch mirrors encoding/json's
+// duplicate-key behavior when true; false preserves the generic request
+// extractor's historical first-match behavior. ok is false when the fast
+// scanner cannot safely preserve encoding/json semantics, so callers can fall
+// back to their existing decoder.
+func extractTopLevelJSONStringFast(body []byte, field string, lastMatch bool) (value string, found, ok bool) {
+	if !json.Valid(body) {
+		return "", false, false
+	}
+	return extractTopLevelJSONStringFastValidated(body, field, lastMatch)
+}
+
+func extractTopLevelJSONStringFastValidated(body []byte, field string, lastMatch bool) (value string, found, ok bool) {
+	object, ok := newRawJSONObjectScanner(body)
+	if !ok {
+		return "", false, false
+	}
+	var raw []byte
+	for {
+		key, start, end, done, scanOK := object.next()
+		if !scanOK {
+			return "", false, false
+		}
+		if done {
+			break
+		}
+		if !rawJSONKeyEqual(key, field) {
+			continue
+		}
+		raw = body[start:end]
+		found = true
+		if !lastMatch {
+			break
+		}
+	}
+	if !found {
+		return "", false, true
+	}
+
+	raw = bytes.TrimSpace(raw)
+	contentStart, contentEnd, end, escaped, stringOK := scanRawJSONString(raw, 0)
+	if !stringOK || end != len(raw) {
+		return "", true, true
+	}
+	if !escaped {
+		return strings.TrimSpace(string(raw[contentStart:contentEnd])), true, true
+	}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", true, true
+	}
+	return strings.TrimSpace(value), true, true
+}
+
+func inspectCanonicalOpenAIChatCompletionResponseFast(body []byte, requestedModel string) (models.OpenAIUsage, bool) {
+	usage, end, ok := inspectCanonicalOpenAIChatCompletionObjectSingleWalk(body, 0, requestedModel, rawJSONSingleWalkMode{
+		strict: true,
+		depth:  1,
+	})
+	if !ok || skipRawJSONSpace(body, end) != len(body) {
+		return models.OpenAIUsage{}, false
+	}
+	return usage, true
+}
+
+func inspectCanonicalOpenAIChatCompletionResponseFastValidated(body []byte, requestedModel string) (models.OpenAIUsage, bool) {
+	usage, end, ok := inspectCanonicalOpenAIChatCompletionObjectSingleWalk(body, 0, requestedModel, rawJSONSingleWalkMode{depth: 1})
+	if !ok || skipRawJSONSpace(body, end) != len(body) {
+		return models.OpenAIUsage{}, false
+	}
+	return usage, true
+}
+
+func inspectCanonicalOpenAIChatCompletionObjectSingleWalk(data []byte, pos int, requestedModel string, walk rawJSONSingleWalkMode) (models.OpenAIUsage, int, bool) {
+	object, ok := walk.object(data, pos)
+	if !ok {
+		return models.OpenAIUsage{}, 0, false
+	}
+
+	idOK := false
+	objectOK := false
+	createdOK := false
+	modelOK := strings.TrimSpace(requestedModel) == ""
+	choicesOK := false
+	usageOK := false
+	var usage models.OpenAIUsage
+
+	for {
+		key, valueStart, done, scanOK := object.next()
+		if !scanOK {
+			return models.OpenAIUsage{}, 0, false
+		}
+		if done {
+			break
+		}
+
+		var valueEnd int
+		switch {
+		case rawJSONKeyEqual(key, "error"):
+			return models.OpenAIUsage{}, 0, false
+		case rawJSONKeyEqual(key, "id"):
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+			idOK = ok && rawJSONNonEmptyString(data[valueStart:valueEnd])
+			ok = idOK
+		case rawJSONKeyEqual(key, "object"):
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+			objectOK = ok && rawJSONNonEmptyString(data[valueStart:valueEnd])
+			ok = objectOK
+		case rawJSONKeyEqual(key, "created"):
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+			createdOK = ok && rawJSONNonNull(data[valueStart:valueEnd])
+			ok = createdOK
+		case rawJSONKeyEqual(key, "model"):
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+			modelOK = ok && rawJSONNonEmptyString(data[valueStart:valueEnd])
+			ok = modelOK
+		case rawJSONKeyEqual(key, "choices"):
+			choicesWalk, childOK := walk.child()
+			if !childOK {
+				return models.OpenAIUsage{}, 0, false
+			}
+			valueEnd, choicesOK = inspectCanonicalOpenAIChatChoicesSingleWalk(data, valueStart, choicesWalk)
+			ok = choicesOK
+		case rawJSONKeyEqual(key, "usage"):
+			usageWalk, childOK := walk.child()
+			if !childOK {
+				return models.OpenAIUsage{}, 0, false
+			}
+			usage, valueEnd, usageOK = inspectCanonicalOpenAIUsageSingleWalk(data, valueStart, usageWalk)
+			ok = usageOK
+		default:
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+		}
+		if !ok || !object.advance(valueEnd) {
+			return models.OpenAIUsage{}, 0, false
+		}
+	}
+
+	if !idOK || !objectOK || !createdOK || !modelOK || !choicesOK || !usageOK {
+		return models.OpenAIUsage{}, 0, false
+	}
+	return usage, object.pos, true
+}
+
+func inspectCanonicalOpenAIUsageSingleWalk(data []byte, pos int, walk rawJSONSingleWalkMode) (models.OpenAIUsage, int, bool) {
+	object, ok := walk.object(data, pos)
+	if !ok {
+		return models.OpenAIUsage{}, 0, false
+	}
+	usage := models.OpenAIUsage{}
+	promptOK := false
+	completionOK := false
+	totalOK := false
+
+	for {
+		key, valueStart, done, scanOK := object.next()
+		if !scanOK {
+			return models.OpenAIUsage{}, 0, false
+		}
+		if done {
+			break
+		}
+
+		valueEnd, valueOK := walk.valueEnd(data, valueStart)
+		if !valueOK {
+			return models.OpenAIUsage{}, 0, false
+		}
+		switch {
+		case rawJSONKeyEqual(key, "prompt_tokens"):
+			usage.PromptTokens, promptOK = rawJSONInt(data[valueStart:valueEnd])
+			valueOK = promptOK
+		case rawJSONKeyEqual(key, "completion_tokens"):
+			usage.CompletionTokens, completionOK = rawJSONInt(data[valueStart:valueEnd])
+			valueOK = completionOK
+		case rawJSONKeyEqual(key, "total_tokens"):
+			usage.TotalTokens, totalOK = rawJSONInt(data[valueStart:valueEnd])
+			valueOK = totalOK
+		case rawJSONKeyEqual(key, "prompt_tokens_details"), rawJSONKeyEqual(key, "completion_tokens_details"):
+			return models.OpenAIUsage{}, 0, false
+		}
+		if !valueOK || !object.advance(valueEnd) {
+			return models.OpenAIUsage{}, 0, false
+		}
+	}
+
+	if !promptOK || !completionOK || !totalOK {
+		return models.OpenAIUsage{}, 0, false
+	}
+	return usage, object.pos, true
+}
+
+func inspectCanonicalOpenAIChatChoicesSingleWalk(data []byte, pos int, walk rawJSONSingleWalkMode) (int, bool) {
+	array, ok := walk.array(data, pos)
+	if !ok {
+		return 0, false
+	}
+	for {
+		valueStart, done, scanOK := array.next()
+		if !scanOK {
+			return 0, false
+		}
+		if done {
+			return array.pos, true
+		}
+		choiceWalk, childOK := walk.child()
+		if !childOK {
+			return 0, false
+		}
+		valueEnd, valueOK := inspectCanonicalOpenAIChatChoiceSingleWalk(data, valueStart, choiceWalk)
+		if !valueOK || !array.advance(valueEnd) {
+			return 0, false
+		}
+	}
+}
+
+func inspectCanonicalOpenAIChatChoiceSingleWalk(data []byte, pos int, walk rawJSONSingleWalkMode) (int, bool) {
+	choice, ok := walk.object(data, pos)
+	if !ok {
+		return 0, false
+	}
+	indexOK := false
+	finishOK := false
+	messageOK := false
+
+	for {
+		key, valueStart, done, scanOK := choice.next()
+		if !scanOK {
+			return 0, false
+		}
+		if done {
+			break
+		}
+
+		var valueEnd int
+		switch {
+		case rawJSONKeyEqual(key, "index"):
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+			indexOK = ok && rawJSONNonNull(data[valueStart:valueEnd])
+			ok = indexOK
+		case rawJSONKeyEqual(key, "finish_reason"):
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+			finishOK = ok && rawJSONNonEmptyString(data[valueStart:valueEnd])
+			ok = finishOK
+		case rawJSONKeyEqual(key, "message"):
+			messageWalk, childOK := walk.child()
+			if !childOK {
+				return 0, false
+			}
+			valueEnd, messageOK = inspectCanonicalOpenAIChatMessageSingleWalk(data, valueStart, messageWalk)
+			ok = messageOK
+		case rawJSONKeyEqual(key, "tool_calls"), rawJSONKeyEqual(key, "function_call"):
+			return 0, false
+		default:
+			valueEnd, ok = walk.valueEnd(data, valueStart)
+		}
+		if !ok || !choice.advance(valueEnd) {
+			return 0, false
+		}
+	}
+
+	if !indexOK || !finishOK || !messageOK {
+		return 0, false
+	}
+	return choice.pos, true
+}
+
+func inspectCanonicalOpenAIChatMessageSingleWalk(data []byte, pos int, walk rawJSONSingleWalkMode) (int, bool) {
+	message, ok := walk.object(data, pos)
+	if !ok {
+		return 0, false
+	}
+	roleOK := false
+	contentOK := false
+
+	for {
+		key, valueStart, done, scanOK := message.next()
+		if !scanOK {
+			return 0, false
+		}
+		if done {
+			break
+		}
+
+		valueEnd, valueOK := walk.valueEnd(data, valueStart)
+		if !valueOK {
+			return 0, false
+		}
+		switch {
+		case rawJSONKeyEqual(key, "role"):
+			roleOK = rawJSONNonEmptyString(data[valueStart:valueEnd])
+			valueOK = roleOK
+		case rawJSONKeyEqual(key, "content"):
+			contentOK = rawJSONNonNull(data[valueStart:valueEnd])
+			valueOK = contentOK
+		}
+		if !valueOK || !message.advance(valueEnd) {
+			return 0, false
+		}
+	}
+
+	if !roleOK || !contentOK {
+		return 0, false
+	}
+	return message.pos, true
+}
+
+func replaceSingleTopLevelRawJSONField(body []byte, field string, replacement json.RawMessage) ([]byte, bool) {
+	if !json.Valid(body) || !json.Valid(replacement) {
+		return body, false
+	}
+	object, ok := newRawJSONObjectScanner(body)
+	if !ok {
+		return body, false
+	}
+	matchStart := -1
+	matchEnd := -1
+	for {
+		key, start, end, done, ok := object.next()
+		if !ok {
+			return body, false
+		}
+		if done {
+			break
+		}
+		if !rawJSONKeyEqual(key, field) {
+			continue
+		}
+		if matchStart >= 0 {
+			return body, false
+		}
+		matchStart = start
+		matchEnd = end
+	}
+	if matchStart < 0 {
+		return body, false
+	}
+	out := make([]byte, len(body)-(matchEnd-matchStart)+len(replacement))
+	copy(out, body[:matchStart])
+	n := matchStart + copy(out[matchStart:], replacement)
+	copy(out[n:], body[matchEnd:])
+	return out, true
+}
+
+func replaceSingleTopLevelRawJSONFieldInPlace(body []byte, field string, replacement json.RawMessage) ([]byte, bool) {
+	if !json.Valid(body) || !json.Valid(replacement) {
+		return body, false
+	}
+	object, ok := newRawJSONObjectScanner(body)
+	if !ok {
+		return body, false
+	}
+	matchStart := -1
+	matchEnd := -1
+	for {
+		key, start, end, done, scanOK := object.next()
+		if !scanOK {
+			return body, false
+		}
+		if done {
+			break
+		}
+		if !rawJSONKeyEqual(key, field) {
+			continue
+		}
+		if matchStart >= 0 {
+			return body, false
+		}
+		matchStart = start
+		matchEnd = end
+	}
+	if matchStart < 0 {
+		return body, false
+	}
+
+	originalLength := len(body)
+	newLength := originalLength - (matchEnd - matchStart) + len(replacement)
+	if newLength > cap(body) {
+		return body, false
+	}
+	out := body[:newLength]
+	copy(out[matchStart+len(replacement):], body[matchEnd:originalLength])
+	copy(out[matchStart:], replacement)
+	return out, true
+}

--- a/proxy/raw_json_fast.go
+++ b/proxy/raw_json_fast.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/sozercan/vekil/models"
 )
@@ -293,6 +294,7 @@ func scanRawJSONString(data []byte, pos int) (contentStart, contentEnd, end int,
 		return 0, 0, 0, false, false
 	}
 	contentStart = pos + 1
+	nonASCII := false
 	for pos = contentStart; pos < len(data); pos++ {
 		switch data[pos] {
 		case '\\':
@@ -301,8 +303,14 @@ func scanRawJSONString(data []byte, pos int) (contentStart, contentEnd, end int,
 			if pos >= len(data) {
 				return 0, 0, 0, false, false
 			}
+			nonASCII = nonASCII || data[pos] >= utf8.RuneSelf
 		case '"':
+			if nonASCII && !utf8.Valid(data[contentStart:pos]) {
+				return 0, 0, 0, false, false
+			}
 			return contentStart, pos, pos + 1, escaped, true
+		default:
+			nonASCII = nonASCII || data[pos] >= utf8.RuneSelf
 		}
 	}
 	return 0, 0, 0, false, false
@@ -315,6 +323,7 @@ func scanStrictRawJSONString(data []byte, pos int) (contentStart, contentEnd, en
 		return 0, 0, 0, false, false
 	}
 	contentStart = pos + 1
+	nonASCII := false
 	for pos = contentStart; pos < len(data); pos++ {
 		switch data[pos] {
 		case '\\':
@@ -323,6 +332,7 @@ func scanStrictRawJSONString(data []byte, pos int) (contentStart, contentEnd, en
 			if pos >= len(data) {
 				return 0, 0, 0, false, false
 			}
+			nonASCII = nonASCII || data[pos] >= utf8.RuneSelf
 			switch data[pos] {
 			case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
 			case 'u':
@@ -339,11 +349,15 @@ func scanStrictRawJSONString(data []byte, pos int) (contentStart, contentEnd, en
 				return 0, 0, 0, false, false
 			}
 		case '"':
+			if nonASCII && !utf8.Valid(data[contentStart:pos]) {
+				return 0, 0, 0, false, false
+			}
 			return contentStart, pos, pos + 1, escaped, true
 		default:
 			if data[pos] < 0x20 {
 				return 0, 0, 0, false, false
 			}
+			nonASCII = nonASCII || data[pos] >= utf8.RuneSelf
 		}
 	}
 	return 0, 0, 0, false, false
@@ -610,11 +624,20 @@ func rawJSONHasNonEmptyArrayFast(raw []byte) (bool, bool) {
 
 func rawJSONInt(raw []byte) (int, bool) {
 	raw = bytes.TrimSpace(raw)
-	value, err := strconv.ParseInt(string(raw), 10, 64)
-	if err != nil || int64(int(value)) != value {
+	value, err := strconv.Atoi(string(raw))
+	if err != nil {
 		return 0, false
 	}
-	return int(value), true
+	return value, true
+}
+
+func rawJSONCreatedUnchangedByNormalizer(raw []byte) bool {
+	raw = bytes.TrimSpace(raw)
+	if !rawJSONNonNull(raw) {
+		return false
+	}
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	return err != nil || value != 0
 }
 
 // extractTopLevelJSONStringFast returns an exact top-level string field without
@@ -727,7 +750,7 @@ func inspectCanonicalOpenAIChatCompletionObjectSingleWalk(data []byte, pos int, 
 			ok = objectOK
 		case rawJSONKeyEqual(key, "created"):
 			valueEnd, ok = walk.valueEnd(data, valueStart)
-			createdOK = ok && rawJSONNonNull(data[valueStart:valueEnd])
+			createdOK = ok && rawJSONCreatedUnchangedByNormalizer(data[valueStart:valueEnd])
 			ok = createdOK
 		case rawJSONKeyEqual(key, "model"):
 			valueEnd, ok = walk.valueEnd(data, valueStart)
@@ -802,7 +825,7 @@ func inspectCanonicalOpenAIUsageSingleWalk(data []byte, pos int, walk rawJSONSin
 		}
 	}
 
-	if !promptOK || !completionOK || !totalOK {
+	if !promptOK || !completionOK || !totalOK || usage.TotalTokens == 0 && (usage.PromptTokens != 0 || usage.CompletionTokens != 0) {
 		return models.OpenAIUsage{}, 0, false
 	}
 	return usage, object.pos, true
@@ -953,51 +976,17 @@ func replaceSingleTopLevelRawJSONField(body []byte, field string, replacement js
 	if matchStart < 0 {
 		return body, false
 	}
-	out := make([]byte, len(body)-(matchEnd-matchStart)+len(replacement))
+	if matchEnd < matchStart || matchEnd > len(body) {
+		return body, false
+	}
+	retainedLength := len(body) - (matchEnd - matchStart)
+	maxInt := int(^uint(0) >> 1)
+	if len(replacement) > maxInt-retainedLength {
+		return body, false
+	}
+	out := make([]byte, retainedLength+len(replacement))
 	copy(out, body[:matchStart])
 	n := matchStart + copy(out[matchStart:], replacement)
 	copy(out[n:], body[matchEnd:])
-	return out, true
-}
-
-func replaceSingleTopLevelRawJSONFieldInPlace(body []byte, field string, replacement json.RawMessage) ([]byte, bool) {
-	if !json.Valid(body) || !json.Valid(replacement) {
-		return body, false
-	}
-	object, ok := newRawJSONObjectScanner(body)
-	if !ok {
-		return body, false
-	}
-	matchStart := -1
-	matchEnd := -1
-	for {
-		key, start, end, done, scanOK := object.next()
-		if !scanOK {
-			return body, false
-		}
-		if done {
-			break
-		}
-		if !rawJSONKeyEqual(key, field) {
-			continue
-		}
-		if matchStart >= 0 {
-			return body, false
-		}
-		matchStart = start
-		matchEnd = end
-	}
-	if matchStart < 0 {
-		return body, false
-	}
-
-	originalLength := len(body)
-	newLength := originalLength - (matchEnd - matchStart) + len(replacement)
-	if newLength > cap(body) {
-		return body, false
-	}
-	out := body[:newLength]
-	copy(out[matchStart+len(replacement):], body[matchEnd:originalLength])
-	copy(out[matchStart:], replacement)
 	return out, true
 }

--- a/proxy/raw_json_fast_test.go
+++ b/proxy/raw_json_fast_test.go
@@ -78,6 +78,28 @@ func TestInspectOpenAIChatRequestFastStrictJSON(t *testing.T) {
 	}
 }
 
+func TestRawJSONStringScannersRejectInvalidUTF8(t *testing.T) {
+	rawString := []byte{'"', 0xff, '"'}
+	if _, _, _, _, ok := scanRawJSONString(rawString, 0); ok {
+		t.Fatal("non-strict string scanner accepted invalid UTF-8")
+	}
+	if _, _, _, _, ok := scanStrictRawJSONString(rawString, 0); ok {
+		t.Fatal("strict string scanner accepted invalid UTF-8")
+	}
+
+	body := append([]byte(`{"model":"`), 0xff)
+	body = append(body, []byte(`","messages":[]}`)...)
+	if !json.Valid(body) {
+		t.Fatal("encoding/json compatibility fixture is not valid JSON")
+	}
+	if _, ok := inspectOpenAIChatRequestFast(body); ok {
+		t.Fatal("fast request inspection accepted invalid UTF-8 instead of falling back")
+	}
+	if got, want := extractOpenAIChatCompletionsRequestModel(body), "\ufffd"; got != want {
+		t.Fatalf("decoded model = %q, want replacement-rune model %q", got, want)
+	}
+}
+
 func FuzzInspectOpenAIChatRequestFastStrictJSON(f *testing.F) {
 	for _, seed := range [][]byte{
 		[]byte(`{"model":"model","messages":[{"role":"user","content":"hello"}],"stream":false}`),
@@ -105,69 +127,6 @@ func FuzzInspectOpenAIChatRequestFastStrictJSON(f *testing.F) {
 			t.Fatalf("strict inspection = %+v, validated = %+v for %q", strict, validated, body)
 		}
 	})
-}
-
-func TestReplaceSingleTopLevelRawJSONFieldInPlace(t *testing.T) {
-	tests := []struct {
-		name        string
-		body        string
-		replacement string
-		capacity    int
-		want        string
-		wantOK      bool
-	}{
-		{
-			name:        "shrinks",
-			body:        `{"model":"public-long","messages":[]}`,
-			replacement: `"short"`,
-			capacity:    128,
-			want:        `{"model":"short","messages":[]}`,
-			wantOK:      true,
-		},
-		{
-			name:        "grows within capacity",
-			body:        `{"model":"short","messages":[]}`,
-			replacement: `"upstream-model-long"`,
-			capacity:    128,
-			want:        `{"model":"upstream-model-long","messages":[]}`,
-			wantOK:      true,
-		},
-		{
-			name:        "insufficient capacity",
-			body:        `{"model":"short","messages":[]}`,
-			replacement: `"upstream-model-long"`,
-			want:        `{"model":"short","messages":[]}`,
-		},
-		{
-			name:        "duplicate field",
-			body:        `{"model":"first","model":"second"}`,
-			replacement: `"upstream"`,
-			capacity:    128,
-			want:        `{"model":"first","model":"second"}`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			capacity := tt.capacity
-			if capacity == 0 {
-				capacity = len(tt.body)
-			}
-			buffer := make([]byte, len(tt.body), capacity)
-			copy(buffer, tt.body)
-			original := append([]byte(nil), buffer...)
-			got, ok := replaceSingleTopLevelRawJSONFieldInPlace(buffer, "model", []byte(tt.replacement))
-			if ok != tt.wantOK {
-				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
-			}
-			if string(got) != tt.want {
-				t.Fatalf("body = %s, want %s", got, tt.want)
-			}
-			if !tt.wantOK && !bytes.Equal(buffer, original) {
-				t.Fatalf("failed replacement mutated input: got %s, want %s", buffer, original)
-			}
-		})
-	}
 }
 
 func TestInspectCanonicalOpenAIChatCompletionResponseFast(t *testing.T) {
@@ -223,6 +182,16 @@ func TestInspectCanonicalOpenAIChatCompletionResponseFast(t *testing.T) {
 			name:           "null created falls back",
 			requestedModel: "public-model",
 			body:           `{"id":"chat-1","object":"chat.completion","created":null,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "zero created falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":0,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "zero total with nonzero components falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":0}}`,
 		},
 		{
 			name:           "missing message role falls back",

--- a/proxy/raw_json_fast_test.go
+++ b/proxy/raw_json_fast_test.go
@@ -1,0 +1,333 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestInspectOpenAIChatRequestFastStrictJSON(t *testing.T) {
+	validFast := []string{
+		`{"model":"model","messages":[{"role":"user","content":"hello"}]}`,
+		` { "model" : "model", "messages" : [ { "role" : "user", "content" : [ { "type" : "text", "text" : "hello\\nworld" } ] } ], "stream": false, "temperature": -1.25e+2 } `,
+		`{"model":"model","messages":[{"role":"user","content":"\u263a"}],"tools":[],"stream_options":null}`,
+	}
+	for _, body := range validFast {
+		t.Run(body, func(t *testing.T) {
+			if !json.Valid([]byte(body)) {
+				t.Fatal("test fixture is not valid JSON")
+			}
+			strict, ok := inspectOpenAIChatRequestFast([]byte(body))
+			if !ok {
+				t.Fatal("strict inspection unexpectedly fell back")
+			}
+			validated, ok := inspectOpenAIChatRequestFastValidated([]byte(body))
+			if !ok {
+				t.Fatal("validated inspection unexpectedly fell back")
+			}
+			if strict.message != validated.message || strict.param != validated.param || strict.invalid != validated.invalid ||
+				strict.mode != validated.mode || !bytes.Equal(strict.modelRaw, validated.modelRaw) {
+				t.Fatalf("strict inspection = %+v, validated = %+v", strict, validated)
+			}
+		})
+	}
+
+	fallbacks := []string{
+		`[]`,
+		`{"\u006dodel":"model","messages":[{"role":"user","content":"hello"}]}`,
+		`{"model":"model","messages":[{"role":"user","content":"hello"}],"stream":false,"stream":true}`,
+		`{"model":"model","messages":[{"role":"user","content":"hello"}],"Stream":true}`,
+		`{"model":"model","messages":` + strings.Repeat(`[`, maxFastRawJSONNestingDepth) + `0` + strings.Repeat(`]`, maxFastRawJSONNestingDepth) + `}`,
+	}
+	for _, body := range fallbacks {
+		t.Run("fallback/"+body[:min(len(body), 48)], func(t *testing.T) {
+			if !json.Valid([]byte(body)) {
+				t.Fatal("fallback fixture is not valid JSON")
+			}
+			if _, ok := inspectOpenAIChatRequestFast([]byte(body)); ok {
+				t.Fatal("strict inspection accepted a required fallback")
+			}
+		})
+	}
+
+	malformed := []string{
+		``,
+		`{"model":"model","messages":[}`,
+		`{"model":"model" "messages":[]}`,
+		`{"model":"model","messages":[],}`,
+		`{"model":"model","messages":[1,]}`,
+		`{"model":"model","messages":[],"bad":"\x"}`,
+		`{"model":"model","messages":[],"bad":"\u12xz"}`,
+		"{\"model\":\"model\",\"messages\":[],\"bad\":\"\n\"}",
+		`{"model":"model","messages":[],"bad":01}`,
+		`{"model":"model","messages":[],"bad":1.}`,
+		`{"model":"model","messages":[],"bad":1e+}`,
+		`{"model":"model","messages":[],"bad":truth}`,
+		`{"model":"model","messages":[]} trailing`,
+	}
+	for _, body := range malformed {
+		t.Run("malformed/"+body, func(t *testing.T) {
+			if json.Valid([]byte(body)) {
+				t.Fatal("malformed fixture is valid JSON")
+			}
+			if _, ok := inspectOpenAIChatRequestFast([]byte(body)); ok {
+				t.Fatal("strict inspection accepted invalid JSON")
+			}
+		})
+	}
+}
+
+func FuzzInspectOpenAIChatRequestFastStrictJSON(f *testing.F) {
+	for _, seed := range [][]byte{
+		[]byte(`{"model":"model","messages":[{"role":"user","content":"hello"}],"stream":false}`),
+		[]byte(`{"model":"model","messages":[{"role":"user","content":[{"type":"text","text":"hello\\nworld"}]}],"tools":[]}`),
+		[]byte(`{"model":"model","messages":[],"temperature":-1.25e+2,"metadata":{"nested":[true,false,null]}}`),
+		[]byte(`{"model":"model","messages":[}`),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte) {
+		strict, ok := inspectOpenAIChatRequestFast(body)
+		if !ok {
+			return
+		}
+		if !json.Valid(body) {
+			t.Fatalf("strict inspection accepted invalid JSON: %q", body)
+		}
+		validated, validatedOK := inspectOpenAIChatRequestFastValidated(body)
+		if !validatedOK {
+			t.Fatalf("strict inspection accepted input rejected by validated scanner: %q", body)
+		}
+		if strict.message != validated.message || strict.param != validated.param || strict.invalid != validated.invalid ||
+			strict.mode != validated.mode || !bytes.Equal(strict.modelRaw, validated.modelRaw) {
+			t.Fatalf("strict inspection = %+v, validated = %+v for %q", strict, validated, body)
+		}
+	})
+}
+
+func TestReplaceSingleTopLevelRawJSONFieldInPlace(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		replacement string
+		capacity    int
+		want        string
+		wantOK      bool
+	}{
+		{
+			name:        "shrinks",
+			body:        `{"model":"public-long","messages":[]}`,
+			replacement: `"short"`,
+			capacity:    128,
+			want:        `{"model":"short","messages":[]}`,
+			wantOK:      true,
+		},
+		{
+			name:        "grows within capacity",
+			body:        `{"model":"short","messages":[]}`,
+			replacement: `"upstream-model-long"`,
+			capacity:    128,
+			want:        `{"model":"upstream-model-long","messages":[]}`,
+			wantOK:      true,
+		},
+		{
+			name:        "insufficient capacity",
+			body:        `{"model":"short","messages":[]}`,
+			replacement: `"upstream-model-long"`,
+			want:        `{"model":"short","messages":[]}`,
+		},
+		{
+			name:        "duplicate field",
+			body:        `{"model":"first","model":"second"}`,
+			replacement: `"upstream"`,
+			capacity:    128,
+			want:        `{"model":"first","model":"second"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capacity := tt.capacity
+			if capacity == 0 {
+				capacity = len(tt.body)
+			}
+			buffer := make([]byte, len(tt.body), capacity)
+			copy(buffer, tt.body)
+			original := append([]byte(nil), buffer...)
+			got, ok := replaceSingleTopLevelRawJSONFieldInPlace(buffer, "model", []byte(tt.replacement))
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("body = %s, want %s", got, tt.want)
+			}
+			if !tt.wantOK && !bytes.Equal(buffer, original) {
+				t.Fatalf("failed replacement mutated input: got %s, want %s", buffer, original)
+			}
+		})
+	}
+}
+
+func TestInspectCanonicalOpenAIChatCompletionResponseFast(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		requestedModel string
+		wantOK         bool
+		wantPrompt     int
+		wantCompletion int
+		wantTotal      int
+	}{
+		{
+			name:           "canonical",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}`,
+			wantOK:         true,
+			wantPrompt:     2,
+			wantCompletion: 3,
+			wantTotal:      5,
+		},
+		{
+			name:           "canonical whitespace and unknown fields",
+			requestedModel: "public-model",
+			body: ` {
+				"id": "chat-1", "object": "chat.completion", "created": 1,
+				"model": "upstream-model", "vendor": {"nested": [1, 2, 3]},
+				"choices": [{"index": 0, "message": {"role": "assistant", "content": ["ok"]}, "finish_reason": "stop", "logprobs": null}],
+				"usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5, "vendor": true}
+			} `,
+			wantOK:         true,
+			wantPrompt:     2,
+			wantCompletion: 3,
+			wantTotal:      5,
+		},
+		{
+			name:           "empty choices are canonical",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+			wantOK:         true,
+		},
+		{
+			name:   "missing model allowed without requested model",
+			body:   `{"id":"chat-1","object":"chat.completion","created":1,"choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+			wantOK: true,
+		},
+		{
+			name:           "missing id falls back",
+			requestedModel: "public-model",
+			body:           `{"object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "null created falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":null,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "missing message role falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "null message content falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":null},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "provider tool shape falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"tool_calls","tool_calls":[]}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "usage details fall back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"prompt_tokens_details":{"cached_tokens":1}}}`,
+		},
+		{
+			name:           "escaped key falls back",
+			requestedModel: "public-model",
+			body:           `{"\u0069d":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "escaped nested key falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"\u0072ole":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "earlier invalid duplicate falls back",
+			requestedModel: "public-model",
+			body:           `{"id":null,"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		},
+		{
+			name:           "malformed unknown value falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0},"vendor":[1,]}`,
+		},
+		{
+			name:           "invalid JSON falls back",
+			requestedModel: "public-model",
+			body:           `{"id":"chat-1"`,
+		},
+	}
+	tests = append(tests, struct {
+		name           string
+		body           string
+		requestedModel string
+		wantOK         bool
+		wantPrompt     int
+		wantCompletion int
+		wantTotal      int
+	}{
+		name:           "deep unknown value falls back",
+		requestedModel: "public-model",
+		body: `{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0},"vendor":` +
+			strings.Repeat(`[`, maxFastRawJSONNestingDepth) + `0` + strings.Repeat(`]`, maxFastRawJSONNestingDepth) + `}`,
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage, ok := inspectCanonicalOpenAIChatCompletionResponseFast([]byte(tt.body), tt.requestedModel)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %t, want %t", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if !json.Valid([]byte(tt.body)) {
+				t.Fatal("strict response inspection accepted invalid JSON")
+			}
+			validatedUsage, validatedOK := inspectCanonicalOpenAIChatCompletionResponseFastValidated([]byte(tt.body), tt.requestedModel)
+			if !validatedOK || validatedUsage != usage {
+				t.Fatalf("strict usage = %+v, validated usage = %+v, ok = %t", usage, validatedUsage, validatedOK)
+			}
+			if usage.PromptTokens != tt.wantPrompt || usage.CompletionTokens != tt.wantCompletion || usage.TotalTokens != tt.wantTotal {
+				t.Fatalf("usage = %+v, want prompt=%d completion=%d total=%d", usage, tt.wantPrompt, tt.wantCompletion, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func FuzzInspectCanonicalOpenAIChatCompletionResponseFastStrictJSON(f *testing.F) {
+	for _, seed := range [][]byte{
+		[]byte(`{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}`),
+		[]byte(` {"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0},"vendor":{"nested":[true,false,null]}} `),
+		[]byte(`{"id":"chat-1","object":"chat.completion","created":1,"model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0},"vendor":[1,]}`),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte) {
+		usage, ok := inspectCanonicalOpenAIChatCompletionResponseFast(body, "public-model")
+		if !ok {
+			return
+		}
+		if !json.Valid(body) {
+			t.Fatalf("strict response inspection accepted invalid JSON: %q", body)
+		}
+		validatedUsage, validatedOK := inspectCanonicalOpenAIChatCompletionResponseFastValidated(body, "public-model")
+		if !validatedOK || validatedUsage != usage {
+			t.Fatalf("strict usage = %+v, validated usage = %+v, ok = %t for %q", usage, validatedUsage, validatedOK, body)
+		}
+	})
+}

--- a/proxy/request_summary.go
+++ b/proxy/request_summary.go
@@ -5,12 +5,17 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/sozercan/vekil/logger"
 	"github.com/sozercan/vekil/models"
 )
 
 type requestSummaryContextKey struct{}
+
+var requestSummaryPool = sync.Pool{New: func() any {
+	return &RequestSummary{}
+}}
 
 // RequestSummary is a mutable per-request summary populated by handlers and
 // emitted by the server-level request logging middleware.
@@ -53,6 +58,11 @@ type RequestSummary struct {
 	totalTokens               *int
 	cachedTokens              *int
 	reasoningTokens           *int
+	promptTokensValue         int
+	completionTokensValue     int
+	totalTokensValue          int
+	cachedTokensValue         int
+	reasoningTokensValue      int
 	// extraPromptTokens / extraCompletionTokens accumulate out-of-band token
 	// spend that is separate from the turn's own reported usage — e.g. an
 	// internal /responses compaction call made while serving a 413 oversized-
@@ -70,7 +80,8 @@ type RequestSummary struct {
 	// statsSuppressed excludes local shutdown rejections and lifecycle-canceled
 	// in-flight work from provider traffic accounting. A semantic provider failure
 	// already recorded in failureStatus wins and cannot be suppressed afterward.
-	statsSuppressed bool
+	statsSuppressed   bool
+	retryStatsTracked atomic.Bool
 }
 
 // WithRequestSummary attaches a mutable request summary to ctx and returns both
@@ -85,6 +96,30 @@ func WithRequestSummary(ctx context.Context) (context.Context, *RequestSummary) 
 	}
 	summary := &RequestSummary{}
 	return context.WithValue(ctx, requestSummaryContextKey{}, summary), summary
+}
+
+// AcquireRequestSummary attaches a pooled summary when ctx does not already
+// carry one. Server middleware must call ReleaseRequestSummary only when owned
+// is true and only after handler, stats, and logging work has completed.
+func AcquireRequestSummary(ctx context.Context) (context.Context, *RequestSummary, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if existing := RequestSummaryFromContext(ctx); existing != nil {
+		return ctx, existing, false
+	}
+	summary := requestSummaryPool.Get().(*RequestSummary)
+	*summary = RequestSummary{}
+	return context.WithValue(ctx, requestSummaryContextKey{}, summary), summary, true
+}
+
+// ReleaseRequestSummary returns a server-owned summary to the pool.
+func ReleaseRequestSummary(summary *RequestSummary) {
+	if summary == nil {
+		return
+	}
+	*summary = RequestSummary{}
+	requestSummaryPool.Put(summary)
 }
 
 // RequestSummaryFromContext returns the mutable request summary attached to ctx,
@@ -498,18 +533,21 @@ func (s *RequestSummary) setOpenAIUsage(usage *models.OpenAIUsage) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.promptTokens = summaryIntPtr(usage.PromptTokens)
-	s.completionTokens = summaryIntPtr(usage.CompletionTokens)
-	s.totalTokens = summaryIntPtr(usage.TotalTokens)
+	s.promptTokensValue = usage.PromptTokens
+	s.completionTokensValue = usage.CompletionTokens
+	s.totalTokensValue = usage.TotalTokens
+	s.promptTokens = &s.promptTokensValue
+	s.completionTokens = &s.completionTokensValue
+	s.totalTokens = &s.totalTokensValue
 	if usage.PromptTokensDetails != nil {
-		s.cachedTokens = summaryIntPtr(usage.PromptTokensDetails.CachedTokens)
+		s.cachedTokensValue = usage.PromptTokensDetails.CachedTokens
+		s.cachedTokens = &s.cachedTokensValue
 	}
 	if usage.CompletionTokensDetails != nil {
-		s.reasoningTokens = summaryIntPtr(usage.CompletionTokensDetails.ReasoningTokens)
+		s.reasoningTokensValue = usage.CompletionTokensDetails.ReasoningTokens
+		s.reasoningTokens = &s.reasoningTokensValue
 	}
 }
-
-func summaryIntPtr(v int) *int { return &v }
 
 // setFailureStatus records an out-of-band failure status (first one wins) for a
 // request whose HTTP status was already committed before the failure was known.

--- a/proxy/request_summary_test.go
+++ b/proxy/request_summary_test.go
@@ -1,6 +1,26 @@
 package proxy
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
+
+func TestAcquireRequestSummaryOwnershipAndReset(t *testing.T) {
+	ctx, summary, owned := AcquireRequestSummary(context.Background())
+	if !owned || summary == nil {
+		t.Fatalf("AcquireRequestSummary() = summary:%p owned:%v, want owned summary", summary, owned)
+	}
+	_, existing, existingOwned := AcquireRequestSummary(ctx)
+	if existingOwned || existing != summary {
+		t.Fatalf("AcquireRequestSummary(existing) = summary:%p owned:%v, want %p false", existing, existingOwned, summary)
+	}
+	summary.setRoute("openai_chat", "gpt-5", false)
+	summary.retryStatsTracked.Store(true)
+	ReleaseRequestSummary(summary)
+	if summary.endpoint != "" || summary.model != "" || summary.retryStatsTracked.Load() {
+		t.Fatalf("released summary retained state: %#v", summary)
+	}
+}
 
 func TestRequestSummaryRouteObservability(t *testing.T) {
 	summary := &RequestSummary{}

--- a/proxy/retry.go
+++ b/proxy/retry.go
@@ -1,14 +1,18 @@
 package proxy
 
 import (
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -196,6 +200,18 @@ func drainReaderAndClose(reader io.Reader, body io.ReadCloser) {
 // doWithRetry executes an HTTP request with retry on transient failures.
 // The reqFactory is called on each attempt to produce a fresh request body.
 func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*http.Response, error) {
+	return h.doWithRetryMode(reqFactory, false)
+}
+
+// doInferenceWithRetry preserves the inference dispatch contract that one
+// reserved attempt produces one physical send. It therefore bypasses
+// http.Client redirect handling and sends through the configured transport
+// directly; catalog and auxiliary requests keep ordinary Client behavior.
+func (h *ProxyHandler) doInferenceWithRetry(reqFactory func() (*http.Request, error)) (*http.Response, error) {
+	return h.doWithRetryMode(reqFactory, true)
+}
+
+func (h *ProxyHandler) doWithRetryMode(reqFactory func() (*http.Request, error), inference bool) (*http.Response, error) {
 	maxRetries := h.maxRetries
 	if maxRetries == 0 {
 		maxRetries = 3
@@ -232,7 +248,7 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 			return nil, ctxErr
 		}
 
-		resp, err := h.client.Do(req)
+		resp, err := h.sendRetryRequest(req, inference)
 		lifecyclePreempted := errors.Is(context.Cause(req.Context()), errProxyLifecycleShutdown) &&
 			contextTerminationMatches(req.Context(), err)
 		if pending != nil && !lifecyclePreempted {
@@ -311,6 +327,168 @@ func (h *ProxyHandler) doWithRetry(reqFactory func() (*http.Request, error)) (*h
 		}
 	}
 	return nil, lastErr
+}
+
+func (h *ProxyHandler) sendRetryRequest(req *http.Request, inference bool) (*http.Response, error) {
+	client := h.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	autoDecompressGzip := providerRequestAutoDecompressGzip(req)
+	if !inference || client.Timeout != 0 || client.Jar != nil || client.CheckRedirect != nil || req.URL == nil || req.URL.User != nil {
+		resp, err := client.Do(req)
+		if err != nil {
+			return resp, err
+		}
+		maybeAutoDecompressProviderResponse(resp, autoDecompressGzip)
+		return resp, nil
+	}
+	if req.RequestURI != "" {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+		return nil, &url.Error{Op: strings.ToLower(req.Method), URL: req.URL.String(), Err: errors.New("http: Request.RequestURI can't be set in client requests")}
+	}
+	if req.Header == nil {
+		req.Header = make(http.Header)
+	}
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if tlsErr, ok := err.(tls.RecordHeaderError); ok && string(tlsErr.RecordHeader[:]) == "HTTP/" {
+			err = http.ErrSchemeMismatch
+		}
+		return nil, &url.Error{Op: strings.ToLower(req.Method), URL: req.URL.String(), Err: err}
+	}
+	if resp == nil {
+		return nil, &url.Error{Op: strings.ToLower(req.Method), URL: req.URL.String(), Err: fmt.Errorf("http: RoundTripper implementation (%T) returned a nil *Response with a nil error", transport)}
+	}
+	if resp.Body == nil {
+		if resp.ContentLength > 0 && req.Method != http.MethodHead {
+			return nil, &url.Error{Op: strings.ToLower(req.Method), URL: req.URL.String(), Err: fmt.Errorf("http: RoundTripper implementation (%T) returned a *Response with content length %d but a nil Body", transport, resp.ContentLength)}
+		}
+		resp.Body = http.NoBody
+	}
+	if resp.Request == nil {
+		resp.Request = req
+	}
+	maybeAutoDecompressProviderResponse(resp, autoDecompressGzip)
+	return resp, nil
+}
+
+var (
+	errProviderGzipReadInProgress = errors.New("concurrent read on gzip response body")
+	errProviderGzipBodyClosed     = errors.New("read on closed gzip response body")
+	providerGzipReaderPool        = sync.Pool{New: func() any { return new(gzip.Reader) }}
+)
+
+type providerGzipEOFReader struct{}
+
+func (providerGzipEOFReader) Read([]byte) (int, error) { return 0, io.EOF }
+func (providerGzipEOFReader) ReadByte() (byte, error)  { return 0, io.EOF }
+
+func providerGzipReaderPoolGet(body io.Reader) (*gzip.Reader, error) {
+	reader := providerGzipReaderPool.Get().(*gzip.Reader)
+	if err := reader.Reset(body); err != nil {
+		providerGzipReaderPoolPut(reader)
+		return nil, err
+	}
+	return reader, nil
+}
+
+func providerGzipReaderPoolPut(reader *gzip.Reader) {
+	// Reset against a flate.Reader so gzip does not allocate a bufio.Reader,
+	// and so the pooled reader does not retain the completed response body.
+	var empty flate.Reader = providerGzipEOFReader{}
+	_ = reader.Reset(empty)
+	providerGzipReaderPool.Put(reader)
+}
+
+type providerAutoGzipResponseBody struct {
+	body   io.ReadCloser
+	mu     sync.Mutex
+	reader *gzip.Reader
+	state  error
+}
+
+func (b *providerAutoGzipResponseBody) acquire() (*gzip.Reader, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.state != nil {
+		return nil, b.state
+	}
+	if b.reader == nil {
+		b.state = errProviderGzipReadInProgress
+		b.mu.Unlock()
+		reader, err := providerGzipReaderPoolGet(b.body)
+		b.mu.Lock()
+		if b.state != errProviderGzipReadInProgress {
+			if reader != nil {
+				providerGzipReaderPoolPut(reader)
+			}
+			return nil, b.state
+		}
+		b.reader = reader
+		b.state = err
+		if err != nil {
+			return nil, err
+		}
+	}
+	reader := b.reader
+	b.reader = nil
+	b.state = errProviderGzipReadInProgress
+	return reader, nil
+}
+
+func (b *providerAutoGzipResponseBody) release(reader *gzip.Reader) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.state == errProviderGzipReadInProgress {
+		b.reader = reader
+		b.state = nil
+		return
+	}
+	providerGzipReaderPoolPut(reader)
+}
+
+func (b *providerAutoGzipResponseBody) Read(p []byte) (int, error) {
+	reader, err := b.acquire()
+	if err != nil {
+		return 0, err
+	}
+	defer b.release(reader)
+	return reader.Read(p)
+}
+
+func (b *providerAutoGzipResponseBody) Close() error {
+	if b == nil || b.body == nil {
+		return nil
+	}
+	b.mu.Lock()
+	if b.state == nil && b.reader != nil {
+		providerGzipReaderPoolPut(b.reader)
+		b.reader = nil
+	}
+	b.state = errProviderGzipBodyClosed
+	b.mu.Unlock()
+	return b.body.Close()
+}
+
+func maybeAutoDecompressProviderResponse(resp *http.Response, enabled bool) {
+	if !enabled || resp == nil || resp.Body == nil || !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return
+	}
+	resp.Body = &providerAutoGzipResponseBody{body: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
 }
 
 func contextTerminationMatches(ctx context.Context, err error) bool {

--- a/proxy/retry_test.go
+++ b/proxy/retry_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -48,6 +50,226 @@ func TestDoWithRetry_SuccessOnFirstTry(t *testing.T) {
 	}
 	if calls.Load() != 1 {
 		t.Errorf("expected 1 call, got %d", calls.Load())
+	}
+}
+
+func TestInferenceRetryRejectsRedirectsWhileOrdinaryRetryFollows(t *testing.T) {
+	var redirectedCalls atomic.Int32
+	redirected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer redirected.Close()
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirected.URL, http.StatusTemporaryRedirect)
+	}))
+	defer primary.Close()
+
+	h := &ProxyHandler{
+		client:         primary.Client(),
+		maxRetries:     1,
+		retryBaseDelay: time.Millisecond,
+	}
+	request := func() (*http.Request, error) {
+		return http.NewRequest(http.MethodGet, primary.URL, nil)
+	}
+
+	resp, err := h.doInferenceWithRetry(request)
+	if err != nil {
+		t.Fatalf("doInferenceWithRetry() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("inference status = %d, want %d", resp.StatusCode, http.StatusTemporaryRedirect)
+	}
+	if got := redirectedCalls.Load(); got != 0 {
+		t.Fatalf("inference redirect target calls = %d, want 0", got)
+	}
+
+	resp, err = h.doWithRetry(request)
+	if err != nil {
+		t.Fatalf("doWithRetry() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ordinary retry status = %d, want 200", resp.StatusCode)
+	}
+	if got := redirectedCalls.Load(); got != 1 {
+		t.Fatalf("ordinary redirect target calls = %d, want 1", got)
+	}
+}
+
+func TestInferenceRetryAutoDecompressesSealedProviderGzipResponse(t *testing.T) {
+	payload := []byte(`{"id":"chatcmpl-test","choices":[]}`)
+	compressed := gzipTestPayload(t, payload)
+	acceptEncoding := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		acceptEncoding <- r.Header.Get("Accept-Encoding")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(compressed)))
+		_, _ = w.Write(compressed)
+	}))
+	defer server.Close()
+
+	h := &ProxyHandler{
+		client:         server.Client(),
+		maxRetries:     1,
+		retryBaseDelay: time.Millisecond,
+	}
+	providers, _, _, err := h.buildProviders(ProvidersConfig{
+		Providers: []ProviderConfig{{
+			ID:             "local-openai",
+			Type:           "openai-compatible",
+			Default:        true,
+			BaseURL:        server.URL,
+			AuthType:       "none",
+			ModelDiscovery: "static",
+			Models:         []ProviderModelConfig{{PublicID: "local-chat"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProviders() error = %v", err)
+	}
+	provider := providers["local-openai"]
+	requestBody := []byte(`{"model":"local-chat","messages":[]}`)
+	resp, err := h.doInferenceWithRetry(func() (*http.Request, error) {
+		return h.newProviderJSONInferenceRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, requestBody, nil, "")
+	})
+	if err != nil {
+		t.Fatalf("doInferenceWithRetry() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := <-acceptEncoding; got != "gzip" {
+		t.Fatalf("upstream Accept-Encoding = %q, want gzip", got)
+	}
+	assertAutoDecompressedProviderResponse(t, resp, payload)
+}
+
+func TestInferenceRetryPreservesOperatorSuppliedResponseEncoding(t *testing.T) {
+	payload := []byte(`{"ok":true}`)
+	compressed := gzipTestPayload(t, payload)
+	h := &ProxyHandler{
+		maxRetries:     1,
+		retryBaseDelay: time.Millisecond,
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Accept-Encoding"); got != "identity" {
+				t.Fatalf("Accept-Encoding = %q, want identity", got)
+			}
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Header:        http.Header{"Content-Encoding": []string{"gzip"}, "Content-Length": []string{strconv.Itoa(len(compressed))}},
+				Body:          io.NopCloser(bytes.NewReader(compressed)),
+				ContentLength: int64(len(compressed)),
+				Request:       req,
+			}, nil
+		})},
+	}
+	provider := &providerRuntime{
+		id:           "operator-encoding",
+		kind:         providerTypeOpenAICompatible,
+		baseURL:      "https://upstream.example",
+		authType:     providerAuthTypeNone,
+		extraHeaders: http.Header{"Accept-Encoding": []string{"identity"}},
+		paths:        providerEndpointPaths{chatCompletions: providerEndpointChatCompletions},
+	}
+	if err := sealProviderRequestTemplates(provider); err != nil {
+		t.Fatalf("sealProviderRequestTemplates() error = %v", err)
+	}
+	resp, err := h.doInferenceWithRetry(func() (*http.Request, error) {
+		return h.newProviderJSONInferenceRequest(context.Background(), provider, http.MethodPost, providerEndpointChatCompletions, []byte(`{}`), nil, "")
+	})
+	if err != nil {
+		t.Fatalf("doInferenceWithRetry() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if got := resp.Header.Get("Content-Length"); got != strconv.Itoa(len(compressed)) {
+		t.Fatalf("Content-Length header = %q, want %d", got, len(compressed))
+	}
+	if resp.ContentLength != int64(len(compressed)) || resp.Uncompressed {
+		t.Fatalf("response metadata = ContentLength %d, Uncompressed %t; want %d, false", resp.ContentLength, resp.Uncompressed, len(compressed))
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !bytes.Equal(got, compressed) {
+		t.Fatalf("response body was unexpectedly decoded")
+	}
+}
+
+func TestSingleInferenceSendAutoDecompressesAndClosesProviderGzipResponse(t *testing.T) {
+	payload := []byte(`{"ok":true}`)
+	compressed := gzipTestPayload(t, payload)
+	underlying := &trackingReadCloser{reader: bytes.NewReader(compressed)}
+	h := &ProxyHandler{client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("Accept-Encoding"); got != "gzip" {
+			t.Fatalf("Accept-Encoding = %q, want gzip", got)
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Encoding": []string{"gzip"}, "Content-Length": []string{strconv.Itoa(len(compressed))}},
+			Body:          underlying,
+			ContentLength: int64(len(compressed)),
+			Request:       req,
+		}, nil
+	})}}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Body = newProviderRequestBody([]byte(`{}`), providerRouteInfo{id: "explicit-provider", kind: string(providerTypeOpenAICompatible)}, true)
+	req.ContentLength = 2
+
+	resp, err := h.singleInferenceSend(req, nil)
+	if err != nil {
+		t.Fatalf("singleInferenceSend() error = %v", err)
+	}
+	assertAutoDecompressedProviderResponse(t, resp, payload)
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("response Close() error = %v", err)
+	}
+	if !underlying.closed {
+		t.Fatal("response Close() did not close compressed upstream body")
+	}
+}
+
+func gzipTestPayload(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatalf("gzip Write() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("gzip Close() error = %v", err)
+	}
+	return compressed.Bytes()
+}
+
+func assertAutoDecompressedProviderResponse(t *testing.T, resp *http.Response, want []byte) {
+	t.Helper()
+	if got := resp.Header.Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding = %q, want removed", got)
+	}
+	if got := resp.Header.Get("Content-Length"); got != "" {
+		t.Fatalf("Content-Length header = %q, want removed", got)
+	}
+	if resp.ContentLength != -1 || !resp.Uncompressed {
+		t.Fatalf("response metadata = ContentLength %d, Uncompressed %t; want -1, true", resp.ContentLength, resp.Uncompressed)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("decoded response body = %q, want %q", got, want)
 	}
 }
 

--- a/proxy/route_executor.go
+++ b/proxy/route_executor.go
@@ -3011,7 +3011,7 @@ func (h *ProxyHandler) executeExplicitRouteRequestPath(ctx context.Context, rout
 			break
 		}
 
-		req, err := h.newProviderJSONRequest(ctx, target.provider, http.MethodPost, dispatchPath, preparedBody, cloneSanitizedRouteHeaders(extraHeaders), "", owner)
+		req, err := h.newProviderJSONInferenceRequest(ctx, target.provider, http.MethodPost, dispatchPath, preparedBody, cloneSanitizedRouteHeaders(extraHeaders), "", owner)
 		if err != nil {
 			failure := routeAttemptFailure{err: err, attribution: attribution, delivery: requestDefinitelyNotDelivered, progress: upstreamProgressNone, commitment: downstreamCommitmentNone, decision: routeRetrySuppressedNonretryable}
 			failures = append(failures, failure)
@@ -3278,6 +3278,7 @@ func (h *ProxyHandler) singleInferenceSend(req *http.Request, observation *route
 	if req == nil {
 		return nil, fmt.Errorf("upstream request is required")
 	}
+	autoDecompressGzip := providerRequestAutoDecompressGzip(req)
 	attemptCtx, attemptCancel := context.WithCancel(req.Context())
 	owner := &routeAttemptTransportOwner{cancel: attemptCancel}
 	req = req.WithContext(attemptCtx)
@@ -3298,6 +3299,7 @@ func (h *ProxyHandler) singleInferenceSend(req *http.Request, observation *route
 	if resp.Request == nil {
 		resp.Request = req
 	}
+	maybeAutoDecompressProviderResponse(resp, autoDecompressGzip)
 	resp.Body = &routeAttemptTransportBody{inner: resp.Body, owner: owner, observation: observation}
 	return resp, err
 }

--- a/proxy/stats.go
+++ b/proxy/stats.go
@@ -1785,12 +1785,19 @@ func markRetryStatsTracked(ctx context.Context) context.Context {
 	if ctx == nil {
 		return context.WithValue(context.Background(), retryStatsTrackedContextKey{}, true)
 	}
+	if summary := RequestSummaryFromContext(ctx); summary != nil {
+		summary.retryStatsTracked.Store(true)
+		return ctx
+	}
 	return context.WithValue(ctx, retryStatsTrackedContextKey{}, true)
 }
 
 func isRetryStatsTracked(ctx context.Context) bool {
 	if ctx == nil {
 		return false
+	}
+	if summary := RequestSummaryFromContext(ctx); summary != nil && summary.retryStatsTracked.Load() {
+		return true
 	}
 	v, _ := ctx.Value(retryStatsTrackedContextKey{}).(bool)
 	return v

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -36,10 +36,14 @@ func (r *lifecycleAwareReadCloser) Read(p []byte) (int, error) {
 	// context.Canceled. Consult the request context only for that exact class of
 	// read failure; EOF, resets, and deadlines remain provider failures even if
 	// shutdown races immediately afterward.
-	if err != nil && errors.Is(err, context.Canceled) && r.ctx != nil && errors.Is(context.Cause(r.ctx), errProxyLifecycleShutdown) {
+	if lifecycleCancellationAtReadFailure(r.ctx, err) {
 		r.cancellationAtFailure.Store(true)
 	}
 	return n, err
+}
+
+func lifecycleCancellationAtReadFailure(ctx context.Context, err error) bool {
+	return err != nil && errors.Is(err, context.Canceled) && ctx != nil && errors.Is(context.Cause(ctx), errProxyLifecycleShutdown)
 }
 
 func (r *lifecycleAwareReadCloser) canceledAtFailure() bool {

--- a/proxy/tool_optimizer_responses.go
+++ b/proxy/tool_optimizer_responses.go
@@ -17,7 +17,7 @@ func toolExecutionScopeFromHeaders(headers http.Header) string {
 	if headers == nil {
 		return ""
 	}
-	if sessionID := strings.TrimSpace(headers.Get("session_id")); sessionID != "" {
+	if sessionID := strings.TrimSpace(headers.Get("Session_id")); sessionID != "" {
 		return "session:" + sessionID
 	}
 	parentThread := strings.TrimSpace(headers.Get("X-Codex-Parent-Thread-Id"))

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sozercan/vekil/logger"
@@ -17,7 +18,26 @@ import (
 )
 
 func (h *ProxyHandler) newLifecycleUpstreamContext(timeout time.Duration) (context.Context, context.CancelFunc) {
-	causeCtx, cancelCause := context.WithCancelCause(h.lifecycleContext())
+	return h.newLifecycleUpstreamContextFrom(h.lifecycleContext(), timeout)
+}
+
+func (h *ProxyHandler) newLifecycleUpstreamContextFrom(lifecycle context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if lifecycle == nil {
+		lifecycle = context.Background()
+	}
+	if !h.ShuttingDown() {
+		ctx, cancel := context.WithTimeout(lifecycle, timeout)
+		// BeginShutdown publishes draining before canceling the lifecycle root.
+		// Keep the ordinary path to one child context, but recheck after creating
+		// it so a context installed in that ordering window still returns with the
+		// proxy-shutdown cause below.
+		if !h.ShuttingDown() || lifecycle.Err() != nil {
+			return ctx, cancel
+		}
+		cancel()
+	}
+
+	causeCtx, cancelCause := context.WithCancelCause(lifecycle)
 	ctx, cancelTimeout := context.WithTimeout(causeCtx, timeout)
 	// BeginShutdown publishes draining before canceling the lifecycle root so
 	// admission closes first. Close that tiny ordering window for children
@@ -54,11 +74,8 @@ func (h *ProxyHandler) newInferenceUpstreamContextFrom(inbound context.Context, 
 	if streaming {
 		timeout = h.effectiveStreamingUpstreamTimeout()
 	}
-	ctx, cancel := h.newLifecycleUpstreamContext(timeout)
-	if isRetryStatsTracked(inbound) {
-		ctx = markRetryStatsTracked(ctx)
-	}
-	return ctx, cancel
+	lifecycle := h.lifecycleContextForRetryStats(isRetryStatsTracked(inbound))
+	return h.newLifecycleUpstreamContextFrom(lifecycle, timeout)
 }
 
 func upstreamStatusCode(err error, fallback int) int {
@@ -74,6 +91,9 @@ func upstreamStatusCode(err error, fallback int) int {
 }
 
 func extractRequestModel(body []byte) string {
+	if model, _, ok := extractTopLevelJSONStringFast(body, "model", false); ok {
+		return model
+	}
 	dec := json.NewDecoder(bytes.NewReader(body))
 	tok, err := dec.Token()
 	if err != nil {
@@ -202,6 +222,17 @@ func prepareResolvedProviderRequestBody(
 	provider *providerRuntime,
 	owner providerModel,
 ) ([]byte, error) {
+	return prepareResolvedProviderRequestBodyWithOwnership(body, requestModel, endpoint, provider, owner, false)
+}
+
+func prepareResolvedProviderRequestBodyWithOwnership(
+	body []byte,
+	requestModel string,
+	endpoint string,
+	provider *providerRuntime,
+	owner providerModel,
+	mutable bool,
+) ([]byte, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("provider is required")
 	}
@@ -209,12 +240,39 @@ func prepareResolvedProviderRequestBody(
 	rewrittenBody := body
 	if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
 		var err error
-		rewrittenBody, _, err = rewriteRequestModelForProviderFromModel(body, requestModel, owner.upstreamModel)
+		if mutable {
+			rewrittenBody, _, err = rewriteRequestModelForProviderFromModelJSONInPlace(body, requestModel, owner.upstreamModel, owner.upstreamModelJSON)
+		} else {
+			rewrittenBody, _, err = rewriteRequestModelForProviderFromModelJSON(body, requestModel, owner.upstreamModel, owner.upstreamModelJSON)
+		}
 		if err != nil {
 			return nil, err
 		}
 	}
 	return applyProviderModelRequestPolicy(rewrittenBody, endpoint, owner), nil
+}
+
+func rewriteRequestModelForProviderFromModelJSONInPlace(body []byte, currentModel string, upstreamModel string, rawModel json.RawMessage) ([]byte, bool, error) {
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	if upstreamModel == "" {
+		return body, false, nil
+	}
+
+	currentModel = strings.TrimSpace(currentModel)
+	if currentModel == "" || currentModel == upstreamModel {
+		return body, false, nil
+	}
+	if len(rawModel) == 0 {
+		var err error
+		rawModel, err = json.Marshal(upstreamModel)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	if rewritten, ok := replaceSingleTopLevelRawJSONFieldInPlace(body, "model", rawModel); ok {
+		return rewritten, true, nil
+	}
+	return rewriteRequestModelForProviderFromModelJSON(body, currentModel, upstreamModel, rawModel)
 }
 
 func applyProviderModelRequestPolicy(body []byte, endpoint string, owner providerModel) []byte {
@@ -276,6 +334,31 @@ func (h *ProxyHandler) postResolvedProviderRequest(
 	body []byte,
 	extraHeaders http.Header,
 ) (*http.Response, error) {
+	return h.postResolvedProviderRequestForModel(ctx, provider, owner, endpoint, body, extraHeaders, extractRequestModel(body))
+}
+
+func (h *ProxyHandler) postResolvedProviderRequestForModel(
+	ctx context.Context,
+	provider *providerRuntime,
+	owner providerModel,
+	endpoint string,
+	body []byte,
+	extraHeaders http.Header,
+	requestModel string,
+) (*http.Response, error) {
+	return h.postResolvedProviderRequestForModelWithOwnership(ctx, provider, owner, endpoint, body, extraHeaders, requestModel, false)
+}
+
+func (h *ProxyHandler) postResolvedProviderRequestForModelWithOwnership(
+	ctx context.Context,
+	provider *providerRuntime,
+	owner providerModel,
+	endpoint string,
+	body []byte,
+	extraHeaders http.Header,
+	requestModel string,
+	mutable bool,
+) (*http.Response, error) {
 	if provider == nil {
 		return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
 	}
@@ -283,13 +366,13 @@ func (h *ProxyHandler) postResolvedProviderRequest(
 		ctx = context.Background()
 	}
 
-	preparedBody, err := prepareResolvedProviderRequestBody(body, extractRequestModel(body), endpoint, provider, owner)
+	preparedBody, err := prepareResolvedProviderRequestBodyWithOwnership(body, requestModel, endpoint, provider, owner, mutable)
 	if err != nil {
 		return nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 	}
 
-	return h.doWithRetry(func() (*http.Request, error) {
-		return h.newProviderJSONRequest(ctx, provider, http.MethodPost, endpoint, preparedBody, extraHeaders, "", owner)
+	return h.doInferenceWithRetry(func() (*http.Request, error) {
+		return h.newProviderJSONInferenceRequest(ctx, provider, http.MethodPost, endpoint, preparedBody, extraHeaders, "", owner)
 	})
 }
 
@@ -450,8 +533,8 @@ func (h *ProxyHandler) postJSONEndpointWithHeadersForModel(ctx context.Context, 
 		return nil, err
 	}
 
-	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "", owner)
+	return h.doInferenceWithRetry(func() (*http.Request, error) {
+		req, err := h.newProviderJSONInferenceRequest(ctx, provider, http.MethodPost, path, rewrittenBody, extraHeaders, "", owner)
 		if err != nil {
 			return nil, err
 		}
@@ -506,8 +589,8 @@ func (h *ProxyHandler) postAnthropicMessagesCountTokens(ctx context.Context, bod
 		}
 	}
 
-	return h.doWithRetry(func() (*http.Request, error) {
-		req, err := h.newProviderJSONRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "", owner)
+	return h.doInferenceWithRetry(func() (*http.Request, error) {
+		req, err := h.newProviderJSONInferenceRequest(ctx, provider, http.MethodPost, providerEndpointMessagesCount, rewrittenBody, extraHeaders, "", owner)
 		if err != nil {
 			return nil, err
 		}
@@ -586,6 +669,10 @@ func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response) error {
 // responses fail open to passthrough behavior.
 func (h *ProxyHandler) writeOpenAIChatCompletionResponse(ctx context.Context, w http.ResponseWriter, resp *http.Response, requestedModel string) error {
 	return writePassthroughSniffingUsage(w, resp, func(body []byte) ([]byte, bool) {
+		if usage, canonical := inspectCanonicalOpenAIChatCompletionResponse(body, requestedModel); canonical {
+			observeOpenAIUsage(ctx, &usage)
+			return body, false
+		}
 		out, changed, err := normalizeOpenAIChatCompletionResponse(body, requestedModel, time.Now())
 		if err != nil {
 			observeOpenAIUsage(ctx, sniffOpenAIUsage(body))
@@ -611,6 +698,21 @@ func (h *ProxyHandler) writeOpenAIPassthroughObservingUsage(ctx context.Context,
 // buffered whole. Oversized bodies stream through with usage stats skipped.
 const usageSniffMaxBuffer = 4 << 20 // 4 MiB
 
+const (
+	usageSniffTinyBufferSize  = 512
+	usageSniffSmallBufferSize = 4 << 10
+)
+
+var usageSniffTinyBufferPool = sync.Pool{New: func() any {
+	buffer := make([]byte, usageSniffTinyBufferSize)
+	return &buffer
+}}
+
+var usageSniffSmallBufferPool = sync.Pool{New: func() any {
+	buffer := make([]byte, usageSniffSmallBufferSize)
+	return &buffer
+}}
+
 // writePassthroughSniffingUsage writes a non-streaming upstream response to the
 // client while buffering at most usageSniffMaxBuffer bytes so the supplied
 // transform can sniff usage and optionally rewrite the complete body. A 2xx body
@@ -622,6 +724,11 @@ func writePassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, t
 	if resp == nil || resp.Body == nil {
 		return &responseBodyWriteError{err: fmt.Errorf("upstream response body is unavailable"), upstream: true}
 	}
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices &&
+		resp.ContentLength >= 0 && resp.ContentLength < usageSniffSmallBufferSize {
+		return writeSmallKnownLengthPassthroughSniffingUsage(w, resp, transform)
+	}
+
 	body := newLifecycleAwareReadCloser(resp.Body, responseRequestContext(resp))
 	defer func() { _ = body.Close() }()
 
@@ -640,7 +747,12 @@ func writePassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, t
 	}
 
 	// Read one byte past the cap so we can tell a full body from an oversized one.
-	prefix, err := io.ReadAll(io.LimitReader(body, usageSniffMaxBuffer+1))
+	// Known small Content-Length responses use one exact allocation instead of
+	// constructing a limiter and growing io.ReadAll's default buffer.
+	prefix, pooledBuffer, err := readUsageSniffPrefix(body, resp.ContentLength)
+	if pooledBuffer != nil {
+		defer releaseUsageSniffBuffer(pooledBuffer)
+	}
 	if body.canceledAtFailure() {
 		return newResponseBodyWriteError(resp, context.Canceled, false, true, body.canceledAtFailure())
 	}
@@ -683,6 +795,139 @@ func writePassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, t
 		return newResponseBodyWriteError(resp, err, true, tracked.writeErr == nil, body.canceledAtFailure())
 	}
 	return nil
+}
+
+func writeSmallKnownLengthPassthroughSniffingUsage(w http.ResponseWriter, resp *http.Response, transform func([]byte) ([]byte, bool)) error {
+	ctx := responseRequestContext(resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	pooledBuffer := borrowUsageSniffBuffer(resp.ContentLength)
+	defer releaseUsageSniffBuffer(pooledBuffer)
+	prefix := (*pooledBuffer)[:int(resp.ContentLength)+1]
+	n, canceledAtFailure, err := readFullObservingLifecycle(resp.Body, ctx, prefix)
+	if canceledAtFailure {
+		return newResponseBodyWriteError(resp, context.Canceled, false, true, true)
+	}
+	switch err {
+	case nil:
+		// The body exceeded its advertised length. Continue to the normal cap so
+		// a malformed Content-Length cannot truncate the downstream response.
+		body := newLifecycleAwareReadCloser(resp.Body, ctx)
+		rest, readErr := io.ReadAll(io.LimitReader(body, int64(usageSniffMaxBuffer+1-len(prefix))))
+		prefix = append(prefix, rest...)
+		if body.canceledAtFailure() {
+			return newResponseBodyWriteError(resp, context.Canceled, false, true, true)
+		}
+		if readErr != nil {
+			return newResponseBodyWriteError(resp, readErr, false, true, false)
+		}
+		if len(prefix) > usageSniffMaxBuffer {
+			copyPassthroughHeaders(w.Header(), resp.Header)
+			w.WriteHeader(resp.StatusCode)
+			if _, writeErr := w.Write(prefix); writeErr != nil {
+				return newResponseBodyWriteError(resp, writeErr, true, false, false)
+			}
+			tracked := &bodyCopyWriter{w: w}
+			_, copyErr := io.Copy(tracked, body)
+			if body.canceledAtFailure() {
+				return newResponseBodyWriteError(resp, context.Canceled, true, true, true)
+			}
+			if copyErr != nil {
+				return newResponseBodyWriteError(resp, copyErr, true, tracked.writeErr == nil, false)
+			}
+			return nil
+		}
+	case io.EOF, io.ErrUnexpectedEOF:
+		prefix = prefix[:n]
+	default:
+		return newResponseBodyWriteError(resp, err, false, true, false)
+	}
+
+	copyPassthroughHeaders(w.Header(), resp.Header)
+	out := prefix
+	changed := false
+	if transform != nil {
+		out, changed = transform(prefix)
+	}
+	if changed {
+		w.Header().Del("Content-Length")
+		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+	}
+	w.WriteHeader(resp.StatusCode)
+	if _, writeErr := w.Write(out); writeErr != nil {
+		return newResponseBodyWriteError(resp, writeErr, true, false, false)
+	}
+	return nil
+}
+
+func readFullObservingLifecycle(body io.Reader, ctx context.Context, buffer []byte) (n int, canceledAtFailure bool, err error) {
+	for n < len(buffer) && err == nil {
+		var read int
+		read, err = body.Read(buffer[n:])
+		n += read
+		if lifecycleCancellationAtReadFailure(ctx, err) {
+			canceledAtFailure = true
+		}
+	}
+	if n >= len(buffer) {
+		err = nil
+	} else if n > 0 && errors.Is(err, io.EOF) {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, canceledAtFailure, err
+}
+
+func readUsageSniffPrefix(body io.Reader, contentLength int64) ([]byte, *[]byte, error) {
+	const limit = usageSniffMaxBuffer + 1
+	if contentLength < 0 || contentLength > usageSniffMaxBuffer {
+		prefix, err := io.ReadAll(io.LimitReader(body, limit))
+		return prefix, nil, err
+	}
+
+	var pooledBuffer *[]byte
+	var prefix []byte
+	if contentLength < usageSniffSmallBufferSize {
+		pooledBuffer = borrowUsageSniffBuffer(contentLength)
+		prefix = (*pooledBuffer)[:int(contentLength)+1]
+	} else {
+		prefix = make([]byte, int(contentLength)+1)
+	}
+	n, err := io.ReadFull(body, prefix)
+	switch err {
+	case nil:
+		// The body exceeded its advertised length. Continue to the normal cap so
+		// a malformed Content-Length cannot truncate the downstream response.
+		if len(prefix) >= limit {
+			return prefix, pooledBuffer, nil
+		}
+		rest, readErr := io.ReadAll(io.LimitReader(body, int64(limit-len(prefix))))
+		return append(prefix, rest...), pooledBuffer, readErr
+	case io.EOF, io.ErrUnexpectedEOF:
+		return prefix[:n], pooledBuffer, nil
+	default:
+		return nil, pooledBuffer, err
+	}
+}
+
+func borrowUsageSniffBuffer(contentLength int64) *[]byte {
+	if contentLength < usageSniffTinyBufferSize {
+		return usageSniffTinyBufferPool.Get().(*[]byte)
+	}
+	return usageSniffSmallBufferPool.Get().(*[]byte)
+}
+
+func releaseUsageSniffBuffer(buffer *[]byte) {
+	if buffer == nil {
+		return
+	}
+	switch cap(*buffer) {
+	case usageSniffTinyBufferSize:
+		*buffer = (*buffer)[:usageSniffTinyBufferSize]
+		usageSniffTinyBufferPool.Put(buffer)
+	case usageSniffSmallBufferSize:
+		*buffer = (*buffer)[:usageSniffSmallBufferSize]
+		usageSniffSmallBufferPool.Put(buffer)
+	}
 }
 
 // sniffOpenAIUsage extracts the usage block from a non-streaming OpenAI chat

--- a/proxy/upstream_http.go
+++ b/proxy/upstream_http.go
@@ -222,17 +222,6 @@ func prepareResolvedProviderRequestBody(
 	provider *providerRuntime,
 	owner providerModel,
 ) ([]byte, error) {
-	return prepareResolvedProviderRequestBodyWithOwnership(body, requestModel, endpoint, provider, owner, false)
-}
-
-func prepareResolvedProviderRequestBodyWithOwnership(
-	body []byte,
-	requestModel string,
-	endpoint string,
-	provider *providerRuntime,
-	owner providerModel,
-	mutable bool,
-) ([]byte, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("provider is required")
 	}
@@ -240,39 +229,12 @@ func prepareResolvedProviderRequestBodyWithOwnership(
 	rewrittenBody := body
 	if !providerUsesAzureClassicDeploymentPath(provider, endpoint) {
 		var err error
-		if mutable {
-			rewrittenBody, _, err = rewriteRequestModelForProviderFromModelJSONInPlace(body, requestModel, owner.upstreamModel, owner.upstreamModelJSON)
-		} else {
-			rewrittenBody, _, err = rewriteRequestModelForProviderFromModelJSON(body, requestModel, owner.upstreamModel, owner.upstreamModelJSON)
-		}
+		rewrittenBody, _, err = rewriteRequestModelForProviderFromModelJSON(body, requestModel, owner.upstreamModel, owner.upstreamModelJSON)
 		if err != nil {
 			return nil, err
 		}
 	}
 	return applyProviderModelRequestPolicy(rewrittenBody, endpoint, owner), nil
-}
-
-func rewriteRequestModelForProviderFromModelJSONInPlace(body []byte, currentModel string, upstreamModel string, rawModel json.RawMessage) ([]byte, bool, error) {
-	upstreamModel = strings.TrimSpace(upstreamModel)
-	if upstreamModel == "" {
-		return body, false, nil
-	}
-
-	currentModel = strings.TrimSpace(currentModel)
-	if currentModel == "" || currentModel == upstreamModel {
-		return body, false, nil
-	}
-	if len(rawModel) == 0 {
-		var err error
-		rawModel, err = json.Marshal(upstreamModel)
-		if err != nil {
-			return nil, false, err
-		}
-	}
-	if rewritten, ok := replaceSingleTopLevelRawJSONFieldInPlace(body, "model", rawModel); ok {
-		return rewritten, true, nil
-	}
-	return rewriteRequestModelForProviderFromModelJSON(body, currentModel, upstreamModel, rawModel)
 }
 
 func applyProviderModelRequestPolicy(body []byte, endpoint string, owner providerModel) []byte {
@@ -346,19 +308,6 @@ func (h *ProxyHandler) postResolvedProviderRequestForModel(
 	extraHeaders http.Header,
 	requestModel string,
 ) (*http.Response, error) {
-	return h.postResolvedProviderRequestForModelWithOwnership(ctx, provider, owner, endpoint, body, extraHeaders, requestModel, false)
-}
-
-func (h *ProxyHandler) postResolvedProviderRequestForModelWithOwnership(
-	ctx context.Context,
-	provider *providerRuntime,
-	owner providerModel,
-	endpoint string,
-	body []byte,
-	extraHeaders http.Header,
-	requestModel string,
-	mutable bool,
-) (*http.Response, error) {
 	if provider == nil {
 		return nil, &providerRequestError{statusCode: http.StatusInternalServerError, err: fmt.Errorf("provider is required")}
 	}
@@ -366,7 +315,7 @@ func (h *ProxyHandler) postResolvedProviderRequestForModelWithOwnership(
 		ctx = context.Background()
 	}
 
-	preparedBody, err := prepareResolvedProviderRequestBodyWithOwnership(body, requestModel, endpoint, provider, owner, mutable)
+	preparedBody, err := prepareResolvedProviderRequestBody(body, requestModel, endpoint, provider, owner)
 	if err != nil {
 		return nil, &providerRequestError{statusCode: http.StatusBadRequest, err: err}
 	}

--- a/proxy/upstream_http_test.go
+++ b/proxy/upstream_http_test.go
@@ -76,6 +76,21 @@ func TestExtractRequestModel(t *testing.T) {
 			body: `["gpt-4.1"]`,
 			want: "",
 		},
+		{
+			name: "escaped model string",
+			body: `{"model":"gpt-4\u002e1","input":"hello"}`,
+			want: "gpt-4.1",
+		},
+		{
+			name: "first duplicate model is preserved",
+			body: `{"model":"first","model":"second"}`,
+			want: "first",
+		},
+		{
+			name: "escaped model key falls back to decoder",
+			body: `{"mo\u0064el":"gpt-4.1"}`,
+			want: "gpt-4.1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -94,6 +109,48 @@ func TestReadDirectAnthropicJSONBodyRejectsOversizedExplicitResponse(t *testing.
 	}
 	if data != nil {
 		t.Fatalf("readDirectAnthropicJSONBody() data = %q, want nil on oversized response", data)
+	}
+}
+
+func TestReadUsageSniffPrefixUsesKnownLengthWithoutTruncatingMismatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		contentLength int64
+	}{
+		{name: "exact", body: "payload", contentLength: int64(len("payload"))},
+		{name: "shorter than advertised", body: "short", contentLength: 20},
+		{name: "longer than advertised", body: "longer payload", contentLength: 4},
+		{name: "unknown", body: "unknown", contentLength: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, pooledBuffer, err := readUsageSniffPrefix(strings.NewReader(tt.body), tt.contentLength)
+			defer releaseUsageSniffBuffer(pooledBuffer)
+			if err != nil {
+				t.Fatalf("readUsageSniffPrefix() error = %v", err)
+			}
+			if string(got) != tt.body {
+				t.Fatalf("readUsageSniffPrefix() = %q, want %q", got, tt.body)
+			}
+		})
+	}
+}
+
+func TestProviderRouteFromRequestUsesInferenceBodyWithContextFallback(t *testing.T) {
+	bodyRoute := providerRouteInfo{id: "body-provider", kind: string(providerTypeOpenAICompatible)}
+	contextRoute := providerRouteInfo{id: "context-provider", kind: string(providerTypeAzureOpenAI)}
+	ctx := context.WithValue(context.Background(), providerRouteContextKey{}, contextRoute)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	req.Body = newProviderRequestBody([]byte(`{}`), bodyRoute, false)
+	if got, ok := providerRouteFromRequest(req); !ok || got != bodyRoute {
+		t.Fatalf("providerRouteFromRequest() = %+v, %t; want body route %+v", got, ok, bodyRoute)
+	}
+
+	req.Body = http.NoBody
+	if got, ok := providerRouteFromRequest(req); !ok || got != contextRoute {
+		t.Fatalf("providerRouteFromRequest() fallback = %+v, %t; want context route %+v", got, ok, contextRoute)
 	}
 }
 
@@ -1126,9 +1183,92 @@ func TestPostChatCompletions_UsesAzureClassicDeploymentURLAndKeepsPublicBodyMode
 // bytes, for exercising the passthrough/usage-sniff helpers directly.
 func fakeBodyResponse(body string) *http.Response {
 	return &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(body)),
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+func TestWriteSmallKnownLengthPassthroughSniffingUsagePreservesLengthMismatches(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		body          string
+		contentLength int64
+	}{
+		{name: "exact", body: `{"ok":true}`, contentLength: int64(len(`{"ok":true}`))},
+		{name: "shorter than advertised", body: `{"ok":true}`, contentLength: 100},
+		{name: "longer than advertised", body: `{"ok":true,"extra":true}`, contentLength: 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := fakeBodyResponse(tt.body)
+			resp.ContentLength = tt.contentLength
+			w := httptest.NewRecorder()
+			if err := writePassthroughSniffingUsage(w, resp, nil); err != nil {
+				t.Fatalf("writePassthroughSniffingUsage() error = %v", err)
+			}
+			if got := w.Body.String(); got != tt.body {
+				t.Fatalf("body = %q, want %q", got, tt.body)
+			}
+		})
+	}
+}
+
+func TestBorrowUsageSniffBufferSelectsSizeTier(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		contentLength int64
+		wantCapacity  int
+	}{
+		{name: "tiny", contentLength: usageSniffTinyBufferSize - 1, wantCapacity: usageSniffTinyBufferSize},
+		{name: "small", contentLength: usageSniffTinyBufferSize, wantCapacity: usageSniffSmallBufferSize},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := borrowUsageSniffBuffer(tt.contentLength)
+			defer releaseUsageSniffBuffer(buffer)
+			if got := cap(*buffer); got != tt.wantCapacity {
+				t.Fatalf("buffer capacity = %d, want %d", got, tt.wantCapacity)
+			}
+		})
+	}
+}
+
+type bytesAndErrorReadCloser struct {
+	body []byte
+	err  error
+	done bool
+}
+
+func (r *bytesAndErrorReadCloser) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	r.done = true
+	return copy(p, r.body), r.err
+}
+
+func (*bytesAndErrorReadCloser) Close() error { return nil }
+
+func TestWriteSmallKnownLengthPassthroughSniffingUsageCapturesCancellationWithBytes(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(errProxyLifecycleShutdown)
+	body := []byte(`{"ok":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	resp := &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          &bytesAndErrorReadCloser{body: body, err: context.Canceled},
+		ContentLength: int64(len(body) - 1),
+		Request:       req,
+	}
+
+	err := writePassthroughSniffingUsage(httptest.NewRecorder(), resp, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("writePassthroughSniffingUsage() error = %v, want context.Canceled", err)
+	}
+	var writeErr *responseBodyWriteError
+	if !errors.As(err, &writeErr) || !writeErr.cancellationAtFailure || !writeErr.upstream || writeErr.committed {
+		t.Fatalf("responseBodyWriteError = %#v, want precommit upstream lifecycle cancellation", writeErr)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,26 @@ type responseRecorder struct {
 	bytes  int64
 }
 
+var responseRecorderPool = sync.Pool{
+	New: func() any { return new(responseRecorder) },
+}
+
+func acquireResponseRecorder(w http.ResponseWriter) *responseRecorder {
+	recorder := responseRecorderPool.Get().(*responseRecorder)
+	recorder.ResponseWriter = w
+	return recorder
+}
+
+func releaseResponseRecorder(recorder *responseRecorder) {
+	if recorder == nil {
+		return
+	}
+	recorder.ResponseWriter = nil
+	recorder.status = 0
+	recorder.bytes = 0
+	responseRecorderPool.Put(recorder)
+}
+
 func (r *responseRecorder) WriteHeader(status int) {
 	if r.status != 0 {
 		return
@@ -216,8 +236,12 @@ func withProviderValidationGate(next http.Handler, handler startupReadinessGate)
 func withRequestLog(next http.Handler, log *logger.Logger, handler *proxy.ProxyHandler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		recorder := &responseRecorder{ResponseWriter: w}
-		ctx, summary := proxy.WithRequestSummary(r.Context())
+		recorder := acquireResponseRecorder(w)
+		defer releaseResponseRecorder(recorder)
+		ctx, summary, ownsSummary := proxy.AcquireRequestSummary(r.Context())
+		if ownsSummary {
+			defer proxy.ReleaseRequestSummary(summary)
+		}
 
 		admitted := handler == nil || !handler.ShuttingDown() || r.URL.Path == "/healthz"
 		tracked := admitted && handler != nil && handler.TracksRequest(r.Method, r.URL.Path)
@@ -236,14 +260,14 @@ func withRequestLog(next http.Handler, log *logger.Logger, handler *proxy.ProxyH
 		}
 
 		r = r.WithContext(ctx)
-		var releaseRequestBody func()
+		var requestBodyBinding proxy.RequestBodyLifecycleBinding
 		if admitted && handler != nil {
-			var forceClose func()
+			var forceClose io.Closer
 			if conn, ok := r.Context().Value(serverConnContextKey{}).(net.Conn); ok && conn != nil {
-				forceClose = func() { _ = conn.Close() }
+				forceClose = conn
 			}
-			releaseRequestBody = handler.BindRequestBodyToLifecycle(r, forceClose)
-			defer releaseRequestBody()
+			requestBodyBinding = handler.BindRequestBodyToLifecycle(r, forceClose)
+			defer requestBodyBinding.ReleaseAndRecycle(r)
 		}
 		if admitted {
 			next.ServeHTTP(recorder, r)
@@ -266,7 +290,7 @@ func withRequestLog(next http.Handler, log *logger.Logger, handler *proxy.ProxyH
 		if tracked && !summary.StatsSuppressed() {
 			handler.RecordRequest(summary, statsStatus, r.Header.Get("User-Agent"), elapsed)
 		}
-		if log != nil {
+		if log != nil && log.Enabled(logger.LevelInfo) {
 			fields := []logger.Field{
 				logger.F("method", r.Method),
 				logger.F("path", r.URL.Path),


### PR DESCRIPTION
## Summary

- add bounded JSON fast paths for common OpenAI Chat request and response inspection while preserving compatibility fallbacks
- reduce per-request allocations across routing, lifecycle tracking, request summaries, upstream I/O, retries, and provider request construction
- default serve-mode garbage collection to GOGC=200 unless the operator explicitly configures GOGC

## Validation

- make test
- make vet
- make lint
- make build
- go test -race ./... -count=1