### PR TITLE
fix: address issue #366

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ docker run --user "$(id -u):$(id -g)" -e HOME=/home/nonroot \
 
 Native binaries are available from [GitHub Releases](https://github.com/sozercan/vekil/releases/latest).
 
+### Use a different port
+
+The native binary listens on port 1337 by default. Choose another port with
+either the flag or environment variable:
+
+```bash
+vekil --port 8080
+PORT=8080 vekil
+```
+
+Update client and API base URLs to use the selected port, for example
+`http://localhost:8080`. With Docker, `-p 127.0.0.1:8080:1337` changes only the
+host-facing port. To also change Vekil's listener inside the container, set a
+matching container port:
+
+```bash
+docker run --rm -e PORT=8080 -p 127.0.0.1:8080:8080 ghcr.io/sozercan/vekil:latest
+```
+
+If startup reports `address already in use`, identify the process listening on
+the default port on Unix-like systems, then stop that process or choose another
+port:
+
+```bash
+lsof -nP -iTCP:1337 -sTCP:LISTEN
+```
+
 On Apple Silicon Macs, install the native tray app via Homebrew:
 
 ```bash


### PR DESCRIPTION
## Summary

Automated implementation for issue #366.

## Source

Issue title: Document how to run vekil on a non-default port and what to do when :1337 is already in use

Closes #366.

## Validation

See Orka task `monissue-vekil-monitor-366-issue-implementation-monr-19166c9bb0` for execution details.
