### PR TITLE
fix(proxy): omit empty role from streaming chat completion deltas

### DIFF
--- a/models/openai.go
+++ b/models/openai.go
@@ -33,7 +33,7 @@ type StreamOptions struct {
 
 // OpenAIMessage is a single message in an OpenAI conversation.
 type OpenAIMessage struct {
-	Role       string           `json:"role"`
+	Role       string           `json:"role,omitempty"`
 	Content    json.RawMessage  `json:"content,omitempty"`
 	Refusal    json.RawMessage  `json:"refusal,omitempty"`
 	Name       string           `json:"name,omitempty"`

--- a/models/openai_test.go
+++ b/models/openai_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOpenAIStreamChoiceOmitsEmptyDeltaRole(t *testing.T) {
+	choice := OpenAIStreamChoice{
+		Index: 0,
+		Delta: OpenAIMessage{Content: json.RawMessage(`"hello"`)},
+	}
+
+	got, err := json.Marshal(choice)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"index":0,"delta":{"content":"hello"}}`; string(got) != want {
+		t.Fatalf("json.Marshal() = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
Streaming chat-completion chunks serialize the delta through `OpenAIMessage`, whose `role` field has no `omitempty`, so content deltas carry `"role":""`. Clients that validate chunks against the OpenAI schema (OpenCode via `@ai-sdk/openai-compatible`) reject the empty enum value and fail the request with `Type validation failed`. Found while running OpenCode behind Orka's ACP provider proxy with vekil `latest` and `v0.14.1`.

Test plan: `go test ./models/... ./proxy/...` green; verified live that OpenCode completes a prompt once deltas omit the empty role.