### PR TITLE
docs: add upstream error troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Documentation lives under [`docs/`](docs/README.md); start with these:
 | [Responses WebSocket](docs/responses-websocket.md)           | Websocket bridge tuning             |
 | [Client Examples](docs/clients.md)                           | Copy-paste snippets per client      |
 | [Agent Launchers](docs/agent-launchers.md)                   | One-command coding-agent sessions   |
+| [Troubleshooting](docs/troubleshooting.md)                   | Recovery for client-visible errors  |
 | [API Reference](docs/api.md)                                 | Endpoint behavior and compatibility |
 | [Architecture](docs/architecture.md)                         | Package layout and design notes     |
 | [Traffic Dashboard](docs/dashboard.md)                       | Live browser dashboard and stats    |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This folder is intentionally split into small, single-purpose files so humans an
 | [`responses-websocket.md`](responses-websocket.md) | Codex-style `GET /v1/responses` websocket bridge tuning | websocket bridge, auto-compaction, or compact retry knobs change |
 | [`clients.md`](clients.md) | copy-paste client examples | onboarding snippets or client compatibility changes |
 | [`agent-launchers.md`](agent-launchers.md) | one-command coding-agent launchers, lifecycle, logs, and credential isolation | launcher targets, flags, process lifecycle, or child configuration changes |
+| [`troubleshooting.md`](troubleshooting.md) | symptom-based recovery and diagnostic guidance for client-visible failures | a recurring failure gains a known recovery path or new diagnostic evidence |
 | [`api.md`](api.md) | public endpoint map plus cross-surface Chat/Responses compatibility contract | public routes or Chat compatibility behavior changes |
 | [`gemini.md`](gemini.md) | Gemini translation compatibility details | Gemini request/response translation behavior changes |
 | [`responses.md`](responses.md) | native Responses behavior, the Chat-over-Responses boundary, compact, and memory shims | Responses passthrough, Chat adaptation, compaction, or shim behavior changes |

--- a/docs/agent-launchers.md
+++ b/docs/agent-launchers.md
@@ -318,7 +318,7 @@ browser dashboard is not exposed. The end-of-session summary is written to
 stderr so non-interactive agent output on stdout remains pipeline-safe.
 
 If Codex reports an upstream `408 user_request_timeout`, see
-[Upstream 408 request-body timeout](responses.md#upstream-408-request-body-timeout)
+[Troubleshooting](troubleshooting.md#408-user_request_timeout-timed-out-reading-request-body)
 for retry and diagnosis guidance.
 
 ## Credential and process isolation

--- a/docs/agent-launchers.md
+++ b/docs/agent-launchers.md
@@ -317,6 +317,10 @@ The startup banner prints the exact proxy URL and log path. Routes other than
 browser dashboard is not exposed. The end-of-session summary is written to
 stderr so non-interactive agent output on stdout remains pipeline-safe.
 
+If Codex reports an upstream `408 user_request_timeout`, see
+[Upstream 408 request-body timeout](responses.md#upstream-408-request-body-timeout)
+for retry and diagnosis guidance.
+
 ## Credential and process isolation
 
 The child receives a sanitized copy of the parent environment. Vekil removes:

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -10,34 +10,8 @@ Detailed behavior for Vekil-owned Responses compatibility features. For the gene
 
 `POST /v1/responses` requests are accepted up to `64 MiB` so oversized session replays can reach the proxy-owned compaction fallback instead of failing at the default request-body limit. If upstream rejects a replay-like request with `413 Payload Too Large`, the proxy can compact the older prefix of an array `input` and retry the request with one proxy-owned checkpoint plus the most recent tail items. A request is treated as replay-like only when the body contains prior transcript evidence such as assistant/tool output items or a proxy-owned compaction checkpoint; `previous_response_id` and Codex turn/window headers alone do not trigger summarization. The fallback starts by preserving the configured tail, aligns the tail boundary so tool/function call-output pairs are not split across the checkpoint, and under `413` pressure dynamically halves the preserved tail (`12 -> 6 -> 3 -> 1`, or `len(input)-1` first for shorter replays) and retries until the compacted replay fits or only the latest item remains. The compaction calls share the same attempt budget and chunking controls as `/v1/responses/compact` (`--compact-upstream-chunk-bytes` and `--compact-upstream-max-attempts`). When a provider/model returns `413` for a compaction body, the proxy remembers the smaller target in memory for 30 minutes and starts later compaction fallbacks for that provider/model at the learned target, while the normal no-413 `/v1/responses` fast path remains unchanged. If the internal compaction result is incomplete, lacks nonempty message output text, or exceeds the summary-response limit, Vekil returns the original `413` instead of retrying with an empty or partial checkpoint.
 
-### Upstream 408 request-body timeout
-
-Codex may report an error like this:
-
-```text
-unexpected status 408 Request Timeout: upstream error (408):
-Timed out reading request body. Try again, or use a smaller request size.
-(code=user_request_timeout)
-```
-
-The URL in the error is the local Vekil endpoint because that is where Codex
-connected. The nested `upstream error` means the selected provider returned the
-408 while reading the forwarded body. This is separate from Vekil's `64 MiB`
-inbound request limit. Increasing `--streaming-upstream-timeout` does not address
-it because response streaming has not started yet.
-
-Retry the turn first. Vekil treats HTTP 408 as transient and sends a fresh
-request body within its retry budget. The client may also retry, and every
-attempt receives a new request ID. If the same session keeps failing, compact it
-or start a new session with less history.
-
-Keep the failed request ID and timestamp. For launcher sessions, inspect the
-proxy JSON log path printed in the startup banner. For a normal server, use the
-dashboard or `GET /stats.json`: `status_codes` counts final 408 responses,
-`retries_by_code` counts internal 408 retries, and a newer `recent` entry with
-`status: 200` confirms recovery. If several independent sessions fail in the
-same time window, capture their request IDs before investigating the selected
-provider's ingress path.
+If a client reports `408 user_request_timeout` or "Timed out reading request
+body," see [Troubleshooting](troubleshooting.md#408-user_request_timeout-timed-out-reading-request-body).
 
 Like chat completions, Responses requests are routed by the public `model` ID. Legacy unsupported-model fallback remains on the selected provider. A version-2 `priority_failover` route is different: it may try the next equivalent target in that same public route, but it never falls back to another public model route.
 

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -10,6 +10,35 @@ Detailed behavior for Vekil-owned Responses compatibility features. For the gene
 
 `POST /v1/responses` requests are accepted up to `64 MiB` so oversized session replays can reach the proxy-owned compaction fallback instead of failing at the default request-body limit. If upstream rejects a replay-like request with `413 Payload Too Large`, the proxy can compact the older prefix of an array `input` and retry the request with one proxy-owned checkpoint plus the most recent tail items. A request is treated as replay-like only when the body contains prior transcript evidence such as assistant/tool output items or a proxy-owned compaction checkpoint; `previous_response_id` and Codex turn/window headers alone do not trigger summarization. The fallback starts by preserving the configured tail, aligns the tail boundary so tool/function call-output pairs are not split across the checkpoint, and under `413` pressure dynamically halves the preserved tail (`12 -> 6 -> 3 -> 1`, or `len(input)-1` first for shorter replays) and retries until the compacted replay fits or only the latest item remains. The compaction calls share the same attempt budget and chunking controls as `/v1/responses/compact` (`--compact-upstream-chunk-bytes` and `--compact-upstream-max-attempts`). When a provider/model returns `413` for a compaction body, the proxy remembers the smaller target in memory for 30 minutes and starts later compaction fallbacks for that provider/model at the learned target, while the normal no-413 `/v1/responses` fast path remains unchanged. If the internal compaction result is incomplete, lacks nonempty message output text, or exceeds the summary-response limit, Vekil returns the original `413` instead of retrying with an empty or partial checkpoint.
 
+### Upstream 408 request-body timeout
+
+Codex may report an error like this:
+
+```text
+unexpected status 408 Request Timeout: upstream error (408):
+Timed out reading request body. Try again, or use a smaller request size.
+(code=user_request_timeout)
+```
+
+The URL in the error is the local Vekil endpoint because that is where Codex
+connected. The nested `upstream error` means the selected provider returned the
+408 while reading the forwarded body. This is separate from Vekil's `64 MiB`
+inbound request limit. Increasing `--streaming-upstream-timeout` does not address
+it because response streaming has not started yet.
+
+Retry the turn first. Vekil treats HTTP 408 as transient and sends a fresh
+request body within its retry budget. The client may also retry, and every
+attempt receives a new request ID. If the same session keeps failing, compact it
+or start a new session with less history.
+
+Keep the failed request ID and timestamp. For launcher sessions, inspect the
+proxy JSON log path printed in the startup banner. For a normal server, use the
+dashboard or `GET /stats.json`: `status_codes` counts final 408 responses,
+`retries_by_code` counts internal 408 retries, and a newer `recent` entry with
+`status: 200` confirms recovery. If several independent sessions fail in the
+same time window, capture their request IDs before investigating the selected
+provider's ingress path.
+
 Like chat completions, Responses requests are routed by the public `model` ID. Legacy unsupported-model fallback remains on the selected provider. A version-2 `priority_failover` route is different: it may try the next equivalent target in that same public route, but it never falls back to another public model route.
 
 For responses-only Azure deployments such as the `gpt-5.4-pro` example configuration, this is the canonical inference path.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+Start with the status code or error text shown by the client. Each entry explains
+what the error means, what to try first, how to confirm recovery, and what to
+capture if it keeps happening.
+
+## `408 user_request_timeout`: timed out reading request body
+
+### Symptom
+
+Codex may report:
+
+```text
+unexpected status 408 Request Timeout: upstream error (408):
+Timed out reading request body. Try again, or use a smaller request size.
+(code=user_request_timeout)
+```
+
+The URL in the error is the local Vekil endpoint because Codex connected to
+Vekil. The nested `upstream error` means the selected provider returned the 408
+while reading the forwarded body.
+
+This is separate from Vekil's `64 MiB` inbound limit for Responses requests.
+Changing `--streaming-upstream-timeout` does not address it because response
+streaming has not started.
+
+### What to do first
+
+Retry the turn. Vekil treats HTTP 408 as transient and sends a fresh request body
+within its retry budget. The client may also retry after Vekil returns the final
+error.
+
+If the same session keeps failing, compact it or start a new session with less
+history. If several independent sessions fail in the same time window, the
+selected provider's ingress path may be having trouble accepting request bodies.
+
+### How to confirm recovery
+
+For a launcher session, inspect the proxy JSON log path printed in the startup
+banner. For a normal server, use the dashboard or `GET /stats.json`:
+
+- `retries_by_code` with label `408` means Vekil retried an upstream 408.
+- `status_codes` with label `408` counts requests that still ended with 408.
+- A newer `recent` entry for the same endpoint and model with `"status": 200`
+  confirms that a later request completed.
+
+### What to capture if it repeats
+
+Keep the failed request ID and timestamp. Also record the public model or route,
+whether one or several sessions were affected, and the relevant proxy log lines.
+These details distinguish one large session replay from a provider-wide
+ingress problem without exposing the request body.


### PR DESCRIPTION
## Summary

- add a symptom-based troubleshooting guide for client-visible failures
- document what `408 user_request_timeout` means, how to recover, and how to confirm the retry succeeded
- link the guide from Responses, agent launchers, and both documentation indexes

## Validation

- `go test ./proxy -run TestRetryable -count=1`
- relative Markdown links resolve
- `git diff --check`