### PR TITLE
fix: address issue #362

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ docker run --user "$(id -u):$(id -g)" -e HOME=/home/nonroot \
 
 Native binaries are available from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest).
 
+The server listens on port `1337` by default. Override it with the `--port`
+flag or the equivalent `PORT` environment variable:
+
+```bash
+vekil --port 8080
+```
+
 On Apple Silicon Macs, install the native tray app via Homebrew:
 
 ```bash


### PR DESCRIPTION
## Summary

Automated implementation for issue #362.

## Source

Issue title: Document the --port flag and default port in the README

Closes #362.

## Validation

See Orka task `monissue-vekil-monitor-362-issue-implementation-monr-967f713ccf` for execution details.
