### PR TITLE
feat(launch): support foreground session resume

### DIFF
--- a/docs/agent-launchers.md
+++ b/docs/agent-launchers.md
@@ -35,6 +35,13 @@ vekil launch codex \
 Arguments after `--` are forwarded to the selected agent:
 
 ```bash
+vekil launch claude --model claude-opus-5 -- \
+  --resume 56d7498d-6b2e-47ca-92a6-92ddee84ab25
+
+vekil launch codex -- resume --last
+
+vekil launch copilot --model gpt-5.4-mini -- --continue
+
 vekil launch codex -- \
   exec --ephemeral --skip-git-repo-check "Review this workspace"
 
@@ -42,10 +49,16 @@ vekil launch copilot --model gpt-5.4-mini -- \
   --allow-all-tools -p "Review this workspace" -s
 ```
 
-Each launcher reserves model, provider, remote-session, resume, and other
-arguments that could replace the validated routing layer or leave work running
-outside the ephemeral proxy lifecycle. To pin Claude Code or Codex CLI, use the
-launcher's `--model` before `--`; forwarded model overrides remain rejected.
+Foreground resume and fork arguments remain attached to the supervised child
+process and are forwarded. Each launcher still reserves model, provider,
+remote-session, background, server, and other arguments that could replace the
+validated routing layer or leave work running outside the ephemeral proxy
+lifecycle. To pin Claude Code or Codex CLI, use the launcher's `--model` before
+`--`; forwarded model overrides remain rejected.
+
+The proxy and its local credential are ephemeral. Agent-owned conversation
+history can persist across launches, and a resumed conversation uses the new
+launch's provider routing and optional model pin.
 
 ## Model selection modes
 
@@ -131,6 +144,9 @@ settings are printed as `unresolved` instead of being guessed.
 ```bash
 vekil launch claude -- --allowed-tools Read
 
+vekil launch claude --model claude-opus-5 -- \
+  --resume 56d7498d-6b2e-47ca-92a6-92ddee84ab25
+
 vekil launch claude --model claude-sonnet-4.5 -- \
   --allowed-tools "Read,Bash(git status:*)"
 ```
@@ -195,14 +211,17 @@ Responses-backed bridge are accepted only for a single-target baseline in
 `off` or `observe`, and that bridge must be one process (the normal loopback
 launcher topology) or use sticky ingress to the replay-owning replica.
 
-Forwarded settings-source, detached-session, resume, model/fallback, incompatible
-permission-mode, and custom-agent overrides are rejected. Use the
-launcher-level `--model` to pin a model; otherwise model selection remains
+Foreground conversation selection, continuation, and fork arguments are
+forwarded. Settings-source, detached or remote session, model/fallback,
+incompatible permission-mode, and custom-agent overrides remain rejected. Use
+the launcher-level `--model` to pin a model; otherwise model selection remains
 delegated to Claude's normal default.
 
 ## OpenAI Codex CLI
 
 ```bash
+vekil launch codex -- resume --last
+
 vekil launch codex -- \
   exec --ephemeral --skip-git-repo-check "Reply with exactly OK"
 
@@ -265,18 +284,20 @@ support `/responses`. Because the launcher cannot know the choice in advance,
 an unknown or incompatible default fails when Codex requests it rather than
 during launcher startup.
 
+Foreground `resume`, `fork`, and `exec resume` commands are forwarded.
 Forwarded `-m`/`--model`, `-c`/`--config`, profile, OSS/local-provider, remote,
-resume/fork, app-server, remote-control, cloud, and non-agent command modes are
-rejected. For a pinned policy-owned model, forwarded `--search`, equivalent
-web-search feature toggles, and attempts to re-enable `code_mode`,
-`code_mode_only`, or `remote_compaction_v2` are also rejected so the
-compatibility safeguards remain authoritative. Use the launcher-level
-`--model` to pin a model; otherwise selection remains delegated to Codex's
-normal default.
+app-server, remote-control, cloud, and non-agent command modes remain rejected.
+For a pinned policy-owned model, forwarded `--search`, equivalent web-search
+feature toggles, and attempts to re-enable `code_mode`, `code_mode_only`, or
+`remote_compaction_v2` are also rejected so the compatibility safeguards remain
+authoritative. Use the launcher-level `--model` to pin a model; otherwise
+selection remains delegated to Codex's normal default.
 
 ## GitHub Copilot CLI
 
 ```bash
+vekil launch copilot --model gpt-5.4-mini -- --continue
+
 vekil launch copilot --model gpt-5.4-mini -- \
   --allow-all-tools -p "Reply with exactly OK" -s
 ```
@@ -301,8 +322,11 @@ MCPs. `--secret-env-vars` removes the local token plus provider and GitHub
 credential names from shell and MCP subprocesses. Inherited GitHub, OpenAI,
 Anthropic, Azure, provider, and telemetry-header credentials are removed.
 
-Forwarded model, custom-agent, secret-environment, connect/resume/session,
-remote/export/share, ACP-server, and non-agent subcommands are rejected.
+Foreground local resume and continue arguments are forwarded. Forwarded model,
+custom-agent, secret-environment, connect/session-ID, remote/export/share,
+ACP-server, and non-agent subcommands remain rejected. Copilot's offline launch
+mode cannot resume remote task IDs even though `--resume` accepts task IDs as
+well as local session IDs.
 
 ## Logs and statistics
 

--- a/docs/agent-launchers.md
+++ b/docs/agent-launchers.md
@@ -323,10 +323,9 @@ credential names from shell and MCP subprocesses. Inherited GitHub, OpenAI,
 Anthropic, Azure, provider, and telemetry-header credentials are removed.
 
 Foreground local resume and continue arguments are forwarded. Forwarded model,
-custom-agent, secret-environment, connect/session-ID, remote/export/share,
-ACP-server, and non-agent subcommands remain rejected. Copilot's offline launch
-mode cannot resume remote task IDs even though `--resume` accepts task IDs as
-well as local session IDs.
+custom-agent, connect/session-ID, remote/export/share, ACP-server, and non-agent
+subcommands remain rejected. Copilot's offline launch mode cannot resume remote
+task IDs even though `--resume` accepts task IDs as well as local session IDs.
 
 ## Logs and statistics
 

--- a/launch/claude.go
+++ b/launch/claude.go
@@ -171,8 +171,9 @@ func validateClaudeForwardedArgs(args []string) error {
 	expectValue := false
 	seenPositional := false
 	printMode := false
+	foregroundSession := false
 	endOptions := false
-	for _, arg := range args {
+	for index, arg := range args {
 		if expectValue {
 			expectValue = false
 			continue
@@ -196,27 +197,28 @@ func validateClaudeForwardedArgs(args []string) error {
 				arg == "--tmux" || strings.HasPrefix(arg, "--tmux="),
 				arg == "--remote" || strings.HasPrefix(arg, "--remote="),
 				arg == "--cloud" || strings.HasPrefix(arg, "--cloud="),
-				arg == "--remote-control" || strings.HasPrefix(arg, "--remote-control=") || arg == "--rc",
-				arg == "--fork-session":
+				arg == "--environment" || strings.HasPrefix(arg, "--environment="),
+				arg == "--teleport" || strings.HasPrefix(arg, "--teleport="),
+				arg == "--remote-control" || strings.HasPrefix(arg, "--remote-control=") || arg == "--rc":
 				return fmt.Errorf("detached Claude sessions are not supported by an ephemeral Vekil launcher")
 			case arg == "--model" || strings.HasPrefix(arg, "--model="),
 				arg == "--fallback-model" || strings.HasPrefix(arg, "--fallback-model="),
-				arg == "--continue" || arg == "-c",
-				arg == "--resume" || strings.HasPrefix(arg, "--resume=") || arg == "-r" || strings.HasPrefix(arg, "-r"),
-				arg == "--session-id" || strings.HasPrefix(arg, "--session-id="),
-				arg == "--from-pr" || strings.HasPrefix(arg, "--from-pr="),
-				arg == "--teleport" || strings.HasPrefix(arg, "--teleport="),
 				arg == "--agent" || strings.HasPrefix(arg, "--agent="),
 				arg == "--agents" || strings.HasPrefix(arg, "--agents="):
-				return fmt.Errorf("claude model or session overrides are not supported by the managed Vekil launcher")
+				return fmt.Errorf("claude model or custom-agent overrides are not supported by the managed Vekil launcher")
+			case claudeForegroundSessionSelector(arg):
+				foregroundSession = true
+				if claudeSessionSelectorHasOptionalValue(arg) && index+1 < len(args) && !strings.HasPrefix(args[index+1], "-") {
+					expectValue = true
+				}
 			}
-			if claudeOptionRequiresValue(arg) {
+			if claudeOptionRequiresValue(arg) && index+1 < len(args) && !strings.HasPrefix(args[index+1], "-") {
 				expectValue = true
 			}
 			continue
 		}
 		if !seenPositional {
-			if !printMode && claudeNonAgentCommand(arg) {
+			if !printMode && !foregroundSession && claudeNonAgentCommand(arg) {
 				return fmt.Errorf("detached Claude agent-management commands are not supported by an ephemeral Vekil launcher")
 			}
 			seenPositional = true
@@ -264,7 +266,29 @@ func unsupportedClaudePermissionMode(mode string) error {
 func claudeNonAgentCommand(command string) bool {
 	switch command {
 	case "agents", "attach", "auth", "auto-mode", "doctor", "gateway", "install", "mcp",
-		"plugin", "plugins", "project", "remote-control", "setup-token", "ultrareview", "update", "upgrade":
+		"import", "kill", "logs", "plugin", "plugins", "project", "remote-control", "respawn", "rm",
+		"setup-token", "stop", "ultrareview", "update", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func claudeForegroundSessionSelector(arg string) bool {
+	switch {
+	case arg == "--continue" || arg == "-c",
+		arg == "--resume" || strings.HasPrefix(arg, "--resume=") || arg == "-r" || strings.HasPrefix(arg, "-r"),
+		arg == "--session-id" || strings.HasPrefix(arg, "--session-id="),
+		arg == "--from-pr" || strings.HasPrefix(arg, "--from-pr="):
+		return true
+	default:
+		return false
+	}
+}
+
+func claudeSessionSelectorHasOptionalValue(arg string) bool {
+	switch arg {
+	case "--resume", "-r", "--from-pr":
 		return true
 	default:
 		return false

--- a/launch/claude_test.go
+++ b/launch/claude_test.go
@@ -418,9 +418,13 @@ func TestClaudeAdapterRejectsUnsupportedForwardedModes(t *testing.T) {
 		{name: "attached init only", args: []string{"--init-only=true"}, want: "initialization-only"},
 		{name: "background", args: []string{"--background"}, want: "detached Claude sessions"},
 		{name: "tmux", args: []string{"--tmux"}, want: "detached Claude sessions"},
-		{name: "model", args: []string{"--model", "responses-only"}, want: "model or session overrides"},
-		{name: "model after prompt", args: []string{"--print", "hello", "--model", "responses-only"}, want: "model or session overrides"},
-		{name: "fallback model", args: []string{"--fallback-model", "other"}, want: "model or session overrides"},
+		{name: "cloud", args: []string{"--cloud"}, want: "detached Claude sessions"},
+		{name: "environment", args: []string{"--environment", "ccpool_test"}, want: "detached Claude sessions"},
+		{name: "teleport", args: []string{"--teleport", "session-id"}, want: "detached Claude sessions"},
+		{name: "remote control", args: []string{"--remote-control"}, want: "detached Claude sessions"},
+		{name: "model", args: []string{"--model", "responses-only"}, want: "model or custom-agent overrides"},
+		{name: "model after prompt", args: []string{"--print", "hello", "--model", "responses-only"}, want: "model or custom-agent overrides"},
+		{name: "fallback model", args: []string{"--fallback-model", "other"}, want: "model or custom-agent overrides"},
 		{name: "dangerous permission bypass", args: []string{"--dangerously-skip-permissions"}, want: "permission bypass"},
 		{name: "enable dangerous permission bypass", args: []string{"--allow-dangerously-skip-permissions"}, want: "permission bypass"},
 		{name: "accept edits permission mode", args: []string{"--permission-mode", "acceptEdits"}, want: "permission mode"},
@@ -428,12 +432,7 @@ func TestClaudeAdapterRejectsUnsupportedForwardedModes(t *testing.T) {
 		{name: "bypass permission mode", args: []string{"--permission-mode", "bypassPermissions"}, want: "permission mode"},
 		{name: "dont ask permission mode", args: []string{"--permission-mode=dontAsk"}, want: "permission mode"},
 		{name: "plan permission mode", args: []string{"--permission-mode", "plan"}, want: "permission mode"},
-		{name: "resume", args: []string{"--resume"}, want: "model or session overrides"},
-		{name: "attached short resume", args: []string{"-rsession-id"}, want: "model or session overrides"},
-		{name: "session id", args: []string{"--session-id", "00000000-0000-0000-0000-000000000000"}, want: "model or session overrides"},
-		{name: "attached session id", args: []string{"--session-id=00000000-0000-0000-0000-000000000000"}, want: "model or session overrides"},
-		{name: "custom agent", args: []string{"--agent", "reviewer"}, want: "model or session overrides"},
-		{name: "teleport", args: []string{"--teleport", "session"}, want: "model or session overrides"},
+		{name: "custom agent", args: []string{"--agent", "reviewer"}, want: "model or custom-agent overrides"},
 		{name: "subcommand after option", args: []string{"--verbose", "remote-control"}, want: "agent-management commands"},
 		{name: "subcommand after max turns", args: []string{"--max-turns", "5", "agents"}, want: "agent-management commands"},
 		{name: "subcommand after name", args: []string{"--name", "session", "agents"}, want: "agent-management commands"},
@@ -445,7 +444,14 @@ func TestClaudeAdapterRejectsUnsupportedForwardedModes(t *testing.T) {
 		{name: "gateway subcommand", args: []string{"gateway"}, want: "agent-management commands"},
 		{name: "auth subcommand", args: []string{"auth"}, want: "agent-management commands"},
 		{name: "doctor subcommand", args: []string{"doctor"}, want: "agent-management commands"},
+		{name: "import subcommand", args: []string{"import"}, want: "agent-management commands"},
 		{name: "install subcommand", args: []string{"install"}, want: "agent-management commands"},
+		{name: "logs subcommand", args: []string{"logs", "session-id"}, want: "agent-management commands"},
+		{name: "respawn subcommand", args: []string{"respawn", "session-id"}, want: "agent-management commands"},
+		{name: "remove subcommand", args: []string{"rm", "session-id"}, want: "agent-management commands"},
+		{name: "stop subcommand", args: []string{"stop", "session-id"}, want: "agent-management commands"},
+		{name: "kill subcommand", args: []string{"kill", "session-id"}, want: "agent-management commands"},
+		{name: "fork modifier before subcommand", args: []string{"--fork-session", "agents"}, want: "agent-management commands"},
 		{name: "subcommand after delimiter", args: []string{"--", "remote-control"}, want: "agent-management commands"},
 	}
 	for _, tc := range tests {
@@ -459,6 +465,103 @@ func TestClaudeAdapterRejectsUnsupportedForwardedModes(t *testing.T) {
 			})
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("Prepare() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeAdapterPreservesForegroundSessionArgs(t *testing.T) {
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable(): %v", err)
+	}
+	sessionID := "56d7498d-6b2e-47ca-92a6-92ddee84ab25"
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "resume picker", args: []string{"--resume"}},
+		{name: "resume by id", args: []string{"--resume", sessionID}},
+		{name: "resume search matching subcommand", args: []string{"--resume", "agents"}},
+		{name: "attached resume", args: []string{"--resume=" + sessionID}},
+		{name: "short resume picker", args: []string{"-r"}},
+		{name: "short resume by id", args: []string{"-r", sessionID}},
+		{name: "attached short resume", args: []string{"-r" + sessionID}},
+		{name: "continue", args: []string{"--continue"}},
+		{name: "short continue", args: []string{"-c"}},
+		{name: "continue prompt matching subcommand", args: []string{"--continue", "agents"}},
+		{name: "session id", args: []string{"--session-id", sessionID}},
+		{name: "attached session id", args: []string{"--session-id=" + sessionID}},
+		{name: "from pr picker", args: []string{"--from-pr"}},
+		{name: "from pr", args: []string{"--from-pr", "123"}},
+		{name: "attached from pr", args: []string{"--from-pr=https://github.com/example/repo/pull/123"}},
+		{name: "fork resumed session", args: []string{"--resume", sessionID, "--fork-session"}},
+		{name: "fork continued session", args: []string{"--fork-session", "--continue"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared, err := (ClaudeAdapter{}).Prepare(PrepareInput{
+				BaseURL:       "http://127.0.0.1:43210",
+				Model:         ModelInfo{ID: "claude-public", SupportedEndpoints: []string{"/chat/completions"}},
+				Binary:        binary,
+				LocalToken:    "test-token-placeholder",
+				ForwardedArgs: tc.args,
+				DryRun:        true,
+			})
+			if err != nil {
+				t.Fatalf("Prepare(%#v) error = %v", tc.args, err)
+			}
+			t.Cleanup(func() { _ = prepared.Cleanup() })
+			if len(prepared.Args) != len(tc.args)+2 {
+				t.Fatalf("Args = %#v, want managed settings pair followed by %#v", prepared.Args, tc.args)
+			}
+			if got := prepared.Args[2:]; !reflect.DeepEqual(got, tc.args) {
+				t.Fatalf("forwarded args = %#v, want exact argv %#v", got, tc.args)
+			}
+		})
+	}
+}
+
+func TestClaudeAdapterRejectsUnsafeForegroundSessionCombinations(t *testing.T) {
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable(): %v", err)
+	}
+	sessionID := "56d7498d-6b2e-47ca-92a6-92ddee84ab25"
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "background after resume id", args: []string{"--resume", sessionID, "--background"}, want: "detached Claude sessions"},
+		{name: "background before resume id", args: []string{"--background", "--resume", sessionID}, want: "detached Claude sessions"},
+		{name: "background after resume picker", args: []string{"--resume", "--background"}, want: "detached Claude sessions"},
+		{name: "background after required session id", args: []string{"--session-id", "--background"}, want: "detached Claude sessions"},
+		{name: "tmux after resume", args: []string{"--resume", sessionID, "--tmux"}, want: "detached Claude sessions"},
+		{name: "cloud after continue", args: []string{"--continue", "--cloud"}, want: "detached Claude sessions"},
+		{name: "environment after from pr picker", args: []string{"--from-pr", "--environment", "ccpool_test"}, want: "detached Claude sessions"},
+		{name: "remote control after session id", args: []string{"--session-id", sessionID, "--remote-control"}, want: "detached Claude sessions"},
+		{name: "remote after resume", args: []string{"--resume", sessionID, "--remote"}, want: "detached Claude sessions"},
+		{name: "settings after resume", args: []string{"--resume", sessionID, "--settings", "{}"}, want: "settings-source overrides"},
+		{name: "model after resume", args: []string{"--resume", sessionID, "--model", "other"}, want: "model or custom-agent overrides"},
+		{name: "model before resume", args: []string{"--model", "other", "--resume", sessionID}, want: "model or custom-agent overrides"},
+		{name: "agent after continue", args: []string{"--continue", "--agent", "reviewer"}, want: "model or custom-agent overrides"},
+		{name: "permission bypass after resume", args: []string{"--resume", sessionID, "--dangerously-skip-permissions"}, want: "permission bypass"},
+		{name: "permission bypass before resume", args: []string{"--dangerously-skip-permissions", "--resume", sessionID}, want: "permission bypass"},
+		{name: "permission mode after resume", args: []string{"--resume", sessionID, "--permission-mode", "bypassPermissions"}, want: "permission mode"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := (ClaudeAdapter{}).Prepare(PrepareInput{
+				BaseURL:       "http://127.0.0.1:43210",
+				Model:         ModelInfo{ID: "claude-public", SupportedEndpoints: []string{"/chat/completions"}},
+				Binary:        binary,
+				LocalToken:    "test-token-placeholder",
+				ForwardedArgs: tc.args,
+				DryRun:        true,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Prepare(%#v) error = %v, want %q", tc.args, err, tc.want)
 			}
 		})
 	}

--- a/launch/codex.go
+++ b/launch/codex.go
@@ -182,17 +182,17 @@ func validateCodexForwardedArgs(args []string) error {
 	}
 	switch positionals[0] {
 	case "exec", "e":
-		if len(positionals) > 1 && positionals[1] == "resume" {
-			return fmt.Errorf("resumed Codex sessions are not supported by an ephemeral Vekil launcher")
-		}
+		// Normal exec and exec resume remain attached to the managed child.
+		return nil
+	case "resume", "fork":
+		// Interactive resume and fork remain attached to the managed child.
+		// Remote variants are rejected above.
 		return nil
 	case "review":
 		return nil
-	case "resume", "fork":
-		return fmt.Errorf("resumed Codex sessions are not supported by an ephemeral Vekil launcher")
 	case "app-server", "remote-control", "cloud", "cloud-tasks", "responses-api-proxy", "stdio-to-uds", "exec-server", "mcp-server":
 		return fmt.Errorf("detached or server Codex modes are not supported by an ephemeral Vekil launcher")
-	case "login", "logout", "mcp", "plugin", "plugins", "app", "completion", "update", "doctor", "debug", "execpolicy", "apply", "a", "archive", "delete", "unarchive", "features", "sandbox", "help":
+	case "agents", "login", "logout", "mcp", "plugin", "plugins", "app", "completion", "update", "doctor", "debug", "execpolicy", "apply", "a", "queue", "archive", "delete", "migrate-rollouts", "unarchive", "features", "sandbox", "help":
 		return fmt.Errorf("codex command %q is not an agent session", positionals[0])
 	default:
 		return nil

--- a/launch/codex_test.go
+++ b/launch/codex_test.go
@@ -259,13 +259,20 @@ func TestCodexAdapterRejectsManagedOverridesAndNonAgentModes(t *testing.T) {
 		{name: "config", args: []string{"-c", `model_provider="other"`}, want: "model or provider overrides"},
 		{name: "profile", args: []string{"-p", "other"}, want: "model or provider overrides"},
 		{name: "remote", args: []string{"--remote", "ws://example"}, want: "remote Codex sessions"},
-		{name: "resume", args: []string{"resume", "last"}, want: "resumed Codex sessions"},
-		{name: "exec resume", args: []string{"exec", "resume", "last"}, want: "resumed Codex sessions"},
-		{name: "alias exec resume", args: []string{"e", "resume", "last"}, want: "resumed Codex sessions"},
+		{name: "resume model override", args: []string{"resume", "--last", "--model", "other"}, want: "model or provider overrides"},
+		{name: "fork config override", args: []string{"fork", "session-id", "-c", `model_provider="other"`}, want: "model or provider overrides"},
+		{name: "exec resume profile override", args: []string{"exec", "resume", "--last", "--profile", "other"}, want: "model or provider overrides"},
+		{name: "alias exec resume local provider override", args: []string{"e", "resume", "session-id", "--local-provider", "ollama"}, want: "model or provider overrides"},
+		{name: "resume remote", args: []string{"resume", "--last", "--remote", "ws://example"}, want: "remote Codex sessions"},
+		{name: "fork remote auth", args: []string{"fork", "session-id", "--remote-auth-token-env", "REMOTE_TOKEN"}, want: "remote Codex sessions"},
 		{name: "app server", args: []string{"app-server"}, want: "detached or server"},
+		{name: "cloud", args: []string{"cloud"}, want: "detached or server"},
 		{name: "cloud tasks", args: []string{"cloud-tasks"}, want: "detached or server"},
 		{name: "responses proxy", args: []string{"responses-api-proxy"}, want: "detached or server"},
 		{name: "stdio relay", args: []string{"stdio-to-uds"}, want: "detached or server"},
+		{name: "agents", args: []string{"agents"}, want: "not an agent session"},
+		{name: "queue", args: []string{"queue", "session-id", "message"}, want: "not an agent session"},
+		{name: "migrate rollouts", args: []string{"migrate-rollouts"}, want: "not an agent session"},
 		{name: "apply alias", args: []string{"a"}, want: "not an agent session"},
 		{name: "execpolicy", args: []string{"execpolicy"}, want: "not an agent session"},
 		{name: "login", args: []string{"login"}, want: "not an agent session"},
@@ -290,6 +297,56 @@ func TestCodexAdapterRejectsManagedOverridesAndNonAgentModes(t *testing.T) {
 		if err := validateCodexForwardedArgs(args); err != nil {
 			t.Fatalf("validateCodexForwardedArgs(%#v) = %v", args, err)
 		}
+	}
+}
+
+func TestCodexAdapterPreservesForegroundContinuationArgs(t *testing.T) {
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sessionID = "56d7498d-6b2e-47ca-92a6-92ddee84ab25"
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "interactive resume by id", args: []string{"resume", sessionID, "continue the review"}},
+		{name: "interactive resume latest", args: []string{"resume", "--last"}},
+		{name: "interactive fork by id", args: []string{"fork", sessionID, "try another approach"}},
+		{name: "exec resume", args: []string{"exec", "resume", "--last", "continue the review"}},
+		{name: "exec alias resume by id", args: []string{"e", "resume", sessionID, "continue the review"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared, err := (CodexAdapter{}).Prepare(PrepareInput{
+				BaseURL: "http://127.0.0.1:43210",
+				Model: ModelInfo{
+					ID:                 "gpt-public",
+					SupportedEndpoints: []string{"/responses"},
+				},
+				Binary:        binary,
+				LocalToken:    "test-token-placeholder",
+				ForwardedArgs: tc.args,
+				DryRun:        true,
+			})
+			if err != nil {
+				t.Fatalf("Prepare() error = %v", err)
+			}
+			if prepared.Cleanup != nil {
+				t.Cleanup(func() { _ = prepared.Cleanup() })
+			}
+			if !containsAdjacent(prepared.Args, "-m", "gpt-public") {
+				t.Fatalf("Codex args did not preserve the managed model: %#v", prepared.Args)
+			}
+			providerID := codexProviderID("test-token-placeholder")
+			if !containsString(prepared.Args, `model_provider="`+providerID+`"`) {
+				t.Fatalf("Codex args did not preserve the managed provider: %#v", prepared.Args)
+			}
+			got := prepared.Args[len(prepared.Args)-len(tc.args):]
+			if !reflect.DeepEqual(got, tc.args) {
+				t.Fatalf("forwarded args = %#v, want %#v", got, tc.args)
+			}
+		})
 	}
 }
 

--- a/launch/copilot.go
+++ b/launch/copilot.go
@@ -199,7 +199,8 @@ func validateCopilotForwardedArgs(args []string) error {
 	var positionals []string
 	expectValue := false
 	endOptions := false
-	for _, arg := range args {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		if expectValue {
 			expectValue = false
 			continue
@@ -209,6 +210,12 @@ func validateCopilotForwardedArgs(args []string) error {
 			continue
 		}
 		if !endOptions && strings.HasPrefix(arg, "-") {
+			if arg == "--resume" || arg == "-r" {
+				if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+					i++
+				}
+				continue
+			}
 			switch {
 			case arg == "--model" || strings.HasPrefix(arg, "--model="),
 				arg == "--agent" || strings.HasPrefix(arg, "--agent="):
@@ -219,13 +226,11 @@ func validateCopilotForwardedArgs(args []string) error {
 				arg == "--disable-builtin-mcps" || strings.HasPrefix(arg, "--disable-builtin-mcps="):
 				return fmt.Errorf("copilot launcher safety overrides are managed by Vekil")
 			case arg == "--connect" || strings.HasPrefix(arg, "--connect="),
-				arg == "--continue",
-				arg == "--resume" || strings.HasPrefix(arg, "--resume="), arg == "-r" || strings.HasPrefix(arg, "-r="), (strings.HasPrefix(arg, "-r") && len(arg) > 2),
 				arg == "--session-id" || strings.HasPrefix(arg, "--session-id="),
 				arg == "--remote" || strings.HasPrefix(arg, "--remote="),
 				arg == "--remote-export" || strings.HasPrefix(arg, "--remote-export="),
 				arg == "--share" || strings.HasPrefix(arg, "--share="), arg == "--share-gist":
-				return fmt.Errorf("remote, resumed, or shared Copilot sessions are not supported by an ephemeral Vekil launcher")
+				return fmt.Errorf("remote, session-ID, or shared Copilot modes are not supported by an ephemeral Vekil launcher")
 			case arg == "--acp":
 				return fmt.Errorf("copilot ACP server mode is not supported by an ephemeral Vekil launcher")
 			}

--- a/launch/copilot_test.go
+++ b/launch/copilot_test.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"encoding/json"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -99,6 +100,49 @@ func TestCopilotAdapterSelectsChatCompletions(t *testing.T) {
 	}
 }
 
+func TestCopilotAdapterPreservesLocalSessionContinuationArgs(t *testing.T) {
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sessionID = "56d7498d-6b2e-47ca-92a6-92ddee84ab25"
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "continue", args: []string{"--continue"}},
+		{name: "long picker", args: []string{"--resume"}},
+		{name: "long separate value", args: []string{"--resume", "login"}},
+		{name: "long equals value", args: []string{"--resume=" + sessionID}},
+		{name: "short picker", args: []string{"-r"}},
+		{name: "short separate value", args: []string{"-r", "login"}},
+		{name: "short attached value", args: []string{"-r" + sessionID}},
+		{name: "short equals value", args: []string{"-r=" + sessionID}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared, err := (CopilotAdapter{}).Prepare(PrepareInput{
+				BaseURL:       "http://127.0.0.1:43210",
+				Model:         ModelInfo{ID: "chat-model", SupportedEndpoints: []string{"/chat/completions"}},
+				Binary:        binary,
+				ForwardedArgs: tc.args,
+				LocalToken:    "token",
+				DryRun:        true,
+			})
+			if err != nil {
+				t.Fatalf("Prepare() error = %v", err)
+			}
+			if len(prepared.Args) < len(tc.args) {
+				t.Fatalf("prepared args too short: %#v", prepared.Args)
+			}
+			got := prepared.Args[len(prepared.Args)-len(tc.args):]
+			if !slices.Equal(got, tc.args) {
+				t.Fatalf("continuation args = %#v, want exact %#v", got, tc.args)
+			}
+		})
+	}
+}
+
 func TestCopilotAdapterAcceptsPolicyOwnedChatModel(t *testing.T) {
 	binary, err := os.Executable()
 	if err != nil {
@@ -185,12 +229,12 @@ func TestCopilotAdapterRejectsManagedOverridesAndRemoteModes(t *testing.T) {
 		{name: "model", args: []string{"--model", "other"}, want: "model, agent, or environment"},
 		{name: "agent", args: []string{"--agent", "other"}, want: "model, agent, or environment"},
 		{name: "managed safety", args: []string{"--no-remote=false"}, want: "safety overrides"},
-		{name: "connect", args: []string{"--connect=session"}, want: "remote, resumed, or shared"},
-		{name: "continue", args: []string{"--continue"}, want: "remote, resumed, or shared"},
-		{name: "resume", args: []string{"--resume=abc"}, want: "remote, resumed, or shared"},
-		{name: "attached short resume", args: []string{"-rabc"}, want: "remote, resumed, or shared"},
-		{name: "remote", args: []string{"--remote"}, want: "remote, resumed, or shared"},
-		{name: "share", args: []string{"--share-gist"}, want: "remote, resumed, or shared"},
+		{name: "connect", args: []string{"--connect=session"}, want: "remote, session-ID, or shared"},
+		{name: "session id", args: []string{"--session-id", "56d7498d-6b2e-47ca-92a6-92ddee84ab25"}, want: "remote, session-ID, or shared"},
+		{name: "attached session id", args: []string{"--session-id=56d7498d-6b2e-47ca-92a6-92ddee84ab25"}, want: "remote, session-ID, or shared"},
+		{name: "remote", args: []string{"--remote"}, want: "remote, session-ID, or shared"},
+		{name: "remote export", args: []string{"--remote-export"}, want: "remote, session-ID, or shared"},
+		{name: "share", args: []string{"--share-gist"}, want: "remote, session-ID, or shared"},
 		{name: "acp", args: []string{"--acp"}, want: "ACP server"},
 		{name: "login", args: []string{"login"}, want: "not an agent session"},
 		{name: "logout", args: []string{"logout"}, want: "not an agent session"},

--- a/main_test.go
+++ b/main_test.go
@@ -1520,6 +1520,43 @@ func TestRunLaunchCommandDispatchesSupportedTargets(t *testing.T) {
 	}
 }
 
+func TestRunLaunchCommandDryRunForwardsForegroundSessionArgs(t *testing.T) {
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const sessionID = "56d7498d-6b2e-47ca-92a6-92ddee84ab25"
+	tests := []struct {
+		name       string
+		target     string
+		forwarded  []string
+		wantOutput string
+	}{
+		{name: "Claude resume", target: "claude", forwarded: []string{"--resume", sessionID}, wantOutput: `"--resume" "` + sessionID + `"`},
+		{name: "Codex resume", target: "codex", forwarded: []string{"resume", sessionID}, wantOutput: `"resume" "` + sessionID + `"`},
+		{name: "Copilot resume", target: "copilot", forwarded: []string{"--resume=" + sessionID}, wantOutput: `"--resume=` + sessionID + `"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{
+				tc.target,
+				"--model", "test-model",
+				"--binary", binary,
+				"--dry-run",
+				"--",
+			}
+			args = append(args, tc.forwarded...)
+			var stderr bytes.Buffer
+			if code := runLaunchCommand(args, &stderr); code != 0 {
+				t.Fatalf("runLaunchCommand() code = %d; stderr=%s", code, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantOutput) {
+				t.Fatalf("dry-run did not preserve session args %q:\n%s", tc.forwarded, stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunLaunchCommandDryRunUsesConfiguredStaticModelMetadata(t *testing.T) {
 	binary, err := os.Executable()
 	if err != nil {

--- a/proxy/chat_completion_normalizer.go
+++ b/proxy/chat_completion_normalizer.go
@@ -39,6 +39,70 @@ func openAIChatStreamEventMayCarryChunk(eventType string) bool {
 	}
 }
 
+func rewriteOpenAIChatCompletionModelIdentity(payload map[string]json.RawMessage, publicModel string) bool {
+	publicModel = strings.TrimSpace(publicModel)
+	if payload == nil || publicModel == "" {
+		return false
+	}
+
+	changed := false
+	if jsonRawString(payload["model"]) != publicModel {
+		payload["model"] = mustMarshalRaw(publicModel)
+		changed = true
+	}
+
+	copilotUsageRaw, ok := payload["copilot_usage"]
+	if !ok {
+		return changed
+	}
+	var copilotUsage map[string]json.RawMessage
+	if json.Unmarshal(copilotUsageRaw, &copilotUsage) != nil || copilotUsage == nil {
+		return changed
+	}
+	tokenDetailsRaw, ok := copilotUsage["token_details"]
+	if !ok {
+		return changed
+	}
+	var tokenDetails []json.RawMessage
+	if json.Unmarshal(tokenDetailsRaw, &tokenDetails) != nil {
+		return changed
+	}
+
+	detailsChanged := false
+	for i, detailRaw := range tokenDetails {
+		var detail map[string]json.RawMessage
+		if json.Unmarshal(detailRaw, &detail) != nil || detail == nil {
+			continue
+		}
+		modelRaw, ok := detail["model"]
+		if !ok || !isJSONString(modelRaw) || jsonRawString(modelRaw) == publicModel {
+			continue
+		}
+		detail["model"] = mustMarshalRaw(publicModel)
+		rewritten, err := json.Marshal(detail)
+		if err != nil {
+			continue
+		}
+		tokenDetails[i] = rewritten
+		detailsChanged = true
+	}
+	if !detailsChanged {
+		return changed
+	}
+
+	rewrittenDetails, err := json.Marshal(tokenDetails)
+	if err != nil {
+		return changed
+	}
+	copilotUsage["token_details"] = rewrittenDetails
+	rewrittenUsage, err := json.Marshal(copilotUsage)
+	if err != nil {
+		return changed
+	}
+	payload["copilot_usage"] = rewrittenUsage
+	return true
+}
+
 func (n *openAIChatCompletionChunkNormalizer) normalize(eventType, data string) (string, bool) {
 	// OpenAI chat completion streams usually use unnamed SSE events. Also accept
 	// explicit event names that are equivalent to the default SSE "message" event

--- a/proxy/chat_handlers.go
+++ b/proxy/chat_handlers.go
@@ -924,7 +924,7 @@ func normalizeExplicitOpenAIChatResponseModel(resp *http.Response, publicModel s
 	}
 	var payload map[string]json.RawMessage
 	if json.Unmarshal(prefix, &payload) == nil && payload != nil && !hasNonNullJSONField(payload, "error") {
-		payload["model"] = mustMarshalRaw(publicModel)
+		rewriteOpenAIChatCompletionModelIdentity(payload, publicModel)
 		if rewritten, marshalErr := json.Marshal(payload); marshalErr == nil {
 			prefix = rewritten
 		}

--- a/proxy/chat_route_surface_test.go
+++ b/proxy/chat_route_surface_test.go
@@ -463,7 +463,7 @@ func TestExplicitRouteOpenAIChatHTTPRejectionPolicyAndPublicIdentity(t *testing.
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-Vekil-Request-ID", "upstream-spoof")
-			_, _ = io.WriteString(w, `{"id":"chat-secondary","object":"chat.completion","model":"physical-secondary","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+			_, _ = io.WriteString(w, `{"id":"chat-secondary","object":"chat.completion","model":"physical-secondary","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"copilot_usage":{"token_details":[{"model":"physical-secondary","token_count":1}]}}`)
 		}))
 		defer secondary.Close()
 
@@ -479,8 +479,11 @@ func TestExplicitRouteOpenAIChatHTTPRejectionPolicyAndPublicIdentity(t *testing.
 		if primaryCalls.Load() != 1 || secondaryCalls.Load() != 1 {
 			t.Fatalf("calls primary=%d secondary=%d", primaryCalls.Load(), secondaryCalls.Load())
 		}
-		if !strings.Contains(w.Body.String(), `"model":"public-model"`) || strings.Contains(w.Body.String(), "physical-secondary") {
+		if strings.Count(w.Body.String(), `"model":"public-model"`) != 2 || strings.Contains(w.Body.String(), "physical-secondary") {
 			t.Fatalf("public model identity was not normalized: %s", w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), `"copilot_usage"`) {
+			t.Fatalf("copilot usage metadata was not preserved: %s", w.Body.String())
 		}
 		if got := w.Header().Get("X-Vekil-Request-ID"); got == "" || got == "upstream-spoof" || got != summary.OperationID() {
 			t.Fatalf("X-Vekil-Request-ID=%q summary=%q", got, summary.OperationID())
@@ -545,7 +548,8 @@ func TestExplicitRouteOpenAIChatStreamProtectsProxyOperationID(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("X-Vekil-Request-ID", "upstream-spoof")
 		w.Header().Set("X-Request-Id", "chat-stream-request-id")
-		_, _ = io.WriteString(w, "data: {\"id\":\"chat-primary\",\"object\":\"chat.completion.chunk\",\"model\":\"physical-primary\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chat-primary\",\"object\":\"chat.completion.chunk\",\"model\":\"public-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chat-primary\",\"object\":\"chat.completion.chunk\",\"model\":\"public-model\",\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2},\"copilot_usage\":{\"token_details\":[{\"model\":\"physical-primary\",\"token_count\":1}]}}\n\n")
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 	}))
 	defer primary.Close()
@@ -557,7 +561,7 @@ func TestExplicitRouteOpenAIChatStreamProtectsProxyOperationID(t *testing.T) {
 
 	h := newExplicitRouteSurfaceHandler(t, providerTypeAzureOpenAI, providerEndpointChatCompletions, primary.URL, secondary.URL)
 	ctx, summary := WithRequestSummary(context.Background())
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"public-model","stream":true,"messages":[{"role":"user","content":"hi"}]}`)).WithContext(ctx)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"public-model","stream":true,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`)).WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.HandleOpenAIChatCompletions(w, req)
 
@@ -572,6 +576,12 @@ func TestExplicitRouteOpenAIChatStreamProtectsProxyOperationID(t *testing.T) {
 	}
 	if got := w.Header().Get("X-Request-Id"); got != "chat-stream-request-id" {
 		t.Fatalf("X-Request-Id = %q, want chat-stream-request-id", got)
+	}
+	if strings.Count(w.Body.String(), `"model":"public-model"`) != 3 || strings.Contains(w.Body.String(), "physical-primary") {
+		t.Fatalf("stream public model identity was not normalized: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"copilot_usage"`) {
+		t.Fatalf("stream copilot usage metadata was not preserved: %s", w.Body.String())
 	}
 }
 

--- a/proxy/streaming.go
+++ b/proxy/streaming.go
@@ -944,11 +944,9 @@ func streamExplicitRouteOpenAIChatPassthroughWithLifecycle(
 		if json.Unmarshal([]byte(normalized), &payload) != nil || payload == nil || hasNonNullJSONField(payload, "error") {
 			return normalized, changed
 		}
-		model := strings.TrimSpace(publicModel)
-		if model == "" || jsonRawString(payload["model"]) == model {
+		if !rewriteOpenAIChatCompletionModelIdentity(payload, publicModel) {
 			return normalized, changed
 		}
-		payload["model"] = mustMarshalRaw(model)
 		rewritten, err := json.Marshal(payload)
 		if err != nil {
 			return normalized, changed


### PR DESCRIPTION
## Summary

- forward arguments after `--` to every supported launcher: Claude Code, OpenAI Codex CLI, and GitHub Copilot CLI
- support foreground session selection such as Claude `--resume`, Codex `resume --last`, and Copilot `--continue`, along with normal one-shot commands
- keep model and provider selection under Vekil control, and reject remote, detached, server, and other modes that can bypass routing or outlive the ephemeral proxy
- merge Copilot `--secret-env-vars` values with the secret names Vekil manages
- rewrite top-level and nested Copilot usage model identities to the requested public model in explicit Chat JSON and SSE responses
- document the forwarding contract and add argv, validation, and response-identity regression tests

## Examples

```bash
vekil launch claude --model claude-opus-5 -- \
  --resume 56d7498d-6b2e-47ca-92a6-92ddee84ab25

vekil launch codex -- resume --last

vekil launch copilot --model gpt-5.4-mini -- --continue
```

Forwarded model overrides remain rejected. Use `vekil launch --model ID` before `--` to pin the managed session.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `go build -ldflags="-s -w" -o vekil .`
- dry-run argv validation with installed Claude, Codex, and Copilot CLIs
